### PR TITLE
simplified hash types for kitsune2

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,1 @@
+max_width = 80

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,5 +3,21 @@
 version = 3
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bytes"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
+
+[[package]]
 name = "kitsune2_api"
 version = "0.0.1-alpha"
+dependencies = [
+ "base64",
+ "bytes",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,9 @@ members = [
 resolver = "2"
 
 [workspace.dependencies]
+# debugging is far easier when you can see short byte arrays
+# as base64 instead of decimal u8s.
+base64 = "0.22.1"
+# shallow-clone byte arrays is a solved problem.
+# bytes is the crate that solves it.
+bytes = "1.8.0"

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -11,3 +11,5 @@ categories = ["network-programming"]
 edition = "2021"
 
 [dependencies]
+base64 = { workspace = true }
+bytes = { workspace = true }

--- a/crates/api/src/id.rs
+++ b/crates/api/src/id.rs
@@ -1,0 +1,169 @@
+//! Types dealing with data identity or hashing.
+
+macro_rules! imp_deref {
+    ($i:ty, $t:ty) => {
+        impl std::ops::Deref for $i {
+            type Target = $t;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+    };
+}
+
+/// Base data identity type meant for newtyping.
+/// You probably want [AgentId] or [OpId].
+///
+/// In Kitsune2 these bytes should ONLY be the actual hash bytes
+/// or public key of the identity being tracked, without
+/// prefix or suffix.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Id(pub bytes::Bytes);
+
+imp_deref!(Id, bytes::Bytes);
+
+impl Id {
+    /// Get the location u32 based off this Id.
+    //
+    // Holochain previously would re-hash the hash, and then
+    // xor to shrink down to a u32. This extra step is not needed
+    // and does not provide any benefit. One extra hash step does
+    // not prevent location farming, and if the original hash was
+    // distributed well enough, re-hashing it again doesn't improve
+    // distribution.
+    pub fn loc(&self) -> u32 {
+        let mut out = [0_u8; 4];
+        let mut i = 0;
+        for c in &self.0 {
+            out[i] ^= c;
+            i += 1;
+            if i > 3 {
+                i = 0;
+            }
+        }
+        u32::from_le_bytes(out)
+    }
+}
+
+/// The function signature for Id display overrides.
+pub type DisplayCb =
+    fn(&bytes::Bytes, &mut std::fmt::Formatter<'_>) -> std::fmt::Result;
+
+/// The default display function encodes the Id as base64.
+/// This makes debugging so much easier than rust's default of decimal array.
+fn default_display(
+    b: &bytes::Bytes,
+    f: &mut std::fmt::Formatter<'_>,
+) -> std::fmt::Result {
+    use base64::prelude::*;
+    f.write_str(&BASE64_URL_SAFE_NO_PAD.encode(b))
+}
+
+#[inline(always)]
+fn display(
+    b: &bytes::Bytes,
+    f: &mut std::fmt::Formatter<'_>,
+    l: &std::sync::OnceLock<DisplayCb>,
+) -> std::fmt::Result {
+    l.get_or_init(|| default_display)(b, f)
+}
+
+static AGENT_DISP: std::sync::OnceLock<DisplayCb> = std::sync::OnceLock::new();
+
+/// Identifies an agent to be tracked as part of a Kitsune space.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct AgentId(pub Id);
+
+imp_deref!(AgentId, Id);
+
+impl std::fmt::Display for AgentId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        display(&self.0 .0, f, &AGENT_DISP)
+    }
+}
+
+impl std::fmt::Debug for AgentId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        display(&self.0 .0, f, &AGENT_DISP)
+    }
+}
+
+impl AgentId {
+    /// Set the display/debug implementation for AgentId for the duration
+    /// of this process. Note, if anything was printed earlier, the
+    /// default impl will have been set and cannot be changed.
+    /// Returns false if the default was unable to be set.
+    pub fn set_global_display_callback(cb: DisplayCb) -> bool {
+        match AGENT_DISP.set(cb) {
+            Ok(_) => true,
+            Err(_) => false,
+        }
+    }
+}
+
+static SPACE_DISP: std::sync::OnceLock<DisplayCb> = std::sync::OnceLock::new();
+
+/// Identifies a space to be tracked by Kitsune.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SpaceId(pub Id);
+
+imp_deref!(SpaceId, Id);
+
+impl std::fmt::Display for SpaceId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        display(&self.0 .0, f, &SPACE_DISP)
+    }
+}
+
+impl std::fmt::Debug for SpaceId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        display(&self.0 .0, f, &SPACE_DISP)
+    }
+}
+
+impl SpaceId {
+    /// Set the display/debug implementation for SpaceId for the duration
+    /// of this process. Note, if anything was printed earlier, the
+    /// default impl will have been set and cannot be changed.
+    /// Returns false if the default was unable to be set.
+    pub fn set_global_display_callback(cb: DisplayCb) -> bool {
+        match SPACE_DISP.set(cb) {
+            Ok(_) => true,
+            Err(_) => false,
+        }
+    }
+}
+
+static OP_DISP: std::sync::OnceLock<DisplayCb> = std::sync::OnceLock::new();
+
+/// Identifies an op to be tracked by Kitsune.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct OpId(pub Id);
+
+imp_deref!(OpId, Id);
+
+impl std::fmt::Display for OpId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        display(&self.0 .0, f, &OP_DISP)
+    }
+}
+
+impl std::fmt::Debug for OpId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        display(&self.0 .0, f, &OP_DISP)
+    }
+}
+
+impl OpId {
+    /// Set the display/debug implementation for OpId for the duration
+    /// of this process. Note, if anything was printed earlier, the
+    /// default impl will have been set and cannot be changed.
+    /// Returns false if the default was unable to be set.
+    pub fn set_global_display_callback(cb: DisplayCb) -> bool {
+        match OP_DISP.set(cb) {
+            Ok(_) => true,
+            Err(_) => false,
+        }
+    }
+}

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -3,3 +3,6 @@
 //! to define the api of those traits.
 //!
 //! If you want to use Kitsune2 itself, please see the kitsune2 crate.
+
+pub mod id;
+pub use id::{AgentId, OpId, SpaceId};


### PR DESCRIPTION
The kitsune2 spike repo had a dyn trait for these Ids, but that proved difficult to work with. Here, I'm suggesting instead that we go for newtypes around the `Bytes` type which has already solved the shallow clone problem, so we shouldn't have to worry about memory usage if we are using clones of these in hash maps for example.

Another awkwardness with the holochain/kitsune1 interface was debugging in kitsune1 printed out things in hex and without the prefix that holochain uses, so it was difficult to compare the results.

Here, I've gone with a default of printing out the bytes in base64, and also allowing whatever crate is implementing kitsune2 to override the debug/display functions, so in holochain integration, we can have it print out with the prefix and location suffix, or whatever we choose.

Finally, I've altered the location calculation algorithm to something that is far less computationally problematic, and which would be much easier for clients to implement directly. I don't believe there are any downsides to this change, but please correct me if there are!