### PR TITLE
Eliminate the origin time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -711,9 +711,9 @@ dependencies = [
 name = "kitsune2_memory"
 version = "0.1.0"
 dependencies = [
+ "bytes",
  "futures",
  "kitsune2_api",
- "thiserror",
  "tokio",
 ]
 

--- a/crates/api/src/op_store.rs
+++ b/crates/api/src/op_store.rs
@@ -62,7 +62,7 @@ pub trait OpStore: 'static + Send + Sync + std::fmt::Debug {
     fn store_slice_hash(
         &self,
         slice_id: u64,
-        slice_hash: Vec<u8>,
+        slice_hash: bytes::Bytes,
     ) -> BoxFuture<'_, K2Result<()>>;
 
     /// Count the number of stored time slices.
@@ -76,7 +76,7 @@ pub trait OpStore: 'static + Send + Sync + std::fmt::Debug {
     fn retrieve_slice_hash(
         &self,
         slice_id: u64,
-    ) -> BoxFuture<'_, K2Result<Option<Vec<u8>>>>;
+    ) -> BoxFuture<'_, K2Result<Option<bytes::Bytes>>>;
 }
 
 /// Trait-object version of kitsune2 op store.

--- a/crates/api/src/timestamp.rs
+++ b/crates/api/src/timestamp.rs
@@ -21,6 +21,11 @@
 #[serde(transparent)]
 pub struct Timestamp(i64);
 
+/// The unix epoch timestamp.
+///
+/// Since the Timestamp is microseconds from the unix epoch, this is the zero value.
+pub const UNIX_TIMESTAMP: Timestamp = Timestamp(0);
+
 impl Timestamp {
     /// Construct a new timestamp of "now".
     pub fn now() -> Self {

--- a/crates/dht/src/time.rs
+++ b/crates/dht/src/time.rs
@@ -512,7 +512,7 @@ mod tests {
         // The partial should be:
         //   - The minimum factor size, and
         //   - start at the UNIX_TIMESTAMP
-        //   - end at the UNIX_TIMESTAMP+ UNIT_TIME
+        //   - end at the UNIX_TIMESTAMP + UNIT_TIME
         assert_eq!(0, pt.partial_slices[0].size);
         assert_eq!(UNIX_TIMESTAMP, pt.partial_slices[0].start);
         assert_eq!(UNIX_TIMESTAMP + UNIT_TIME, pt.partial_slices[0].end());

--- a/crates/dht/src/time.rs
+++ b/crates/dht/src/time.rs
@@ -287,7 +287,9 @@ impl PartitionedTime {
 
             let hash = combine_op_hashes(op_hashes);
 
-            store.store_slice_hash(self.full_slices, hash).await?;
+            if !hash.is_empty() {
+                store.store_slice_hash(self.full_slices, hash).await?;
+            }
 
             self.full_slices += 1;
             full_slices_end_timestamp += self.full_slice_duration;

--- a/crates/dht/src/time.rs
+++ b/crates/dht/src/time.rs
@@ -1085,8 +1085,11 @@ mod tests {
             .await
             .unwrap();
 
-        // Then a single full slice should have been created
+        // Then a single full slice should have been created as the current time
         assert!(store.slice_hash_count().await.unwrap() > 15_000);
+        // and the count should match the number of full slices that the time partition claims to
+        // have created.
+        assert_eq!(store.slice_hash_count().await.unwrap(), pt.full_slices);
     }
 
     fn validate_partial_slices(pt: &PartitionedTime) {

--- a/crates/dht/src/time.rs
+++ b/crates/dht/src/time.rs
@@ -54,16 +54,14 @@
 //! slices to be stored but is less granular when comparing time slices with another peer.
 
 use crate::constant::UNIT_TIME;
-use kitsune2_api::{DynOpStore, K2Error, K2Result, OpId, Timestamp};
+use kitsune2_api::{
+    DynOpStore, K2Error, K2Result, OpId, Timestamp, UNIX_TIMESTAMP,
+};
 use std::time::Duration;
 
 #[derive(Debug)]
 #[cfg_attr(test, derive(Clone, PartialEq))]
 pub struct PartitionedTime {
-    /// The timestamp at which the time partitioning starts.
-    ///
-    /// This must be a constant among peers who need to compute the same time slices.
-    origin_timestamp: Timestamp,
     /// The factor used to determine the size of the time slices.
     ///
     /// The size of a time slice is 2^factor * [UNIT_TIME].
@@ -137,11 +135,11 @@ impl PartitionedTime {
     /// The resulting [PartitionedTime] will be consistent with the store and the current time.
     /// It should be updated again after [PartitionedTime::next_update_at].
     pub async fn try_from_store(
-        origin_timestamp: Timestamp,
         factor: u8,
+        current_time: Timestamp,
         store: DynOpStore,
     ) -> K2Result<Self> {
-        let mut pt = Self::new(origin_timestamp, factor)?;
+        let mut pt = Self::new(factor)?;
 
         pt.full_slices = store.slice_hash_count().await?;
 
@@ -149,7 +147,7 @@ impl PartitionedTime {
         let full_slice_end_timestamp = pt.full_slice_end_timestamp();
 
         // Given the time reserved by full slices, how much time is left to partition into smaller slices
-        let recent_time = (Timestamp::now() - full_slice_end_timestamp).map_err(|_| {
+        let recent_time = (current_time - full_slice_end_timestamp).map_err(|_| {
             K2Error::other("Failed to calculate recent time, either the clock is wrong or this is a bug")
         })?;
 
@@ -158,7 +156,7 @@ impl PartitionedTime {
         }
 
         // Update the state for the current time. The stored slices might be out of date.
-        pt.update(store, Timestamp::now()).await?;
+        pt.update(current_time, store).await?;
 
         Ok(pt)
     }
@@ -183,8 +181,8 @@ impl PartitionedTime {
     ///   - Update the `next_update_at` field to the next time an update is required.
     pub async fn update(
         &mut self,
-        store: DynOpStore,
         current_time: Timestamp,
+        store: DynOpStore,
     ) -> K2Result<()> {
         // Check if there is enough time to allocate new full slices
         self.update_full_slice_hashes(store.clone(), current_time)
@@ -210,9 +208,8 @@ impl PartitionedTime {
     ///
     /// This constructor just creates an instance with initial values, but it doesn't update the
     /// state with full and partial slices for the current time.
-    fn new(origin_timestamp: Timestamp, factor: u8) -> K2Result<Self> {
+    fn new(factor: u8) -> K2Result<Self> {
         Ok(Self {
-            origin_timestamp,
             factor,
             full_slices: 0,
             partial_slices: Vec::new(),
@@ -231,12 +228,12 @@ impl PartitionedTime {
 
     /// The timestamp at which the last full slice ends.
     ///
-    /// If there are no full slices, then this is the origin timestamp.
+    /// If there are no full slices, then this is the constant [UNIX_TIMESTAMP].
     fn full_slice_end_timestamp(&self) -> Timestamp {
         let full_slices_duration = Duration::from_secs(
             self.full_slices * self.full_slice_duration.as_secs(),
         );
-        self.origin_timestamp + full_slices_duration
+        UNIX_TIMESTAMP + full_slices_duration
     }
 
     /// Figure out how many new full slices need to be allocated.
@@ -290,9 +287,7 @@ impl PartitionedTime {
 
             let hash = combine_op_hashes(op_hashes);
 
-            store
-                .store_slice_hash(self.full_slices, hash.to_vec())
-                .await?;
+            store.store_slice_hash(self.full_slices, hash).await?;
 
             self.full_slices += 1;
             full_slices_end_timestamp += self.full_slice_duration;
@@ -478,9 +473,8 @@ mod tests {
 
     #[test]
     fn new() {
-        let origin_timestamp = Timestamp::now();
         let factor = 4;
-        let pt = PartitionedTime::new(origin_timestamp, factor).unwrap();
+        let pt = PartitionedTime::new(factor).unwrap();
 
         // Full slices would have size 2^4 = 16, so we should reserve space for at least one
         // of each smaller slice size
@@ -489,13 +483,11 @@ mod tests {
 
     #[tokio::test]
     async fn from_store() {
-        let origin_timestamp = Timestamp::now();
         let factor = 4;
         let store = Arc::new(Kitsune2MemoryOpStore::default());
-        let pt =
-            PartitionedTime::try_from_store(origin_timestamp, factor, store)
-                .await
-                .unwrap();
+        let pt = PartitionedTime::try_from_store(factor, UNIX_TIMESTAMP, store)
+            .await
+            .unwrap();
 
         assert_eq!(0, pt.full_slices);
         assert!(pt.partial_slices.is_empty());
@@ -503,15 +495,13 @@ mod tests {
 
     #[tokio::test]
     async fn one_partial_slice() {
-        let now = Timestamp::now();
-        let origin_timestamp =
-            (now - Duration::from_secs(UNIT_TIME.as_secs() + 1)).unwrap();
+        let current_time =
+            UNIX_TIMESTAMP + Duration::from_secs(UNIT_TIME.as_secs() + 1);
         let factor = 4;
         let store = Arc::new(Kitsune2MemoryOpStore::default());
-        let pt =
-            PartitionedTime::try_from_store(origin_timestamp, factor, store)
-                .await
-                .unwrap();
+        let pt = PartitionedTime::try_from_store(factor, current_time, store)
+            .await
+            .unwrap();
 
         // Should allocate no full slices and one partial
         assert_eq!(0, pt.full_slices);
@@ -519,37 +509,29 @@ mod tests {
 
         // The partial should be:
         //   - The minimum factor size, and
-        //   - start at the origin time
-        //   - end at the origin time + UNIT_TIME
+        //   - start at the UNIX_TIMESTAMP
+        //   - end at the UNIX_TIMESTAMP+ UNIT_TIME
         assert_eq!(0, pt.partial_slices[0].size);
-        assert_eq!(origin_timestamp, pt.partial_slices[0].start);
-        assert_eq!(origin_timestamp + UNIT_TIME, pt.partial_slices[0].end());
+        assert_eq!(UNIX_TIMESTAMP, pt.partial_slices[0].start);
+        assert_eq!(UNIX_TIMESTAMP + UNIT_TIME, pt.partial_slices[0].end());
 
         // The next required update should be at the end of the partial slice
         // plus another UNIT_TIME.
-        assert_eq!(origin_timestamp + 2 * UNIT_TIME, pt.next_update_at);
-
-        // Or to put it another way, UNIT_TIME - 1s from now
-        assert_eq!(
-            (now + UNIT_TIME - Duration::from_secs(1)).unwrap(),
-            pt.next_update_at
-        );
+        assert_eq!(UNIX_TIMESTAMP + 2 * UNIT_TIME, pt.next_update_at);
     }
 
     #[tokio::test]
     async fn all_single_partial_slices() {
         let factor = 7;
-        let origin_timestamp = (Timestamp::now()
-            - Duration::from_secs(
+        let current_time = UNIX_TIMESTAMP
+            + Duration::from_secs(
                 // Enough time for all the partial slices
                 min_recent_time(factor).as_secs() + 1,
-            ))
-        .unwrap();
+            );
         let store = Arc::new(Kitsune2MemoryOpStore::default());
-        let pt =
-            PartitionedTime::try_from_store(origin_timestamp, factor, store)
-                .await
-                .unwrap();
+        let pt = PartitionedTime::try_from_store(factor, current_time, store)
+            .await
+            .unwrap();
 
         assert_eq!(0, pt.full_slices);
         assert_eq!(factor as usize, pt.partial_slices.len());
@@ -560,19 +542,17 @@ mod tests {
     #[tokio::test]
     async fn one_double_others_single_partial_slices() {
         let factor = 7;
-        let origin_timestamp = (Timestamp::now()
-            - Duration::from_secs(
+        let current_time = UNIX_TIMESTAMP
+            + Duration::from_secs(
                 min_recent_time(factor).as_secs() +
                 // Add enough time to reserve a double slice in the first spot
             (1u64 << (factor - 1)) * UNIT_TIME.as_secs()
                 + 1,
-            ))
-        .unwrap();
+            );
         let store = Arc::new(Kitsune2MemoryOpStore::default());
-        let pt =
-            PartitionedTime::try_from_store(origin_timestamp, factor, store)
-                .await
-                .unwrap();
+        let pt = PartitionedTime::try_from_store(factor, current_time, store)
+            .await
+            .unwrap();
 
         assert_eq!(factor as usize + 1, pt.partial_slices.len());
         assert_eq!(pt.partial_slices[0].size, factor - 1);
@@ -584,17 +564,15 @@ mod tests {
     #[tokio::test]
     async fn all_double_slices() {
         let factor = 7;
-        let origin_timestamp = (Timestamp::now()
-            - Duration::from_secs(
+        let current_time = UNIX_TIMESTAMP
+            + Duration::from_secs(
                 // Enough time for two of each of the partial slices
                 2 * min_recent_time(factor).as_secs() + 1,
-            ))
-        .unwrap();
+            );
         let store = Arc::new(Kitsune2MemoryOpStore::default());
-        let pt =
-            PartitionedTime::try_from_store(origin_timestamp, factor, store)
-                .await
-                .unwrap();
+        let pt = PartitionedTime::try_from_store(factor, current_time, store)
+            .await
+            .unwrap();
 
         assert_eq!(factor as usize * 2, pt.partial_slices.len());
 
@@ -604,35 +582,32 @@ mod tests {
     #[tokio::test]
     async fn hashes_are_combined_for_partial_slices() {
         let factor = 7;
-        let now = Timestamp::now();
-        let origin_timestamp = (now
-            - Duration::from_secs(
+        let current_time = UNIX_TIMESTAMP
+            + Duration::from_secs(
                 // Enough time for all the partial slices
                 min_recent_time(factor).as_secs() + 1,
-            ))
-        .unwrap();
+            );
 
         let store = Arc::new(Kitsune2MemoryOpStore::default());
         store
             .process_incoming_ops(vec![
                 MetaOp {
                     op_id: OpId::from(bytes::Bytes::from(vec![7; 32])),
-                    timestamp: (now - UNIT_TIME).unwrap(),
+                    timestamp: (current_time - UNIT_TIME).unwrap(),
                     op_data: vec![],
                 },
                 MetaOp {
                     op_id: OpId::from(bytes::Bytes::from(vec![23; 32])),
-                    timestamp: (now - UNIT_TIME).unwrap(),
+                    timestamp: (current_time - UNIT_TIME).unwrap(),
                     op_data: vec![],
                 },
             ])
             .await
             .unwrap();
 
-        let pt =
-            PartitionedTime::try_from_store(origin_timestamp, factor, store)
-                .await
-                .unwrap();
+        let pt = PartitionedTime::try_from_store(factor, current_time, store)
+            .await
+            .unwrap();
 
         assert_eq!(factor as usize, pt.partial_slices.len());
         let last_partial = pt.partial_slices.last().unwrap();
@@ -644,24 +619,22 @@ mod tests {
     #[tokio::test]
     async fn full_slices_with_single_slice_partials() {
         let factor = 7;
-        let origin_timestamp = (Timestamp::now()
-            - Duration::from_secs(
+        let current_time = UNIX_TIMESTAMP
+            + Duration::from_secs(
                 // Two full slices
                 2 * full_slice_duration(factor).as_secs() +
                 // Enough time remaining for recent time
                 min_recent_time(factor)
                 .as_secs()
                 + 1,
-            ))
-        .unwrap();
+            );
         let store = Arc::new(Kitsune2MemoryOpStore::default());
-        store.store_slice_hash(0, vec![1; 64]).await.unwrap();
-        store.store_slice_hash(1, vec![1; 64]).await.unwrap();
+        store.store_slice_hash(0, vec![1; 64].into()).await.unwrap();
+        store.store_slice_hash(1, vec![1; 64].into()).await.unwrap();
 
-        let pt =
-            PartitionedTime::try_from_store(origin_timestamp, factor, store)
-                .await
-                .unwrap();
+        let pt = PartitionedTime::try_from_store(factor, current_time, store)
+            .await
+            .unwrap();
 
         assert_eq!(2, pt.full_slices);
         assert_eq!(factor as usize, pt.partial_slices.len());
@@ -672,16 +645,15 @@ mod tests {
     #[tokio::test]
     async fn missing_full_slices_combines_hashes() {
         let factor = 7;
-        let origin_timestamp = (Timestamp::now()
-            - Duration::from_secs(
+        let current_time = UNIX_TIMESTAMP
+            + Duration::from_secs(
                 // One full slice
                 full_slice_duration(factor).as_secs() +
                 // Enough time remaining for all the single partial slices
                 min_recent_time(factor)
                     .as_secs()
                 + 1,
-            ))
-        .unwrap();
+            );
 
         // Store with no full slices stored
         let store = Arc::new(Kitsune2MemoryOpStore::default());
@@ -689,12 +661,12 @@ mod tests {
             .process_incoming_ops(vec![
                 MetaOp {
                     op_id: OpId::from(bytes::Bytes::from(vec![7; 32])),
-                    timestamp: origin_timestamp,
+                    timestamp: UNIX_TIMESTAMP,
                     op_data: vec![],
                 },
                 MetaOp {
                     op_id: OpId::from(bytes::Bytes::from(vec![23; 32])),
-                    timestamp: origin_timestamp,
+                    timestamp: UNIX_TIMESTAMP,
                     op_data: vec![],
                 },
             ])
@@ -702,8 +674,8 @@ mod tests {
             .unwrap();
 
         let pt = PartitionedTime::try_from_store(
-            origin_timestamp,
             factor,
+            current_time,
             store.clone(),
         )
         .await
@@ -726,17 +698,15 @@ mod tests {
     #[tokio::test]
     async fn compute_hashes_for_full_slices_and_partials() {
         let factor = 7;
-        let now = Timestamp::now();
-        let origin_timestamp = (now
-            - Duration::from_secs(
+        let current_time = UNIX_TIMESTAMP
+            + Duration::from_secs(
                 // One full slice
                 full_slice_duration(factor).as_secs() +
                 // Enough time remaining for all the single partial slices
                 min_recent_time(factor)
                     .as_secs()
                 + 1,
-            ))
-        .unwrap();
+            );
 
         // Store with no full slices stored
         let store = Arc::new(Kitsune2MemoryOpStore::default());
@@ -744,22 +714,22 @@ mod tests {
             .process_incoming_ops(vec![
                 MetaOp {
                     op_id: OpId::from(bytes::Bytes::from(vec![7; 32])),
-                    timestamp: origin_timestamp,
+                    timestamp: UNIX_TIMESTAMP,
                     op_data: vec![],
                 },
                 MetaOp {
                     op_id: OpId::from(bytes::Bytes::from(vec![23; 32])),
-                    timestamp: origin_timestamp,
+                    timestamp: UNIX_TIMESTAMP,
                     op_data: vec![],
                 },
                 MetaOp {
                     op_id: OpId::from(bytes::Bytes::from(vec![7; 32])),
-                    timestamp: (now - UNIT_TIME).unwrap(),
+                    timestamp: (current_time - UNIT_TIME).unwrap(),
                     op_data: vec![],
                 },
                 MetaOp {
                     op_id: OpId::from(bytes::Bytes::from(vec![29; 32])),
-                    timestamp: (now - UNIT_TIME).unwrap(),
+                    timestamp: (current_time - UNIT_TIME).unwrap(),
                     op_data: vec![],
                 },
             ])
@@ -767,8 +737,8 @@ mod tests {
             .unwrap();
 
         let pt = PartitionedTime::try_from_store(
-            origin_timestamp,
             factor,
+            current_time,
             store.clone(),
         )
         .await
@@ -795,17 +765,15 @@ mod tests {
     #[tokio::test]
     async fn update_is_idempotent() {
         let factor = 7;
-        let now = Timestamp::now();
-        let origin_timestamp = (now
-            - Duration::from_secs(
+        let current_time = UNIX_TIMESTAMP
+            + Duration::from_secs(
                 // One full slice
                 full_slice_duration(factor).as_secs() +
                 // Enough time remaining for all the single partial slices
                 min_recent_time(factor)
                     .as_secs()
                 + 1,
-            ))
-        .unwrap();
+            );
 
         // Store with no full slices stored
         let store = Arc::new(Kitsune2MemoryOpStore::default());
@@ -813,22 +781,22 @@ mod tests {
             .process_incoming_ops(vec![
                 MetaOp {
                     op_id: OpId::from(bytes::Bytes::from(vec![7; 32])),
-                    timestamp: origin_timestamp,
+                    timestamp: UNIX_TIMESTAMP,
                     op_data: vec![],
                 },
                 MetaOp {
                     op_id: OpId::from(bytes::Bytes::from(vec![23; 32])),
-                    timestamp: origin_timestamp,
+                    timestamp: UNIX_TIMESTAMP,
                     op_data: vec![],
                 },
                 MetaOp {
                     op_id: OpId::from(bytes::Bytes::from(vec![7; 32])),
-                    timestamp: (now - UNIT_TIME).unwrap(),
+                    timestamp: (current_time - UNIT_TIME).unwrap(),
                     op_data: vec![],
                 },
                 MetaOp {
                     op_id: OpId::from(bytes::Bytes::from(vec![29; 32])),
-                    timestamp: (now - UNIT_TIME).unwrap(),
+                    timestamp: (current_time - UNIT_TIME).unwrap(),
                     op_data: vec![],
                 },
             ])
@@ -836,8 +804,8 @@ mod tests {
             .unwrap();
 
         let mut pt = PartitionedTime::try_from_store(
-            origin_timestamp,
             factor,
+            current_time,
             store.clone(),
         )
         .await
@@ -848,10 +816,11 @@ mod tests {
 
         // Update repeatedly, the state should not change
         for _ in 1..10 {
-            let call_at = now + Duration::from_secs(UNIT_TIME.as_secs() / 100);
+            let call_at =
+                current_time + Duration::from_secs(UNIT_TIME.as_secs() / 100);
             assert!(call_at < pt.next_update_at());
 
-            pt.update(store.clone(), call_at).await.unwrap();
+            pt.update(call_at, store.clone()).await.unwrap();
 
             assert_eq!(pt_original, pt);
         }
@@ -860,30 +829,28 @@ mod tests {
     #[tokio::test]
     async fn update_allocate_new_partial() {
         let factor = 7;
-        let now = Timestamp::now();
-        let origin_timestamp = (now
-            - Duration::from_secs(
+        let current_time = UNIX_TIMESTAMP
+            + Duration::from_secs(
                 // One full slice
                 full_slice_duration(factor).as_secs() +
                 // Enough time remaining for all the single partial slices
                 min_recent_time(factor)
                 .as_secs()
                 + 1,
-            ))
-        .unwrap();
+            );
 
         let store = Arc::new(Kitsune2MemoryOpStore::default());
-        store.store_slice_hash(0, vec![1; 64]).await.unwrap();
+        store.store_slice_hash(0, vec![1; 64].into()).await.unwrap();
         store
             .process_incoming_ops(vec![
                 MetaOp {
                     op_id: OpId::from(bytes::Bytes::from(vec![7; 32])),
-                    timestamp: (now - UNIT_TIME).unwrap(),
+                    timestamp: (current_time - UNIT_TIME).unwrap(),
                     op_data: vec![],
                 },
                 MetaOp {
                     op_id: OpId::from(bytes::Bytes::from(vec![29; 32])),
-                    timestamp: (now - UNIT_TIME).unwrap(),
+                    timestamp: (current_time - UNIT_TIME).unwrap(),
                     op_data: vec![],
                 },
             ])
@@ -891,8 +858,8 @@ mod tests {
             .unwrap();
 
         let mut pt = PartitionedTime::try_from_store(
-            origin_timestamp,
             factor,
+            current_time,
             store.clone(),
         )
         .await
@@ -906,13 +873,13 @@ mod tests {
         store
             .process_incoming_ops(vec![MetaOp {
                 op_id: OpId::from(bytes::Bytes::from(vec![13; 32])),
-                timestamp: Timestamp::now(),
+                timestamp: current_time,
                 op_data: vec![],
             }])
             .await
             .unwrap();
 
-        pt.update(store.clone(), Timestamp::now() + UNIT_TIME)
+        pt.update(current_time + UNIT_TIME, store.clone())
             .await
             .unwrap();
 
@@ -928,29 +895,27 @@ mod tests {
     #[tokio::test]
     async fn update_allocate_new_complete() {
         let factor = 7;
-        let now = Timestamp::now();
-        let origin_timestamp = (now
-            - Duration::from_secs(
+        let current_times = UNIX_TIMESTAMP
+            + Duration::from_secs(
                 // One full slice
                 full_slice_duration(factor).as_secs() +
                 // Enough time remaining for all the single partial slices
                 min_recent_time(factor)
                     .as_secs()
                 + 1,
-            ))
-        .unwrap();
+            );
 
         let store = Arc::new(Kitsune2MemoryOpStore::default());
         store
             .process_incoming_ops(vec![
                 MetaOp {
                     op_id: OpId::from(bytes::Bytes::from(vec![7; 32])),
-                    timestamp: origin_timestamp,
+                    timestamp: UNIX_TIMESTAMP,
                     op_data: vec![],
                 },
                 MetaOp {
                     op_id: OpId::from(bytes::Bytes::from(vec![23; 32])),
-                    timestamp: origin_timestamp,
+                    timestamp: UNIX_TIMESTAMP,
                     op_data: vec![],
                 },
             ])
@@ -958,8 +923,8 @@ mod tests {
             .unwrap();
 
         let mut pt = PartitionedTime::try_from_store(
-            origin_timestamp,
             factor,
+            current_times,
             store.clone(),
         )
         .await
@@ -982,11 +947,11 @@ mod tests {
             .unwrap();
 
         pt.update(
+            UNIX_TIMESTAMP
+                + 2 * full_slice_duration(factor)
+                + min_recent_time(factor)
+                + Duration::from_secs(1),
             store.clone(),
-            Timestamp::now()
-                + Duration::from_secs(
-                    2u32.pow(factor as u32) as u64 * UNIT_TIME.as_secs(),
-                ),
         )
         .await
         .unwrap();
@@ -1008,16 +973,14 @@ mod tests {
     #[tokio::test]
     async fn update_allocate_multiple_new_complete() {
         let factor = 7;
-        let now = Timestamp::now();
-        let origin_timestamp = (now
-            - Duration::from_secs(min_recent_time(factor).as_secs() + 1))
-        .unwrap();
+        let current_time = UNIX_TIMESTAMP
+            + Duration::from_secs(min_recent_time(factor).as_secs() + 1);
 
         let store = Arc::new(Kitsune2MemoryOpStore::default());
 
         let mut pt = PartitionedTime::try_from_store(
-            origin_timestamp,
             factor,
+            current_time,
             store.clone(),
         )
         .await
@@ -1027,39 +990,36 @@ mod tests {
 
         store
             .process_incoming_ops(vec![
-                // Store two new ops at the origin timestamp, to go into the first complete slice
+                // Store two new ops at the unix timestamp, to go into the first complete slice
                 MetaOp {
                     op_id: OpId::from(bytes::Bytes::from(vec![7; 32])),
-                    timestamp: origin_timestamp,
+                    timestamp: UNIX_TIMESTAMP,
                     op_data: vec![],
                 },
                 MetaOp {
                     op_id: OpId::from(bytes::Bytes::from(vec![23; 32])),
-                    timestamp: origin_timestamp,
+                    timestamp: UNIX_TIMESTAMP,
                     op_data: vec![],
                 },
-                // Store two new ops at the origin timestamp plus one full time slice,
+                // Store two new ops at the unix timestamp plus one full time slice,
                 // to go into the second complete slice
                 MetaOp {
                     op_id: OpId::from(bytes::Bytes::from(vec![11; 32])),
-                    timestamp: origin_timestamp + pt.full_slice_duration,
+                    timestamp: UNIX_TIMESTAMP + pt.full_slice_duration,
                     op_data: vec![],
                 },
                 MetaOp {
                     op_id: OpId::from(bytes::Bytes::from(vec![37; 32])),
-                    timestamp: origin_timestamp + pt.full_slice_duration,
+                    timestamp: UNIX_TIMESTAMP + pt.full_slice_duration,
                     op_data: vec![],
                 },
             ])
             .await
             .unwrap();
 
-        pt.update(
-            store.clone(),
-            Timestamp::now() + (2 * pt.full_slice_duration),
-        )
-        .await
-        .unwrap();
+        pt.update(current_time + (2 * pt.full_slice_duration), store.clone())
+            .await
+            .unwrap();
 
         assert_eq!(2, pt.full_slices);
         assert_eq!(factor as usize, pt.partial_slices.len());
@@ -1075,8 +1035,58 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn compression_all_empty_slices_at_current_time() {
+        let factor = 7;
+        let current_time = Timestamp::now();
+        let store = Arc::new(Kitsune2MemoryOpStore::default());
+
+        let mut pt = PartitionedTime::try_from_store(
+            factor,
+            current_time,
+            store.clone(),
+        )
+        .await
+        .unwrap();
+
+        // Quick calculation of how many full slices we can fit into the current time, leaving space
+        // for the minimum recent time.
+        // Something like 15k full slices at the time of writing.
+        assert_eq!(
+            (current_time.as_micros() as u128 - pt.min_recent_time.as_micros())
+                / (pt.full_slice_duration.as_micros()),
+            pt.full_slices as u128
+        );
+
+        let slice_hash_count = store.slice_hash_count().await.unwrap();
+        // Should be nothing stored, because we haven't ever created any data.
+        assert_eq!(0, slice_hash_count);
+
+        // Getting some partial slice that doesn't have any data stored will just return `None`
+        let some_slice_hash =
+            store.retrieve_slice_hash(5203984823).await.unwrap();
+        assert!(some_slice_hash.is_none());
+
+        // Now insert an op at the current time
+        store
+            .process_incoming_ops(vec![MetaOp {
+                op_id: OpId::from(bytes::Bytes::from(vec![7; 32])),
+                timestamp: Timestamp::now(),
+                op_data: vec![],
+            }])
+            .await
+            .unwrap();
+        // and compute the new state in the future
+        pt.update(Timestamp::now() + 2 * pt.full_slice_duration, store.clone())
+            .await
+            .unwrap();
+
+        // Then a single full slice should have been created
+        assert!(store.slice_hash_count().await.unwrap() > 15_000);
+    }
+
     fn validate_partial_slices(pt: &PartitionedTime) {
-        let mut start_at = pt.origin_timestamp
+        let mut start_at = UNIX_TIMESTAMP
             + Duration::from_secs(
                 pt.full_slices * full_slice_duration(pt.factor).as_secs(),
             );
@@ -1110,14 +1120,10 @@ mod tests {
     }
 
     fn min_recent_time(factor: u8) -> Duration {
-        PartitionedTime::new(Timestamp::now(), factor)
-            .unwrap()
-            .min_recent_time
+        PartitionedTime::new(factor).unwrap().min_recent_time
     }
 
     fn full_slice_duration(factor: u8) -> Duration {
-        PartitionedTime::new(Timestamp::now(), factor)
-            .unwrap()
-            .full_slice_duration
+        PartitionedTime::new(factor).unwrap().full_slice_duration
     }
 }

--- a/crates/dht/src/time.rs
+++ b/crates/dht/src/time.rs
@@ -1069,6 +1069,8 @@ mod tests {
             store.retrieve_slice_hash(5203984823).await.unwrap();
         assert!(some_slice_hash.is_none());
 
+        println!("Full slices: {}", store.slice_hash_count().await.unwrap());
+
         // Now insert an op at the current time
         store
             .process_incoming_ops(vec![MetaOp {

--- a/crates/dht/src/time.rs
+++ b/crates/dht/src/time.rs
@@ -1088,7 +1088,10 @@ mod tests {
         assert!(store.slice_hash_count().await.unwrap() > 15_000);
         // and the count should match the number of full slices that the time partition claims to
         // have created.
-        assert_eq!(store.slice_hash_count().await.unwrap(), initial_full_slices_count + 1);
+        assert_eq!(
+            store.slice_hash_count().await.unwrap(),
+            initial_full_slices_count + 1
+        );
     }
 
     fn validate_partial_slices(pt: &PartitionedTime) {

--- a/crates/memory/Cargo.toml
+++ b/crates/memory/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 kitsune2_api = { workspace = true }
 futures = { workspace = true }
-thiserror = { workspace = true }
+bytes = { workspace = true }
 
 # Note that this is a dev dependency, which means that this crate should also be considered a dev dependency!
 tokio = { workspace = true, features = ["sync"] }

--- a/crates/memory/src/op_store.rs
+++ b/crates/memory/src/op_store.rs
@@ -1,5 +1,4 @@
 use crate::op_store::time_slice_hash_store::TimeSliceHashStore;
-use crate::time_slice_hash_store::SliceHash;
 use futures::future::BoxFuture;
 use futures::FutureExt;
 use kitsune2_api::{K2Result, MetaOp, OpId, OpStore, Timestamp};
@@ -109,14 +108,7 @@ impl OpStore for Kitsune2MemoryOpStore {
         &self,
         slice_id: u64,
     ) -> BoxFuture<'_, K2Result<Option<bytes::Bytes>>> {
-        async move {
-            Ok(self.read().await.time_slice_hashes.get(slice_id).and_then(
-                |x| match x {
-                    SliceHash::Single { hash, .. } => Some(hash.clone()),
-                    SliceHash::Block { .. } => None,
-                },
-            ))
-        }
-        .boxed()
+        async move { Ok(self.read().await.time_slice_hashes.get(slice_id)) }
+            .boxed()
     }
 }

--- a/crates/memory/src/op_store.rs
+++ b/crates/memory/src/op_store.rs
@@ -88,8 +88,16 @@ impl OpStore for Kitsune2MemoryOpStore {
     /// peers.
     fn slice_hash_count(&self) -> BoxFuture<'_, K2Result<u64>> {
         // +1 to convert from a 0-based index to a count
-        async move { Ok(self.read().await.time_slice_hashes.highest_stored_id.map(|id| id + 1).unwrap_or_default()) }
-            .boxed()
+        async move {
+            Ok(self
+                .read()
+                .await
+                .time_slice_hashes
+                .highest_stored_id
+                .map(|id| id + 1)
+                .unwrap_or_default())
+        }
+        .boxed()
     }
 
     /// Retrieve the hash of a time slice.

--- a/crates/memory/src/op_store.rs
+++ b/crates/memory/src/op_store.rs
@@ -81,10 +81,14 @@ impl OpStore for Kitsune2MemoryOpStore {
     /// Note that this is not the number of hashes that have been provided at unique `slice_id`s.
     /// Start from time slice id 0 and count up to the highest stored id. This value should be the
     /// count based on the highest stored id.
-    /// This value is easier to compare between peers because it tracks an absolute number of time
-    /// slices that have had a slice hash computed and stored. The number of stored hashes would
-    /// only be comparable if the earliest point that data has been seen for is known between two
-    /// peers.
+    /// This value is easier to compare between peers because it ignores sync progress. A simple
+    /// count cannot tell the difference between a peer that has synced the first 4 time slices,
+    /// and a peer who has synced the first 3 time slices and created one recent one. However,
+    /// using the highest stored id shows the difference to be 4 and say 300 respectively.
+    /// Equally, the literal count is more useful if the DHT contains a large amount of data and
+    /// a peer might allocate a recent full slice before completing its initial sync. That situation
+    /// could be created by a configuration that chooses small time-slices. However, in the general
+    /// case, the highest stored id is more useful.
     fn slice_hash_count(&self) -> BoxFuture<'_, K2Result<u64>> {
         // +1 to convert from a 0-based index to a count
         async move {

--- a/crates/memory/src/op_store.rs
+++ b/crates/memory/src/op_store.rs
@@ -92,7 +92,7 @@ impl OpStore for Kitsune2MemoryOpStore {
                 .read()
                 .await
                 .time_slice_hashes
-                .highest_stored_id
+                .highest_stored_id()
                 .map(|id| id + 1)
                 .unwrap_or_default())
         }

--- a/crates/memory/src/op_store.rs
+++ b/crates/memory/src/op_store.rs
@@ -78,9 +78,9 @@ impl OpStore for Kitsune2MemoryOpStore {
 
     /// Retrieve the count of time slice hashes stored.
     ///
-    /// Note that this is not the number of hashes that have been provided at unique `slice_id`s.
-    /// Start from time slice id 0 and count up to the highest stored id. This value should be the
-    /// count based on the highest stored id.
+    /// Note that this is not the total number of hashes of a time slice at a unique `slice_id`.
+    /// This value is the count, based on the highest stored id, starting from time slice id 0 and counting up to the highest stored id. In other words it is the id of the most recent time slice plus 1.
+    ///
     /// This value is easier to compare between peers because it ignores sync progress. A simple
     /// count cannot tell the difference between a peer that has synced the first 4 time slices,
     /// and a peer who has synced the first 3 time slices and created one recent one. However,

--- a/crates/memory/src/op_store.rs
+++ b/crates/memory/src/op_store.rs
@@ -1,8 +1,12 @@
+use crate::op_store::time_slice_hash_store::TimeSliceHashStore;
+use crate::time_slice_hash_store::SliceHash;
 use futures::future::BoxFuture;
 use futures::FutureExt;
 use kitsune2_api::{K2Result, MetaOp, OpId, OpStore, Timestamp};
-use std::collections::{BTreeSet, HashMap};
+use std::collections::BTreeSet;
 use tokio::sync::RwLock;
+
+pub mod time_slice_hash_store;
 
 #[derive(Debug, Default)]
 pub struct Kitsune2MemoryOpStore(pub RwLock<Kitsune2MemoryOpStoreInner>);
@@ -18,7 +22,7 @@ impl std::ops::Deref for Kitsune2MemoryOpStore {
 #[derive(Debug, Default)]
 pub struct Kitsune2MemoryOpStoreInner {
     op_list: BTreeSet<MetaOp>,
-    time_slice_hashes: HashMap<u64, Vec<u8>>,
+    time_slice_hashes: TimeSliceHashStore,
 }
 
 impl OpStore for Kitsune2MemoryOpStore {
@@ -53,32 +57,57 @@ impl OpStore for Kitsune2MemoryOpStore {
         .boxed()
     }
 
+    /// Store the combined hash of a time slice.
+    ///
+    /// The `slice_id` is the index of the time slice. This is a 0-based index. So for a given
+    /// time period being used to slice time, the first `slice_hash` at `slice_id` 0 would
+    /// represent the combined hash of all known ops in the time slice `[0, period)`. Then `slice_id`
+    /// 1 would represent the combined hash of all known ops in the time slice `[period, 2*period)`.
     fn store_slice_hash(
         &self,
         slice_id: u64,
-        slice_hash: Vec<u8>,
+        slice_hash: bytes::Bytes,
     ) -> BoxFuture<'_, K2Result<()>> {
         async move {
             self.write()
                 .await
                 .time_slice_hashes
-                .insert(slice_id, slice_hash);
-            Ok(())
+                .insert(slice_id, slice_hash)
         }
         .boxed()
     }
 
+    /// Retrieve the count of time slice hashes stored.
+    ///
+    /// Note that this is not the number of hashes that have been provided at unique `slice_id`s.
+    /// Start from time slice id 0 and count up to the highest stored id. This value should be the
+    /// count based on the highest stored id.
+    /// This value is easier to compare between peers because it tracks an absolute number of time
+    /// slices that have had a slice hash computed and stored. The number of stored hashes would
+    /// only be comparable if the earliest point that data has been seen for is known between two
+    /// peers.
     fn slice_hash_count(&self) -> BoxFuture<'_, K2Result<u64>> {
-        async move { Ok(self.read().await.time_slice_hashes.len() as u64) }
+        // +1 to convert from a 0-based index to a count
+        async move { Ok(self.read().await.time_slice_hashes.highest_stored_id.map(|id| id + 1).unwrap_or_default()) }
             .boxed()
     }
 
+    /// Retrieve the hash of a time slice.
+    ///
+    /// This must be the same value provided by the caller to `store_slice_hash` for the same `slice_id`.
+    /// If `store_slice_hash` has been called multiple times for the same `slice_id`, the most recent value is returned.
+    /// If the caller has never provided a value for this `slice_id`, return `None`.
     fn retrieve_slice_hash(
         &self,
         slice_id: u64,
-    ) -> BoxFuture<'_, K2Result<Option<Vec<u8>>>> {
+    ) -> BoxFuture<'_, K2Result<Option<bytes::Bytes>>> {
         async move {
-            Ok(self.read().await.time_slice_hashes.get(&slice_id).cloned())
+            Ok(self.read().await.time_slice_hashes.get(slice_id).and_then(
+                |x| match x {
+                    SliceHash::Single { hash, .. } => Some(hash.clone()),
+                    SliceHash::Block { .. } => None,
+                },
+            ))
         }
         .boxed()
     }

--- a/crates/memory/src/op_store/time_slice_hash_store.rs
+++ b/crates/memory/src/op_store/time_slice_hash_store.rs
@@ -3,7 +3,7 @@ use kitsune2_api::{K2Error, K2Result};
 /// In-memory store for time slice hashes.
 ///
 /// The inner store will look something like this:
-/// `[ Block_0_3, Single_3_ABC, Block_4_2, Single_6_DEF ]`
+/// `[ Block(0, 3), Single(3, [a, b, c]), Block(4, 2), Single(6, [d, e, f]) ]`
 ///
 /// Consecutive sequences of empty hashes are compressed into a single block. A block
 /// contains at least 1 hash.

--- a/crates/memory/src/op_store/time_slice_hash_store.rs
+++ b/crates/memory/src/op_store/time_slice_hash_store.rs
@@ -232,7 +232,9 @@ impl TimeSliceHashStore {
             }
         }
 
-        if highest_stored_id != 0 && highest_stored_id != self.highest_stored_id.unwrap() {
+        if highest_stored_id != 0
+            && highest_stored_id != self.highest_stored_id.unwrap()
+        {
             println!(
                 "highest_stored_id does not match: {} != {:?}",
                 highest_stored_id, self.highest_stored_id

--- a/crates/memory/src/op_store/time_slice_hash_store.rs
+++ b/crates/memory/src/op_store/time_slice_hash_store.rs
@@ -1,0 +1,530 @@
+use kitsune2_api::{K2Error, K2Result};
+
+/// In-memory store for time slice hashes.
+///
+/// The inner store will look something like this:
+/// ----, -, -, ----, -, ----, -, ----
+///
+/// Consecutive sequences of empty hashes are compressed into a single block. A block
+/// contains at least 1 hash.
+///
+/// Gaps are not permitted, so the representation starts out as a single block that spans
+/// the entire range of possible slice ids. As hashes are inserted, the block is split around
+/// the inserted hash.
+#[derive(Debug)]
+#[cfg_attr(test, derive(Clone))]
+pub(super) struct TimeSliceHashStore {
+    pub(super) highest_stored_id: Option<u64>,
+    inner: Vec<SliceHash>,
+}
+
+impl Default for TimeSliceHashStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(test, derive(PartialEq))]
+pub enum SliceHash {
+    Single { id: u64, hash: bytes::Bytes },
+    Block { id: u64, count: u64 },
+}
+
+#[cfg(test)]
+impl SliceHash {
+    pub(crate) fn id(&self) -> u64 {
+        match self {
+            SliceHash::Single { id, .. } => *id,
+            SliceHash::Block { id, .. } => *id,
+        }
+    }
+
+    pub(crate) fn end(&self) -> u64 {
+        self.id()
+            + match self {
+                SliceHash::Single { .. } => 0,
+                SliceHash::Block { count, .. } => *count,
+            }
+    }
+}
+
+impl TimeSliceHashStore {
+    pub(super) fn new() -> Self {
+        Self {
+            highest_stored_id: None,
+            inner: vec![SliceHash::Block {
+                id: 0,
+                count: u64::MAX,
+            }],
+        }
+    }
+
+    /// Insert a hash at the given slice id.
+    pub(super) fn insert(
+        &mut self,
+        slice_id: u64,
+        hash: bytes::Bytes,
+    ) -> K2Result<()> {
+        if !hash.is_empty() {
+            match &mut self.highest_stored_id {
+                Some(id) if slice_id > *id => {
+                    *id = slice_id;
+                }
+                None => {
+                    self.highest_stored_id = Some(slice_id);
+                }
+                _ => {}
+            }
+        }
+
+        let mut handled = false;
+        for (i, slice_hash) in self.inner.iter().cloned().enumerate() {
+            match slice_hash {
+                SliceHash::Single { id, .. } => {
+                    if id == slice_id {
+                        if hash.is_empty() {
+                            // This doesn't need to be supported. If we receive an empty hash
+                            // for a slice id after we've already stored a non-empty hash for
+                            // that slice id, then the caller has done something wrong.
+
+                            return Err(K2Error::other("Cannot overwrite non-empty hash with empty hash"));
+                        } else {
+                            // We're overwriting any existing value with a new non-empty value.
+                            if let SliceHash::Single {
+                                hash: existing_hash,
+                                ..
+                            } = &mut self.inner[i]
+                            {
+                                *existing_hash = hash;
+                            }
+                        }
+
+                        handled = true;
+                        break;
+                    }
+                }
+                SliceHash::Block { id, count, .. } => {
+                    if id <= slice_id && slice_id <= id + count {
+                        // Completely contained within a compressed block then either
+                        //   - It is empty, so we can just ignore it.
+                        //   - It is not empty, so we need to split the block into two.
+
+                        if !hash.is_empty() {
+                            if slice_id == id {
+                                // Special case for inserting at the start of the block.
+
+                                // We're overwriting the first value in the block.
+                                self.inner[i] =
+                                    SliceHash::Single { id: slice_id, hash };
+
+                                if count > 1 {
+                                    self.inner.insert(
+                                        i + 1,
+                                        SliceHash::Block {
+                                            id: slice_id + 1,
+                                            count: count - 1,
+                                        },
+                                    );
+                                }
+                            } else if slice_id == id + count {
+                                // Special case for inserting at the end of the block.
+
+                                // We're overwriting the last value in the block.
+                                self.inner[i] =
+                                    SliceHash::Single { id: slice_id, hash };
+
+                                if count > 1 {
+                                    self.inner.insert(
+                                        i,
+                                        SliceHash::Block {
+                                            id,
+                                            count: count - 1,
+                                        },
+                                    );
+                                }
+                            } else {
+                                // Otherwise we're inserting in the middle of a block.
+
+                                // Contained within a compressed block but not empty, so we need
+                                // to split the block into two.
+                                let lower_block = SliceHash::Block {
+                                    id,
+                                    count: slice_id - id - 1,
+                                };
+                                let upper_block = SliceHash::Block {
+                                    id: slice_id + 1,
+                                    count: count - (slice_id - id) - 1,
+                                };
+
+                                // We're going to do one overwrite and two inserts.
+                                self.inner.reserve(2);
+                                self.inner[i] = lower_block;
+                                self.inner.insert(
+                                    i + 1,
+                                    SliceHash::Single { id: slice_id, hash },
+                                );
+                                self.inner.insert(i + 2, upper_block);
+                            }
+                        }
+
+                        handled = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        if !handled {
+            return Err(K2Error::other("Did not know how to insert hash"));
+        }
+
+        Ok(())
+    }
+
+    pub(super) fn get(&self, slice_id: u64) -> Option<&SliceHash> {
+        self.inner.iter().find(|slice_hash| match slice_hash {
+            SliceHash::Single { id, .. } => *id == slice_id,
+            SliceHash::Block { id, count, .. } => {
+                *id <= slice_id && slice_id <= id + count
+            }
+        })
+    }
+
+    #[cfg(test)]
+    pub(super) fn check(&self) -> bool {
+        let mut highest_stored_id = 0;
+        for (i, slice_hash) in self.inner.iter().enumerate() {
+            let previous_end = if i > 0 {
+                self.inner[i - 1].end()
+            } else {
+                u64::MAX
+            };
+
+            match slice_hash {
+                SliceHash::Single { id, .. } => {
+                    if *id != previous_end.wrapping_add(1) {
+                        println!(
+                            "Single does not follow previous: {} != {}",
+                            *id,
+                            previous_end.wrapping_add(1)
+                        );
+                        return false;
+                    }
+                    highest_stored_id = *id;
+                }
+                SliceHash::Block { id, count, .. } => {
+                    if *id != previous_end.wrapping_add(1) {
+                        println!(
+                            "Block does not follow previous: {} != {}",
+                            *id,
+                            previous_end.wrapping_add(1)
+                        );
+                        return false;
+                    }
+
+                    if *count > u64::MAX - *id {
+                        // Not allowed to wrap around
+                        println!("Block wraps around");
+                        return false;
+                    }
+                }
+            }
+        }
+
+        if highest_stored_id != 0 && highest_stored_id != self.highest_stored_id.unwrap() {
+            println!(
+                "highest_stored_id does not match: {} != {:?}",
+                highest_stored_id, self.highest_stored_id
+            );
+            return false;
+        }
+
+        match self.inner.last() {
+            Some(SliceHash::Block { id, count }) => {
+                if *count != u64::MAX - id {
+                    println!(
+                        "Block does not cover remaining range: {} != {}",
+                        *count,
+                        u64::MAX - highest_stored_id
+                    );
+                    return false;
+                }
+            }
+            Some(SliceHash::Single { id, .. }) => {
+                if *id != highest_stored_id || *id != u64::MAX {
+                    println!(
+                        "Single does not cover remaining range: {} != {}",
+                        *id, highest_stored_id
+                    );
+                    return false;
+                }
+            }
+            _ => {
+                println!("No last element");
+                return false;
+            }
+        }
+
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_empty() {
+        let store = TimeSliceHashStore::new();
+
+        assert_eq!(None, store.highest_stored_id);
+        assert_eq!(1, store.inner.len());
+        assert_eq!(
+            SliceHash::Block {
+                id: 0,
+                count: u64::MAX
+            },
+            store.inner[0]
+        );
+
+        assert!(store.check());
+    }
+
+    #[test]
+    fn insert_empty_hash_into_empty() {
+        let mut store = TimeSliceHashStore::new();
+        let original = store.clone();
+
+        store.insert(100, bytes::Bytes::new()).unwrap();
+
+        // Doesn't change the stored value, but does update the highest stored value
+        assert_eq!(original.inner, store.inner);
+        assert_eq!(None, store.highest_stored_id);
+
+        assert!(store.check());
+    }
+
+    #[test]
+    fn insert_single_hash_into_empty() {
+        let mut store = TimeSliceHashStore::new();
+
+        store.insert(100, vec![1, 2, 3].into()).unwrap();
+
+        assert_eq!(3, store.inner.len());
+        assert_eq!(SliceHash::Block { id: 0, count: 99 }, store.inner[0]);
+        assert_eq!(
+            SliceHash::Single {
+                id: 100,
+                hash: vec![1, 2, 3].into()
+            },
+            store.inner[1]
+        );
+        assert_eq!(
+            SliceHash::Block {
+                id: 101,
+                count: u64::MAX - 101
+            },
+            store.inner[2]
+        );
+        assert_eq!(Some(100), store.highest_stored_id);
+
+        assert!(store.check());
+    }
+
+    #[test]
+    fn split_at_right_end_of_block() {
+        let mut store = TimeSliceHashStore::new();
+
+        store.insert(100, vec![1, 2, 3].into()).unwrap();
+        assert_eq!(3, store.inner.len());
+
+        store.insert(99, vec![2, 3, 4].into()).unwrap();
+        assert_eq!(4, store.inner.len());
+
+        assert_eq!(SliceHash::Block { id: 0, count: 98 }, store.inner[0]);
+        assert_eq!(
+            SliceHash::Single {
+                id: 99,
+                hash: vec![2, 3, 4].into()
+            },
+            store.inner[1]
+        );
+        assert_eq!(
+            SliceHash::Single {
+                id: 100,
+                hash: vec![1, 2, 3].into()
+            },
+            store.inner[2]
+        );
+        assert_eq!(
+            SliceHash::Block {
+                id: 101,
+                count: u64::MAX - 101
+            },
+            store.inner[3]
+        );
+
+        assert!(store.check());
+    }
+
+    #[test]
+    fn split_at_left_end_of_block() {
+        let mut store = TimeSliceHashStore::new();
+
+        store.insert(100, vec![1, 2, 3].into()).unwrap();
+        assert_eq!(3, store.inner.len());
+
+        store.insert(101, vec![2, 3, 4].into()).unwrap();
+        assert_eq!(4, store.inner.len());
+
+        assert_eq!(SliceHash::Block { id: 0, count: 99 }, store.inner[0]);
+        assert_eq!(
+            SliceHash::Single {
+                id: 100,
+                hash: vec![1, 2, 3].into()
+            },
+            store.inner[1]
+        );
+        assert_eq!(
+            SliceHash::Single {
+                id: 101,
+                hash: vec![2, 3, 4].into()
+            },
+            store.inner[2]
+        );
+        assert_eq!(
+            SliceHash::Block {
+                id: 102,
+                count: u64::MAX - 102
+            },
+            store.inner[3]
+        );
+
+        assert!(store.check());
+    }
+
+    #[test]
+    fn convert_unit_block_into_single_hash() {
+        let mut store = TimeSliceHashStore::new();
+
+        store.insert(100, vec![1, 2, 3].into()).unwrap();
+        assert_eq!(3, store.inner.len());
+
+        store.insert(102, vec![2, 3, 4].into()).unwrap();
+        assert_eq!(5, store.inner.len());
+
+        assert_eq!(SliceHash::Block { id: 101, count: 0 }, store.inner[2]);
+
+        store.insert(101, vec![3, 4, 5].into()).unwrap();
+        assert_eq!(5, store.inner.len());
+
+        assert_eq!(
+            SliceHash::Single {
+                id: 100,
+                hash: vec![1, 2, 3].into()
+            },
+            store.inner[1]
+        );
+        assert_eq!(
+            SliceHash::Single {
+                id: 101,
+                hash: vec![3, 4, 5].into()
+            },
+            store.inner[2]
+        );
+        assert_eq!(
+            SliceHash::Single {
+                id: 102,
+                hash: vec![2, 3, 4].into()
+            },
+            store.inner[3]
+        );
+
+        assert!(store.check());
+    }
+
+    #[test]
+    fn overwrite_existing_single_hash() {
+        let mut store = TimeSliceHashStore::new();
+
+        store.insert(100, vec![1, 2, 3].into()).unwrap();
+        assert_eq!(3, store.inner.len());
+
+        assert_eq!(
+            SliceHash::Single {
+                id: 100,
+                hash: vec![1, 2, 3].into()
+            },
+            store.inner[1]
+        );
+
+        store.insert(100, vec![2, 3, 4].into()).unwrap();
+        assert_eq!(3, store.inner.len());
+
+        assert_eq!(
+            SliceHash::Single {
+                id: 100,
+                hash: vec![2, 3, 4].into()
+            },
+            store.inner[1]
+        );
+
+        assert!(store.check());
+    }
+
+    #[test]
+    fn highest_stored_ignores_empty() {
+        let mut store = TimeSliceHashStore::new();
+
+        store.insert(100, vec![1, 2, 3].into()).unwrap();
+        assert_eq!(Some(100), store.highest_stored_id);
+
+        store.insert(5000, bytes::Bytes::new()).unwrap();
+        assert_eq!(Some(100), store.highest_stored_id);
+
+        store.insert(120, vec![2, 3, 4].into()).unwrap();
+        assert_eq!(Some(120), store.highest_stored_id);
+
+        assert!(store.check());
+    }
+
+    #[test]
+    fn get() {
+        let mut store = TimeSliceHashStore::new();
+
+        store.insert(100, vec![1, 2, 3].into()).unwrap();
+
+        assert_eq!(
+            Some(&SliceHash::Single {
+                id: 100,
+                hash: vec![1, 2, 3].into()
+            }),
+            store.get(100)
+        );
+        assert_eq!(Some(&SliceHash::Block { id: 0, count: 99 }), store.get(0));
+        assert_eq!(Some(&SliceHash::Block { id: 0, count: 99 }), store.get(30));
+        assert_eq!(Some(&SliceHash::Block { id: 0, count: 99 }), store.get(99));
+        assert_eq!(
+            Some(&SliceHash::Block {
+                id: 101,
+                count: u64::MAX - 101
+            }),
+            store.get(101)
+        );
+        assert_eq!(
+            Some(&SliceHash::Block {
+                id: 101,
+                count: u64::MAX - 101
+            }),
+            store.get(500)
+        );
+        assert_eq!(
+            Some(&SliceHash::Block {
+                id: 101,
+                count: u64::MAX - 101
+            }),
+            store.get(u64::MAX)
+        );
+    }
+}

--- a/crates/memory/src/op_store/time_slice_hash_store.rs
+++ b/crates/memory/src/op_store/time_slice_hash_store.rs
@@ -61,7 +61,10 @@ mod tests {
         let mut store = TimeSliceHashStore::default();
 
         let e = store.insert(100, bytes::Bytes::new()).unwrap_err();
-        assert_eq!("Cannot insert empty combined hash (src: None)", e.to_string());
+        assert_eq!(
+            "Cannot insert empty combined hash (src: None)",
+            e.to_string()
+        );
     }
 
     #[test]

--- a/crates/memory/src/op_store/time_slice_hash_store.rs
+++ b/crates/memory/src/op_store/time_slice_hash_store.rs
@@ -3,7 +3,7 @@ use kitsune2_api::{K2Error, K2Result};
 /// In-memory store for time slice hashes.
 ///
 /// The inner store will look something like this:
-/// ----, -, -, ----, -, ----, -, ----
+/// `[ Block_0_3, Single_3_ABC, Block_4_2, Single_6_DEF ]`
 ///
 /// Consecutive sequences of empty hashes are compressed into a single block. A block
 /// contains at least 1 hash.

--- a/crates/memory/src/op_store/time_slice_hash_store.rs
+++ b/crates/memory/src/op_store/time_slice_hash_store.rs
@@ -57,11 +57,11 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Cannot insert empty combined hash")]
     fn insert_empty_hash_into_empty() {
         let mut store = TimeSliceHashStore::default();
 
-        store.insert(100, bytes::Bytes::new()).unwrap();
+        let e = store.insert(100, bytes::Bytes::new()).unwrap_err();
+        assert_eq!("Cannot insert empty combined hash (src: None)", e.to_string());
     }
 
     #[test]


### PR DESCRIPTION
Getting rid of the origin time means one less value that user has to understand and set. It was a limited value concept anyway because you have to set it to when you create the app so that everyone sees the value origin time. Then if somebody installs the app 6 months later then they have to gossip 6 months worth of empty hashes anyway.

This replaces the origin time concept with starting from the UNIX_TIMESTAMP (i.e. a 0 valued Timestamp, because that's how our Timestamp is defined). Any empty hashes are represented as a `(initial_time_slice_id, count)` pair.

So for a network with a slice period of 1 week, that might look something like:
- UNIX timestamp, through to 3 weeks ago, no data stored
- 3 weeks ago to 2 weeks ago, a combined hash stored
- 2 weeks ago to 1 week ago, a combined hash stored
- From some time this week, until the end of time, no data stored

The only thing I want to call out about this is that the Holochain host implementation for Kitsune will need to implement a persistent version of what I've implemented in memory. I've tried to make it reasonably straight forward but it will take a bit of thought to get the same thing done in a database.