### PR TITLE
Dht hash partitioning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,6 +767,7 @@ dependencies = [
  "kitsune2_memory",
  "kitsune2_test_utils",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/api/src/agent.rs
+++ b/crates/api/src/agent.rs
@@ -165,8 +165,8 @@ pub struct AgentInfo {
     pub url: Option<Url>,
 
     /// The arc over which this agent claims authority.
-    #[serde(default = "StorageArc::default")]
-    pub storage_arc: StorageArc,
+    #[serde(default = "DhtArc::default")]
+    pub storage_arc: DhtArc,
 }
 
 /// Signed agent information.
@@ -305,7 +305,7 @@ mod test {
         let now = Timestamp::from_micros(1731690797907204);
         let later = Timestamp::from_micros(now.as_micros() + 72_000_000_000);
         let url = Some(Url::from_str("ws://test.com:80/test-url").unwrap());
-        let storage_arc = StorageArc::Arc(42, u32::MAX / 13);
+        let storage_arc = DhtArc::Arc(42, u32::MAX / 13);
 
         let enc = AgentInfoSigned::sign(
             &TestCrypto,
@@ -348,7 +348,7 @@ mod test {
     async fn fills_in_default_fields() {
         let dec = AgentInfoSigned::decode(&TestCrypto, br#"{"agentInfo":"{\"agent\":\"dGVzdC1hZ2VudA\",\"space\":\"dGVzdC1zcGFjZQ\",\"createdAt\":\"1731690797907204\",\"expiresAt\":\"1731762797907204\",\"isTombstone\":false}","signature":"ZmFrZS1zaWduYXR1cmU"}"#).unwrap();
         assert!(dec.url.is_none());
-        assert_eq!(StorageArc::Empty, dec.storage_arc);
+        assert_eq!(DhtArc::Empty, dec.storage_arc);
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/crates/api/src/agent.rs
+++ b/crates/api/src/agent.rs
@@ -316,7 +316,7 @@ mod test {
                 expires_at: later,
                 is_tombstone: false,
                 url: url.clone(),
-                storage_arc: storage_arc.clone(),
+                storage_arc,
             },
         )
         .await

--- a/crates/api/src/agent.rs
+++ b/crates/api/src/agent.rs
@@ -115,31 +115,6 @@ pub trait LocalAgent: Signer + 'static + Send + Sync + std::fmt::Debug {
 /// Trait-object [LocalAgent].
 pub type DynLocalAgent = Arc<dyn LocalAgent>;
 
-/// A basic definition of a storage arc compatible with the concept of
-/// storage and querying of items in a store that fall within that arc.
-///
-/// This is intentionally a type definition and NOT a struct to prevent
-/// the accumulation of functionality attached to it. This is intended
-/// to transmit the raw concept of the arc, and ensure that any complexity
-/// of its usage are hidden in the modules that need to use this raw data,
-/// e.g. any store or gossip modules.
-///
-/// - If None, this arc does not claim any coverage.
-/// - If Some, this arc is an inclusive range from the first loc to the second.
-/// - If the first bound is larger than the second, the claim wraps around
-///   the end of u32::MAX to the other side.
-/// - A full arc is represented by `Some((0, u32::MAX))`.
-pub type BasicArc = Option<(u32, u32)>;
-
-/// An empty basic arc (`None`) is used for tombstone entries and for
-/// light-weight nodes that cannot afford the storage and bandwidth of being
-/// an authority.
-pub const BASIC_ARC_EMPTY: BasicArc = None;
-
-/// A full basic arc (`Some((0, u32::MAX))`) is used by nodes that wish to
-/// claim authority over the full DHT.
-pub const BASIC_ARC_FULL: BasicArc = Some((0, u32::MAX));
-
 mod serde_string_timestamp {
     pub fn serialize<S>(
         t: &crate::Timestamp,

--- a/crates/api/src/arc.rs
+++ b/crates/api/src/arc.rs
@@ -193,6 +193,15 @@ mod tests {
     }
 
     #[test]
+    fn contains_empty_arc_no_locations() {
+        let arc = DhtArc::Empty;
+
+        assert!(!arc.contains(0));
+        assert!(!arc.contains(u32::MAX));
+        assert!(!arc.contains(u32::MAX / 2));
+    }
+
+    #[test]
     fn arc_dist_edge_cases() {
         type Dist = u32;
         type Loc = u32;

--- a/crates/api/src/arc.rs
+++ b/crates/api/src/arc.rs
@@ -1,7 +1,6 @@
 //! Kitsune2 arcs represent a range of hash locations on the DHT.
 //!
-//! An arc can exist in its own right and refer to a range of locations on the DHT.
-//! It can also be used in context, such as an agent. Where it represents the range of locations
+//! When used in the context of an agent, it represents the range of hash locations
 //! that agent is responsible for.
 
 use serde::{Deserialize, Serialize};
@@ -10,7 +9,7 @@ use serde::{Deserialize, Serialize};
 /// storage and querying of items in a store that fall within that arc.
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, Default)]
 #[serde(untagged)]
-pub enum StorageArc {
+pub enum DhtArc {
     /// No DHT locations are contained within this arc.
     #[default]
     Empty,
@@ -20,9 +19,9 @@ pub enum StorageArc {
     Arc(u32, u32),
 }
 
-impl StorageArc {
+impl DhtArc {
     /// A full arc that contains all DHT locations.
-    pub const FULL: StorageArc = StorageArc::Arc(0, u32::MAX);
+    pub const FULL: DhtArc = DhtArc::Arc(0, u32::MAX);
 
     /// Get the min distance from a location to an arc in a wrapping u32 space.
     /// This function will only return 0 if the location is covered by the arc.
@@ -62,8 +61,8 @@ impl StorageArc {
     /// ```
     pub fn dist(&self, loc: u32) -> u32 {
         match self {
-            StorageArc::Empty => u32::MAX,
-            StorageArc::Arc(arc_start, arc_end) => {
+            DhtArc::Empty => u32::MAX,
+            DhtArc::Arc(arc_start, arc_end) => {
                 let (d1, d2) = if arc_start > arc_end {
                     // this arc wraps around the end of u32::MAX
 
@@ -134,12 +133,12 @@ impl StorageArc {
     ///
     /// |---b--a-A--B---|
     /// ```
-    pub fn overlaps(&self, other: &StorageArc) -> bool {
+    pub fn overlaps(&self, other: &DhtArc) -> bool {
         match (&self, &other) {
-            (StorageArc::Empty, _) | (_, StorageArc::Empty) => false,
+            (DhtArc::Empty, _) | (_, DhtArc::Empty) => false,
             (
-                this @ StorageArc::Arc(a_beg, a_end),
-                other @ StorageArc::Arc(b_beg, b_end),
+                this @ DhtArc::Arc(a_beg, a_end),
+                other @ DhtArc::Arc(b_beg, b_end),
             ) => {
                 // The only way for there to be overlap is if
                 // either of a's start or end points are within b
@@ -155,11 +154,11 @@ impl StorageArc {
 
 #[cfg(test)]
 mod tests {
-    use crate::StorageArc;
+    use crate::DhtArc;
 
     #[test]
     fn contains_full_arc_all_values() {
-        let arc = StorageArc::FULL;
+        let arc = DhtArc::FULL;
 
         // Contains bounds
         assert!(arc.contains(0));
@@ -171,7 +170,7 @@ mod tests {
 
     #[test]
     fn contains_includes_bounds() {
-        let arc = StorageArc::Arc(32, 64);
+        let arc = DhtArc::Arc(32, 64);
 
         assert!(arc.contains(32));
         assert!(arc.contains(64));
@@ -179,7 +178,7 @@ mod tests {
 
     #[test]
     fn contains_wraps_around() {
-        let arc = StorageArc::Arc(u32::MAX - 32, 32);
+        let arc = DhtArc::Arc(u32::MAX - 32, 32);
 
         assert!(!arc.contains(u32::MAX - 33));
         assert!(arc.contains(u32::MAX - 32));
@@ -195,37 +194,37 @@ mod tests {
     fn arc_dist_edge_cases() {
         type Dist = u32;
         type Loc = u32;
-        const F: &[(Dist, Loc, StorageArc)] = &[
+        const F: &[(Dist, Loc, DhtArc)] = &[
             // Empty arcs contain no values, distance is always u32::MAX
-            (u32::MAX, 0, StorageArc::Empty),
-            (u32::MAX, u32::MAX / 2, StorageArc::Empty),
-            (u32::MAX, u32::MAX, StorageArc::Empty),
+            (u32::MAX, 0, DhtArc::Empty),
+            (u32::MAX, u32::MAX / 2, DhtArc::Empty),
+            (u32::MAX, u32::MAX, DhtArc::Empty),
             // Unit length arcs at max value
-            (1, 0, StorageArc::Arc(u32::MAX, u32::MAX)),
+            (1, 0, DhtArc::Arc(u32::MAX, u32::MAX)),
             (
                 u32::MAX / 2 + 1,
                 u32::MAX / 2,
-                StorageArc::Arc(u32::MAX, u32::MAX),
+                DhtArc::Arc(u32::MAX, u32::MAX),
             ),
             // Unit length arcs at min value
-            (1, u32::MAX, StorageArc::Arc(0, 0)),
-            (u32::MAX / 2, u32::MAX / 2, StorageArc::Arc(0, 0)),
+            (1, u32::MAX, DhtArc::Arc(0, 0)),
+            (u32::MAX / 2, u32::MAX / 2, DhtArc::Arc(0, 0)),
             // Lower bound is inclusive
-            (0, 0, StorageArc::Arc(0, 1)),
-            (0, u32::MAX - 1, StorageArc::Arc(u32::MAX - 1, u32::MAX)),
+            (0, 0, DhtArc::Arc(0, 1)),
+            (0, u32::MAX - 1, DhtArc::Arc(u32::MAX - 1, u32::MAX)),
             // Distance from lower bound, non-wrapping
-            (1, 0, StorageArc::Arc(1, 2)),
-            (1, u32::MAX, StorageArc::Arc(0, 1)),
+            (1, 0, DhtArc::Arc(1, 2)),
+            (1, u32::MAX, DhtArc::Arc(0, 1)),
             // Distance from upper bound, non-wrapping
-            (1, 0, StorageArc::Arc(u32::MAX - 1, u32::MAX)),
+            (1, 0, DhtArc::Arc(u32::MAX - 1, u32::MAX)),
             // Distance from upper bound, wrapping
-            (0, 0, StorageArc::Arc(u32::MAX, 0)),
-            (1, 1, StorageArc::Arc(u32::MAX, 0)),
+            (0, 0, DhtArc::Arc(u32::MAX, 0)),
+            (1, 1, DhtArc::Arc(u32::MAX, 0)),
             // Distance from lower bound, wrapping
-            (1, u32::MAX - 1, StorageArc::Arc(u32::MAX, 0)),
-            (1, u32::MAX - 1, StorageArc::Arc(u32::MAX, 1)),
+            (1, u32::MAX - 1, DhtArc::Arc(u32::MAX, 0)),
+            (1, u32::MAX - 1, DhtArc::Arc(u32::MAX, 1)),
             // Contains, wrapping
-            (0, 0, StorageArc::Arc(u32::MAX, 1)),
+            (0, 0, DhtArc::Arc(u32::MAX, 1)),
         ];
 
         for (dist, loc, arc) in F.iter() {
@@ -242,54 +241,34 @@ mod tests {
     #[test]
     fn arcs_overlap_edge_cases() {
         type DoOverlap = bool;
-        const F: &[(DoOverlap, StorageArc, StorageArc)] = &[
-            (false, StorageArc::Arc(0, 0), StorageArc::Arc(1, 1)),
-            (
-                false,
-                StorageArc::Arc(0, 0),
-                StorageArc::Arc(u32::MAX, u32::MAX),
-            ),
-            (true, StorageArc::Arc(0, 0), StorageArc::Arc(0, 0)),
+        const F: &[(DoOverlap, DhtArc, DhtArc)] = &[
+            (false, DhtArc::Arc(0, 0), DhtArc::Arc(1, 1)),
+            (false, DhtArc::Arc(0, 0), DhtArc::Arc(u32::MAX, u32::MAX)),
+            (true, DhtArc::Arc(0, 0), DhtArc::Arc(0, 0)),
             (
                 true,
-                StorageArc::Arc(u32::MAX, u32::MAX),
-                StorageArc::Arc(u32::MAX, u32::MAX),
+                DhtArc::Arc(u32::MAX, u32::MAX),
+                DhtArc::Arc(u32::MAX, u32::MAX),
             ),
-            (true, StorageArc::Arc(u32::MAX, 0), StorageArc::Arc(0, 0)),
+            (true, DhtArc::Arc(u32::MAX, 0), DhtArc::Arc(0, 0)),
             (
                 true,
-                StorageArc::Arc(u32::MAX, 0),
-                StorageArc::Arc(u32::MAX, u32::MAX),
+                DhtArc::Arc(u32::MAX, 0),
+                DhtArc::Arc(u32::MAX, u32::MAX),
             ),
             (
                 true,
-                StorageArc::Arc(u32::MAX, 0),
-                StorageArc::Arc(u32::MAX, u32::MAX),
+                DhtArc::Arc(u32::MAX, 0),
+                DhtArc::Arc(u32::MAX, u32::MAX),
             ),
-            (true, StorageArc::Arc(0, 3), StorageArc::Arc(1, 2)),
-            (true, StorageArc::Arc(1, 2), StorageArc::Arc(0, 3)),
-            (true, StorageArc::Arc(1, 3), StorageArc::Arc(2, 4)),
-            (true, StorageArc::Arc(2, 4), StorageArc::Arc(1, 3)),
-            (
-                true,
-                StorageArc::Arc(u32::MAX - 1, 1),
-                StorageArc::Arc(u32::MAX, 0),
-            ),
-            (
-                true,
-                StorageArc::Arc(u32::MAX, 0),
-                StorageArc::Arc(u32::MAX - 1, 1),
-            ),
-            (
-                true,
-                StorageArc::Arc(u32::MAX - 1, 0),
-                StorageArc::Arc(u32::MAX, 1),
-            ),
-            (
-                true,
-                StorageArc::Arc(u32::MAX, 1),
-                StorageArc::Arc(u32::MAX - 1, 0),
-            ),
+            (true, DhtArc::Arc(0, 3), DhtArc::Arc(1, 2)),
+            (true, DhtArc::Arc(1, 2), DhtArc::Arc(0, 3)),
+            (true, DhtArc::Arc(1, 3), DhtArc::Arc(2, 4)),
+            (true, DhtArc::Arc(2, 4), DhtArc::Arc(1, 3)),
+            (true, DhtArc::Arc(u32::MAX - 1, 1), DhtArc::Arc(u32::MAX, 0)),
+            (true, DhtArc::Arc(u32::MAX, 0), DhtArc::Arc(u32::MAX - 1, 1)),
+            (true, DhtArc::Arc(u32::MAX - 1, 0), DhtArc::Arc(u32::MAX, 1)),
+            (true, DhtArc::Arc(u32::MAX, 1), DhtArc::Arc(u32::MAX - 1, 0)),
         ];
 
         for (do_overlap, a, b) in F.iter() {

--- a/crates/api/src/arc.rs
+++ b/crates/api/src/arc.rs
@@ -1,0 +1,46 @@
+//! Kitsune2 arcs represent a range of hash locations on the DHT.
+//!
+//! An arc can exist in its own right and refer to a range of locations on the DHT.
+//! It can also be used in context, such as an agent. Where it represents the range of locations
+//! that agent is responsible for.
+
+/// The definition of an arc for Kitsune.
+///
+/// The lower bound is inclusive, the upper bound is exclusive.
+pub type ArcLiteral = (u32, u32);
+
+/// A full arc is represented by `(0, u32::MAX)`.
+pub const ARC_LITERAL_FULL: ArcLiteral = (0, u32::MAX);
+
+/// Check if a location is contained within the arc.
+pub fn arc_contains(arc_literal: ArcLiteral, location: u32) -> bool {
+    if arc_literal.0 < arc_literal.1 {
+        location >= arc_literal.0 && location < arc_literal.1
+    } else {
+        location >= arc_literal.0 || location < arc_literal.1
+    }
+}
+
+/// A basic definition of a storage arc compatible with the concept of
+/// storage and querying of items in a store that fall within that arc.
+///
+/// This is intentionally a type definition and NOT a struct to prevent
+/// the accumulation of functionality attached to it. This is intended
+/// to transmit the raw concept of the arc, and ensure that any complexity
+/// of its usage are hidden in the modules that need to use this raw data,
+/// e.g. any store or gossip modules.
+///
+/// - If None, this arc does not claim any coverage.
+/// - If Some, this arc is an inclusive range from the first loc to the second.
+/// - If the first bound is larger than the second, the claim wraps around
+///   the end of u32::MAX to the other side.
+/// - A full arc is represented by `Some((0, u32::MAX))`.
+pub type BasicArc = Option<ArcLiteral>;
+
+/// An empty basic arc (`None`) is used for tombstone entries and for
+/// light-weight nodes that cannot afford the storage and bandwidth of being
+/// an authority.
+pub const BASIC_ARC_EMPTY: BasicArc = None;
+/// A full basic arc (`Some((0, u32::MAX))`) is used by nodes that wish to
+/// claim authority over the full DHT.
+pub const BASIC_ARC_FULL: BasicArc = Some(ARC_LITERAL_FULL);

--- a/crates/api/src/arc.rs
+++ b/crates/api/src/arc.rs
@@ -17,6 +17,7 @@ pub fn arc_contains(arc_literal: ArcLiteral, location: u32) -> bool {
     if arc_literal.0 < arc_literal.1 {
         location >= arc_literal.0 && location < arc_literal.1
     } else {
+        // Arc wraps around u32::MAX.
         location >= arc_literal.0 || location < arc_literal.1
     }
 }

--- a/crates/api/src/arc.rs
+++ b/crates/api/src/arc.rs
@@ -7,7 +7,9 @@ use serde::{Deserialize, Serialize};
 
 /// The definition of a storage arc compatible with the concept of
 /// storage and querying of items in a store that fall within that arc.
-#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, Default)]
+#[derive(
+    Debug, Clone, Copy, Serialize, Deserialize, Hash, Eq, PartialEq, Default,
+)]
 #[serde(untagged)]
 pub enum DhtArc {
     /// No DHT locations are contained within this arc.

--- a/crates/api/src/arc.rs
+++ b/crates/api/src/arc.rs
@@ -10,7 +10,7 @@
 pub type ArcLiteral = (u32, u32);
 
 /// A full arc is represented by `(0, u32::MAX)`.
-pub const ARC_LITERAL_FULL: ArcLiteral = (0, u32::MAX);
+pub const ARC_LITERAL_FULL: ArcLiteral = (0, 0);
 
 /// Check if a location is contained within the arc.
 pub fn arc_contains(arc_literal: ArcLiteral, location: u32) -> bool {
@@ -45,3 +45,39 @@ pub const BASIC_ARC_EMPTY: BasicArc = None;
 /// A full basic arc (`Some((0, u32::MAX))`) is used by nodes that wish to
 /// claim authority over the full DHT.
 pub const BASIC_ARC_FULL: BasicArc = Some(ARC_LITERAL_FULL);
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn full_arc_includes_all_values() {
+        let arc = super::ARC_LITERAL_FULL;
+
+        // Contains bounds
+        assert!(super::arc_contains(arc, 0));
+        assert!(super::arc_contains(arc, u32::MAX));
+
+        // and a value in the middle somewhere
+        assert!(super::arc_contains(arc, u32::MAX / 2));
+    }
+
+    #[test]
+    fn arc_includes_start_but_not_end() {
+        let arc = (32, 64);
+
+        assert!(super::arc_contains(arc, 32));
+        assert!(super::arc_contains(arc, 40));
+
+        assert!(!super::arc_contains(arc, 64));
+    }
+
+    #[test]
+    fn arc_wraps_around() {
+        let arc = (u32::MAX - 32, 32);
+
+        assert!(super::arc_contains(arc, u32::MAX - 1));
+        assert!(super::arc_contains(arc, u32::MAX));
+        assert!(super::arc_contains(arc, 20));
+
+        assert!(!super::arc_contains(arc, 32));
+    }
+}

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -36,6 +36,10 @@ pub(crate) mod serde_bytes_base64 {
 }
 
 pub mod agent;
+
+pub mod arc;
+pub use arc::*;
+
 pub mod builder;
 pub mod config;
 pub mod kitsune;

--- a/crates/api/src/op_store.rs
+++ b/crates/api/src/op_store.rs
@@ -1,6 +1,6 @@
 //! Kitsune2 op store types.
 
-use crate::{K2Result, OpId, Timestamp};
+use crate::{ArcLiteral, K2Result, OpId, Timestamp};
 use futures::future::BoxFuture;
 use std::cmp::Ordering;
 use std::sync::Arc;
@@ -65,6 +65,7 @@ pub trait OpStore: 'static + Send + Sync + std::fmt::Debug {
     /// The returned ops must be ordered by timestamp, ascending.
     fn retrieve_op_hashes_in_time_slice(
         &self,
+        arc: ArcLiteral,
         start: Timestamp,
         end: Timestamp,
     ) -> BoxFuture<'_, K2Result<Vec<OpId>>>;
@@ -72,12 +73,14 @@ pub trait OpStore: 'static + Send + Sync + std::fmt::Debug {
     /// Store the combined hash of a time slice.
     fn store_slice_hash(
         &self,
+        arc: ArcLiteral,
         slice_id: u64,
         slice_hash: bytes::Bytes,
     ) -> BoxFuture<'_, K2Result<()>>;
 
     /// Count the number of stored time slices.
-    fn slice_hash_count(&self) -> BoxFuture<'_, K2Result<u64>>;
+    fn slice_hash_count(&self, arc: ArcLiteral)
+        -> BoxFuture<'_, K2Result<u64>>;
 
     /// Retrieve the combined hash of a time slice.
     ///
@@ -86,6 +89,7 @@ pub trait OpStore: 'static + Send + Sync + std::fmt::Debug {
     /// using [Self::store_slice_hash].
     fn retrieve_slice_hash(
         &self,
+        arc: ArcLiteral,
         slice_id: u64,
     ) -> BoxFuture<'_, K2Result<Option<bytes::Bytes>>>;
 }

--- a/crates/api/src/op_store.rs
+++ b/crates/api/src/op_store.rs
@@ -1,6 +1,6 @@
 //! Kitsune2 op store types.
 
-use crate::{ArcLiteral, K2Result, OpId, Timestamp};
+use crate::{DhtArc, K2Result, OpId, Timestamp};
 use futures::future::BoxFuture;
 use std::cmp::Ordering;
 use std::sync::Arc;
@@ -65,7 +65,7 @@ pub trait OpStore: 'static + Send + Sync + std::fmt::Debug {
     /// The returned ops must be ordered by timestamp, ascending.
     fn retrieve_op_hashes_in_time_slice(
         &self,
-        arc: ArcLiteral,
+        arc: DhtArc,
         start: Timestamp,
         end: Timestamp,
     ) -> BoxFuture<'_, K2Result<Vec<OpId>>>;
@@ -73,14 +73,13 @@ pub trait OpStore: 'static + Send + Sync + std::fmt::Debug {
     /// Store the combined hash of a time slice.
     fn store_slice_hash(
         &self,
-        arc: ArcLiteral,
+        arc: DhtArc,
         slice_id: u64,
         slice_hash: bytes::Bytes,
     ) -> BoxFuture<'_, K2Result<()>>;
 
     /// Count the number of stored time slices.
-    fn slice_hash_count(&self, arc: ArcLiteral)
-        -> BoxFuture<'_, K2Result<u64>>;
+    fn slice_hash_count(&self, arc: DhtArc) -> BoxFuture<'_, K2Result<u64>>;
 
     /// Retrieve the combined hash of a time slice.
     ///
@@ -89,7 +88,7 @@ pub trait OpStore: 'static + Send + Sync + std::fmt::Debug {
     /// using [Self::store_slice_hash].
     fn retrieve_slice_hash(
         &self,
-        arc: ArcLiteral,
+        arc: DhtArc,
         slice_id: u64,
     ) -> BoxFuture<'_, K2Result<Option<bytes::Bytes>>>;
 }

--- a/crates/api/src/peer_store.rs
+++ b/crates/api/src/peer_store.rs
@@ -30,7 +30,7 @@ pub trait PeerStore: 'static + Send + Sync + std::fmt::Debug {
     /// multiple times and union the results.
     fn get_by_overlapping_storage_arc(
         &self,
-        arc: agent::BasicArc,
+        arc: arc::BasicArc,
     ) -> BoxFut<'_, K2Result<Vec<Arc<agent::AgentInfoSigned>>>>;
 
     /// Get a list of agents sorted by nearness to a target basis location.

--- a/crates/api/src/peer_store.rs
+++ b/crates/api/src/peer_store.rs
@@ -30,7 +30,7 @@ pub trait PeerStore: 'static + Send + Sync + std::fmt::Debug {
     /// multiple times and union the results.
     fn get_by_overlapping_storage_arc(
         &self,
-        arc: arc::StorageArc,
+        arc: arc::DhtArc,
     ) -> BoxFut<'_, K2Result<Vec<Arc<agent::AgentInfoSigned>>>>;
 
     /// Get a list of agents sorted by nearness to a target basis location.

--- a/crates/core/src/factories/mem_peer_store.rs
+++ b/crates/core/src/factories/mem_peer_store.rs
@@ -111,7 +111,7 @@ impl peer_store::PeerStore for MemPeerStore {
 
     fn get_by_overlapping_storage_arc(
         &self,
-        arc: StorageArc,
+        arc: DhtArc,
     ) -> BoxFut<'_, K2Result<Vec<Arc<AgentInfoSigned>>>> {
         let r = self.0.lock().unwrap().get_by_overlapping_storage_arc(arc);
         Box::pin(async move { Ok(r) })
@@ -201,7 +201,7 @@ impl Inner {
 
     pub fn get_by_overlapping_storage_arc(
         &mut self,
-        arc: StorageArc,
+        arc: DhtArc,
     ) -> Vec<Arc<AgentInfoSigned>> {
         self.check_prune();
 
@@ -233,7 +233,7 @@ impl Inner {
             .values()
             .filter_map(|v| {
                 if !v.is_tombstone {
-                    if v.storage_arc == StorageArc::Empty {
+                    if v.storage_arc == DhtArc::Empty {
                         // filter out empty arcs, they can't help us
                         None
                     } else {

--- a/crates/core/src/factories/mem_peer_store/test.rs
+++ b/crates/core/src/factories/mem_peer_store/test.rs
@@ -31,7 +31,7 @@ struct AgentBuild {
     pub expires_at: Option<Timestamp>,
     pub is_tombstone: Option<bool>,
     pub url: Option<Option<Url>>,
-    pub storage_arc: Option<StorageArc>,
+    pub storage_arc: Option<DhtArc>,
 }
 
 impl AgentBuild {
@@ -51,7 +51,7 @@ impl AgentBuild {
         });
         let is_tombstone = self.is_tombstone.unwrap_or(false);
         let url = self.url.unwrap_or(None);
-        let storage_arc = self.storage_arc.unwrap_or(StorageArc::FULL);
+        let storage_arc = self.storage_arc.unwrap_or(DhtArc::FULL);
         let agent_info = serde_json::to_string(&AgentInfo {
             agent,
             space,
@@ -166,28 +166,28 @@ fn fixture_get_by_overlapping_storage_arc() {
     }
 
     #[allow(clippy::type_complexity)]
-    const F: &[(&[&str], StorageArc, &[(&str, StorageArc)])] = &[
+    const F: &[(&[&str], DhtArc, &[(&str, DhtArc)])] = &[
         (
             &["a", "b"],
-            StorageArc::FULL,
-            &[("a", StorageArc::FULL), ("b", StorageArc::FULL)],
+            DhtArc::FULL,
+            &[("a", DhtArc::FULL), ("b", DhtArc::FULL)],
         ),
         (
             &[],
-            StorageArc::FULL,
-            &[("a", StorageArc::Empty), ("b", StorageArc::Empty)],
+            DhtArc::FULL,
+            &[("a", DhtArc::Empty), ("b", DhtArc::Empty)],
         ),
         (
             &[],
-            StorageArc::Empty,
-            &[("a", StorageArc::FULL), ("b", StorageArc::FULL)],
+            DhtArc::Empty,
+            &[("a", DhtArc::FULL), ("b", DhtArc::FULL)],
         ),
         (
             &["a"],
-            StorageArc::Arc(0, u32::MAX / 2),
+            DhtArc::Arc(0, u32::MAX / 2),
             &[
-                ("a", StorageArc::Arc(400, u32::MAX / 2 - 400)),
-                ("b", StorageArc::Arc(u32f(0.8), u32f(0.9))),
+                ("a", DhtArc::Arc(400, u32::MAX / 2 - 400)),
+                ("b", DhtArc::Arc(u32f(0.8), u32f(0.9))),
             ],
         ),
     ];
@@ -224,7 +224,7 @@ fn fixture_get_near_location() {
         let loc = (u32::MAX / 8) * idx;
         s.insert(vec![AgentBuild {
             // for simplicity have agents claim arcs of len 1
-            storage_arc: Some(StorageArc::Arc(loc, loc + 1)),
+            storage_arc: Some(DhtArc::Arc(loc, loc + 1)),
             // set the url to the idx for matching
             url: Some(Some(sneak_url(&idx.to_string()))),
             ..Default::default()
@@ -235,7 +235,7 @@ fn fixture_get_near_location() {
     // these should not be returned because they are invalid.
     s.insert(vec![
         AgentBuild {
-            storage_arc: Some(StorageArc::Empty),
+            storage_arc: Some(DhtArc::Empty),
             url: Some(Some(sneak_url("zero-arc"))),
             ..Default::default()
         }

--- a/crates/core/src/factories/mem_peer_store/test.rs
+++ b/crates/core/src/factories/mem_peer_store/test.rs
@@ -197,7 +197,7 @@ fn fixture_get_by_overlapping_storage_arc() {
 
         for (arc_name, arc) in arc_list.iter() {
             s.insert(vec![AgentBuild {
-                storage_arc: Some(arc.clone()),
+                storage_arc: Some(*arc),
                 url: Some(Some(sneak_url(arc_name))),
                 ..Default::default()
             }
@@ -205,7 +205,7 @@ fn fixture_get_by_overlapping_storage_arc() {
         }
 
         let mut got = s
-            .get_by_overlapping_storage_arc(q.clone())
+            .get_by_overlapping_storage_arc(*q)
             .into_iter()
             .map(|info| unsneak_url(info.url.as_ref().unwrap()))
             .collect::<Vec<_>>();

--- a/crates/dht/Cargo.toml
+++ b/crates/dht/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2021"
 [dependencies]
 kitsune2_api = { workspace = true }
 bytes = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
 kitsune2_memory = { workspace = true }

--- a/crates/dht/src/hash.rs
+++ b/crates/dht/src/hash.rs
@@ -421,7 +421,7 @@ mod tests {
                 .unwrap();
         }
 
-        // Check nothing is current stored in the partials
+        // Check nothing is currently stored in the partials
         for h in &ph.partitioned_hashes {
             for ps in h.partitioned_time.partials() {
                 assert!(ps.hash().is_empty())

--- a/crates/dht/src/hash.rs
+++ b/crates/dht/src/hash.rs
@@ -37,7 +37,7 @@
 //! It is important to note though, that each partition is managing a [PartitionedTime] structure
 //! which requires some memory and processing to maintain. Nodes that take on more partitions will
 //! have more work to do and will have to send more data during gossip rounds. That happens when
-//! there are  changes to data that has made it into a time slice and become part of a combined
+//! there are changes to data that has made it into a time slice and become part of a combined
 //! hash. Generally, nodes will be able to just sync "what's new" but for catch-up, this is true.
 //! As a consequence, a new network that hasn't yet gained enough members to start reducing how
 //! many partitions are covered by each node will have a higher overhead for each node.

--- a/crates/dht/src/hash.rs
+++ b/crates/dht/src/hash.rs
@@ -333,7 +333,7 @@ mod tests {
                         .partitioned_time
                         .full_slice_end_timestamp(),
                 },
-                // Stored in the second partial
+                // Stored in the second time slice of the first space partition.
                 StoredOp {
                     op_id: OpId::from(op_id_bytes_2.clone()),
                     timestamp: ph.partitioned_hashes[0]

--- a/crates/dht/src/hash.rs
+++ b/crates/dht/src/hash.rs
@@ -131,7 +131,7 @@ impl PartitionedHashes {
 
     /// Inform the time partitions of ops that have been stored.
     ///
-    /// The ops are split into the right hash partition based on the location of the op. Then the
+    /// The ops are placed into the right space partition based on the location of the op. Then the
     /// updating of hashes is delegated to the inner time partition for each hash partition.
     pub async fn inform_ops_stored(
         &mut self,

--- a/crates/dht/src/hash.rs
+++ b/crates/dht/src/hash.rs
@@ -99,7 +99,7 @@ impl PartitionedHashes {
         })
     }
 
-    /// Get the next update time the inner time partitions.
+    /// Get the next update time of the inner time partitions.
     pub fn next_update_at(&self) -> Timestamp {
         // Because the minimum `hash_factor` is 0, and we compute 2^hash_factor, there will always be at least one partition.
         self.partitioned_hashes

--- a/crates/dht/src/hash.rs
+++ b/crates/dht/src/hash.rs
@@ -1,0 +1,443 @@
+//! Partition of the hash space.
+//!
+//! The space of possible hashes is mapped to a 32-bit location. See [::kitsune2_api::id::Id::loc] for
+//! more information about this. Each agent is responsible for storing and serving some part of
+//! the hash space. This module provides a structure that partitions the hash space by some factor.
+//!
+//! The factor must be chosen up front and cannot be changed. The factor determines the number of
+//! partitions to create. A factor of 32 will create a single partition. Each unit decrease from 32
+//! will double the number of partitions. A good default for a network that is expected to grow to
+//! a few thousand nodes is 21. This will create 2^11 partitions, which is 2048. Given that data is
+//! also stored redundantly, say 10 times, this is means that 20,000 nodes are needed for the data
+//! to be maximally distributed. With higher replication, say 50 times, and a hash factor of 20,
+//! over 200,000 nodes are needed for maximal distribution.
+//!
+//! Each hash partition manages a [PartitionedTime] structure that is responsible for managing the
+//! time slices for that hash partition. The interface of this module is largely responsible for
+//! delegating the updating of time slices to the inner time partitions. This ensures that all the
+//! time partitions are updated in lockstep. This makes reasoning about the hash-time partitioning
+//! easier.
+//!
+//! This module must be informed about ops that have been stored. There is no active process here
+//! that can look for newly stored ops. When a batch of ops is stored, the [PartitionedHashes] must
+//! be informed and will split the ops into the right hash partition based on the location of the op.
+//! Ops are then pushed to the inner time partition for each hash partition. It is the time
+//! partitions that are responsible for updating the combined hash values.
+
+use crate::PartitionedTime;
+use kitsune2_api::{
+    ArcLiteral, DynOpStore, K2Error, K2Result, StoredOp, Timestamp,
+};
+use std::collections::HashMap;
+
+/// A partitioned hash structure.
+///
+/// Partitions the hash structure into a configurable number of partitions. Each partition is
+/// responsible for managing the time slices for that partition.
+#[derive(Debug)]
+pub struct PartitionedHashes {
+    size: u32,
+    partitioned_hashes: Vec<HashPartition>,
+}
+
+#[derive(Debug)]
+struct HashPartition {
+    _arc: ArcLiteral,
+    partitioned_time: PartitionedTime,
+}
+
+impl PartitionedHashes {
+    /// Create a new partitioned hash structure.
+    ///
+    /// The `hash_factor` determines the number of partitions to create. A value of 32 will create
+    /// a single partition. Each unit decrease from 32 will double the number of partitions.
+    ///
+    /// Each hash partition owns a [PartitionedTime] structure that is responsible for managing
+    /// the time slices for that hash partition. Other parameters to this function are used to
+    /// create the [PartitionedTime] structure.
+    pub async fn try_from_store(
+        hash_factor: u8,
+        time_factor: u8,
+        current_time: Timestamp,
+        store: DynOpStore,
+    ) -> K2Result<Self> {
+        if hash_factor > 32 {
+            return Err(K2Error::other("Hash factor must be 32 or lower"));
+        }
+
+        let (size, num_buckets) = if hash_factor == 32 {
+            (u32::MAX, 1)
+        } else {
+            let size = 1u32 << hash_factor;
+
+            // We will always be one bucket short because u32::MAX is not a power of two. It is one less
+            // than a power of two, so the last bucket is always one short.
+            (size, (u32::MAX / size) + 1)
+        };
+
+        let mut partitioned_hashes = Vec::with_capacity(num_buckets as usize);
+        for i in 0..num_buckets {
+            partitioned_hashes.push(
+                HashPartition::try_from_store(
+                    (i * size, (i + 1).overflowing_mul(size).0),
+                    time_factor,
+                    current_time,
+                    store.clone(),
+                )
+                .await?,
+            );
+        }
+
+        tracing::info!(
+            "Allocated {} hash partitions",
+            partitioned_hashes.len()
+        );
+
+        Ok(Self {
+            size,
+            partitioned_hashes,
+        })
+    }
+
+    /// Get the next update time the inner time partitions.
+    pub fn next_update_at(&self) -> Timestamp {
+        // Because the minimum `hash_factor` is 0, and we compute 2^hash_factor, there will always be at least one partition.
+        self.partitioned_hashes
+            .first()
+            .expect("Always at least one hash partition")
+            .partitioned_time
+            .next_update_at()
+    }
+
+    /// Update the time partitions for each hash partition.
+    pub async fn update(
+        &mut self,
+        store: DynOpStore,
+        current_time: Timestamp,
+    ) -> K2Result<()> {
+        for partition in self.partitioned_hashes.iter_mut() {
+            partition
+                .partitioned_time
+                .update(store.clone(), current_time)
+                .await?;
+        }
+
+        Ok(())
+    }
+
+    /// Inform the time partitions of ops that have been stored.
+    ///
+    /// The ops are split into the right hash partition based on the location of the op. Then the
+    /// updating of hashes is delegated to the inner time partition for each hash partition.
+    pub async fn inform_ops_stored(
+        &mut self,
+        store: DynOpStore,
+        stored_ops: Vec<StoredOp>,
+    ) -> K2Result<()> {
+        let by_location = stored_ops
+            .into_iter()
+            .map(|op| {
+                let location = op.op_id.loc();
+                (location / self.size, op)
+            })
+            .fold(
+                HashMap::<u32, Vec<StoredOp>>::new(),
+                |mut acc, (location, op)| {
+                    acc.entry(location).or_default().push(op);
+                    acc
+                },
+            );
+
+        for (location, ops) in by_location {
+            self.partitioned_hashes[location as usize]
+                .partitioned_time
+                .inform_ops_stored(store.clone(), ops)
+                .await?;
+        }
+
+        Ok(())
+    }
+}
+
+impl HashPartition {
+    pub async fn try_from_store(
+        arc: ArcLiteral,
+        time_factor: u8,
+        current_time: Timestamp,
+        store: DynOpStore,
+    ) -> K2Result<Self> {
+        let partitioned_time = PartitionedTime::try_from_store(
+            time_factor,
+            current_time,
+            arc,
+            store,
+        )
+        .await?;
+        Ok(Self {
+            _arc: arc,
+            partitioned_time,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::UNIT_TIME;
+    use kitsune2_api::{OpId, OpStore, ARC_LITERAL_FULL, UNIX_TIMESTAMP};
+    use kitsune2_memory::{Kitsune2MemoryOp, Kitsune2MemoryOpStore};
+    use kitsune2_test_utils::enable_tracing;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    #[tokio::test]
+    async fn create_with_no_partitioning() {
+        enable_tracing();
+
+        let store = Arc::new(Kitsune2MemoryOpStore::default());
+        let ph =
+            PartitionedHashes::try_from_store(32, 14, Timestamp::now(), store)
+                .await
+                .unwrap();
+        assert_eq!(1, ph.partitioned_hashes.len());
+        assert_eq!(u32::MAX, ph.size);
+        assert_eq!(ARC_LITERAL_FULL, ph.partitioned_hashes[0]._arc);
+    }
+
+    #[tokio::test]
+    async fn create_with_default_partition_factor() {
+        enable_tracing();
+
+        let store = Arc::new(Kitsune2MemoryOpStore::default());
+        let ph =
+            PartitionedHashes::try_from_store(20, 14, Timestamp::now(), store)
+                .await
+                .unwrap();
+        assert_eq!(1 << 20, ph.size);
+        assert_eq!((0, true), (1u32 << 20).overflowing_mul(ph.size));
+    }
+
+    #[tokio::test]
+    async fn covers_full_arc() {
+        enable_tracing();
+
+        // Check that the behaviour is consistent for a reasonable range of expected values
+        for hash_factor in 20u8..31 {
+            let store = Arc::new(Kitsune2MemoryOpStore::default());
+            let ph = PartitionedHashes::try_from_store(
+                hash_factor,
+                14,
+                Timestamp::now(),
+                store,
+            )
+            .await
+            .unwrap();
+
+            let mut start: u32 = 0;
+            for i in 0..ph.partitioned_hashes.len() {
+                let end = start.overflowing_add(ph.size).0;
+                assert_eq!(start, ph.partitioned_hashes[i]._arc.0);
+                assert_eq!(end, ph.partitioned_hashes[i]._arc.1);
+                start = end;
+            }
+
+            assert_eq!(0, start, "While checking factor {}", hash_factor);
+        }
+    }
+
+    #[tokio::test]
+    async fn inform_ops_stored_in_full_slices() {
+        enable_tracing();
+
+        let store = Arc::new(Kitsune2MemoryOpStore::default());
+        let mut ph = PartitionedHashes::try_from_store(
+            20,
+            14,
+            Timestamp::now(),
+            store.clone(),
+        )
+        .await
+        .unwrap();
+
+        let op_id_bytes_1 = bytes::Bytes::from_static(&[7, 0, 0, 0]);
+        let op_id_bytes_2 = bytes::Bytes::from(ph.size.to_le_bytes().to_vec());
+        ph.inform_ops_stored(
+            store.clone(),
+            vec![
+                StoredOp {
+                    op_id: OpId::from(op_id_bytes_1.clone()),
+                    timestamp: UNIX_TIMESTAMP,
+                },
+                StoredOp {
+                    op_id: OpId::from(op_id_bytes_2.clone()),
+                    timestamp: UNIX_TIMESTAMP
+                        + ph.partitioned_hashes[0]
+                            .partitioned_time
+                            .full_slice_duration(),
+                },
+            ],
+        )
+        .await
+        .unwrap();
+
+        let count = store.slice_hash_count((0, ph.size)).await.unwrap();
+        assert_eq!(1, count);
+
+        let hash = store.retrieve_slice_hash((0, ph.size), 0).await.unwrap();
+        assert!(hash.is_some());
+        assert_eq!(op_id_bytes_1, hash.unwrap());
+
+        let count = store
+            .slice_hash_count((ph.size, 2 * ph.size))
+            .await
+            .unwrap();
+        // Note that this is because we've stored at id 1, not that two hashes ended up in this
+        // partition.
+        assert_eq!(2, count);
+
+        let hash = store
+            .retrieve_slice_hash((ph.size, 2 * ph.size), 1)
+            .await
+            .unwrap();
+        assert!(hash.is_some());
+        assert_eq!(op_id_bytes_2, hash.unwrap());
+    }
+
+    #[tokio::test]
+    async fn inform_ops_stored_in_partial_slices() {
+        enable_tracing();
+
+        let store = Arc::new(Kitsune2MemoryOpStore::default());
+        let mut ph = PartitionedHashes::try_from_store(
+            20,
+            14,
+            Timestamp::now(),
+            store.clone(),
+        )
+        .await
+        .unwrap();
+
+        let op_id_bytes_1 = bytes::Bytes::from_static(&[100, 0, 0, 0]);
+        let op_id_bytes_2 = bytes::Bytes::from(ph.size.to_le_bytes().to_vec());
+        ph.inform_ops_stored(
+            store.clone(),
+            vec![
+                // Stored in the first partial
+                StoredOp {
+                    op_id: OpId::from(op_id_bytes_1.clone()),
+                    timestamp: ph.partitioned_hashes[0]
+                        .partitioned_time
+                        .full_slice_end_timestamp(),
+                },
+                // Stored in the second partial
+                StoredOp {
+                    op_id: OpId::from(op_id_bytes_2.clone()),
+                    timestamp: ph.partitioned_hashes[0]
+                        .partitioned_time
+                        .full_slice_end_timestamp()
+                        + Duration::from_secs((1 << 13) * UNIT_TIME.as_secs()),
+                },
+            ],
+        )
+        .await
+        .unwrap();
+
+        // No full slices should get stored
+        for i in 0..(u32::MAX / ph.size) {
+            let count = store
+                .slice_hash_count((i * ph.size, (i + 1) * ph.size))
+                .await
+                .unwrap();
+            assert_eq!(0, count);
+        }
+
+        let partial_slice =
+            &ph.partitioned_hashes[0].partitioned_time.partials()[0];
+        assert_eq!(
+            op_id_bytes_1,
+            bytes::Bytes::from(partial_slice.hash().to_vec())
+        );
+
+        let partial_slice =
+            &ph.partitioned_hashes[1].partitioned_time.partials()[1];
+        assert_eq!(
+            op_id_bytes_2,
+            bytes::Bytes::from(partial_slice.hash().to_vec())
+        );
+    }
+
+    #[tokio::test]
+    async fn next_update_at_consistent() {
+        enable_tracing();
+
+        let store = Arc::new(Kitsune2MemoryOpStore::default());
+        let now = Timestamp::now();
+        let ph = PartitionedHashes::try_from_store(30, 14, now, store.clone())
+            .await
+            .unwrap();
+
+        assert_eq!(4, ph.partitioned_hashes.len());
+
+        let hashes_next_update_at = ph.next_update_at();
+        assert!(hashes_next_update_at >= now);
+
+        for h in ph.partitioned_hashes {
+            assert_eq!(
+                hashes_next_update_at,
+                h.partitioned_time.next_update_at()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn update_all() {
+        enable_tracing();
+        let store = Arc::new(Kitsune2MemoryOpStore::default());
+        let now = Timestamp::now();
+        let mut ph =
+            PartitionedHashes::try_from_store(30, 14, now, store.clone())
+                .await
+                .unwrap();
+
+        assert_eq!(4, ph.partitioned_hashes.len());
+
+        for h in ph.partitioned_hashes.iter() {
+            store
+                .process_incoming_ops(vec![Kitsune2MemoryOp::new(
+                    // Place the op within the current hash partition
+                    OpId::from(bytes::Bytes::copy_from_slice(
+                        (h._arc.0 + 1).to_le_bytes().as_slice(),
+                    )),
+                    now,
+                    h._arc.1.to_be_bytes().to_vec(),
+                )
+                .try_into()
+                .unwrap()])
+                .await
+                .unwrap();
+        }
+
+        // Check nothing is current stored in the partials
+        for h in &ph.partitioned_hashes {
+            for ps in h.partitioned_time.partials() {
+                assert!(ps.hash().is_empty())
+            }
+        }
+
+        // Update with enough extra time to allocate a new partial over the current time
+        ph.update(store, now + UNIT_TIME).await.unwrap();
+
+        // Check that the partials have been updated
+        for h in &ph.partitioned_hashes {
+            // Exactly one partial should now have a hash
+            assert_eq!(
+                1,
+                h.partitioned_time
+                    .partials()
+                    .iter()
+                    .filter(|ps| !ps.hash().is_empty())
+                    .count()
+            );
+        }
+    }
+}

--- a/crates/dht/src/hash.rs
+++ b/crates/dht/src/hash.rs
@@ -36,7 +36,11 @@ use std::collections::HashMap;
 /// responsible for managing the time slices for that partition.
 #[derive(Debug)]
 pub struct PartitionedHashes {
+    /// This is just a convenience for internal function use.
+    /// This should always be exactly `((u32::MAX + 1) / self.partitioned_hashes.len()`.
     size: u32,
+    /// The partition count here (length of Vec) should always be a power of 2.
+    /// (2**0, 2**1, etc).
     partitioned_hashes: Vec<HashPartition>,
 }
 

--- a/crates/dht/src/hash.rs
+++ b/crates/dht/src/hash.rs
@@ -8,7 +8,7 @@
 //! partitions to create. A factor of 32 will create a single partition. Each unit decrease from 32
 //! will double the number of partitions. A good default for a network that is expected to grow to
 //! a few thousand nodes is 21. This will create 2^11 partitions, which is 2048. Given that data is
-//! also stored redundantly, say 10 times, this is means that 20,000 nodes are needed for the data
+//! also stored redundantly, say 10 times, this means that 20,000 nodes are needed for the data
 //! to be maximally distributed. With higher replication, say 50 times, and a hash factor of 20,
 //! over 200,000 nodes are needed for maximal distribution.
 //!

--- a/crates/dht/src/hash.rs
+++ b/crates/dht/src/hash.rs
@@ -326,7 +326,7 @@ mod tests {
         ph.inform_ops_stored(
             store.clone(),
             vec![
-                // Stored in the first partial
+                // Stored in the first time slice of the first space partition.
                 StoredOp {
                     op_id: OpId::from(op_id_bytes_1.clone()),
                     timestamp: ph.partitioned_hashes[0]

--- a/crates/dht/src/hash.rs
+++ b/crates/dht/src/hash.rs
@@ -15,7 +15,7 @@
 //! Each hash partition manages a [PartitionedTime] structure that is responsible for managing the
 //! time slices for that hash partition. The interface of this module is largely responsible for
 //! delegating the updating of time slices to the inner time partitions. This ensures that all the
-//! time partitions are updated in lockstep. This makes reasoning about the hash-time partitioning
+//! time partitions are updated in lockstep. This makes reasoning about the space-time partitioning
 //! easier.
 //!
 //! This module must be informed about ops that have been stored. There is no active process here

--- a/crates/dht/src/lib.rs
+++ b/crates/dht/src/lib.rs
@@ -1,5 +1,8 @@
 pub mod constant;
 pub use constant::*;
 
+pub mod hash;
+pub use hash::*;
+
 pub mod time;
 pub use time::*;

--- a/crates/dht/src/time.rs
+++ b/crates/dht/src/time.rs
@@ -55,7 +55,8 @@
 
 use crate::constant::UNIT_TIME;
 use kitsune2_api::{
-    DynOpStore, K2Error, K2Result, OpId, Timestamp, UNIX_TIMESTAMP,
+    ArcLiteral, DynOpStore, K2Error, K2Result, OpId, StoredOp, Timestamp,
+    UNIX_TIMESTAMP,
 };
 use std::time::Duration;
 
@@ -94,6 +95,10 @@ pub struct PartitionedTime {
     /// It is idempotent to call [PartitionedTime::update] more often than required, but it is not
     /// efficient.
     next_update_at: Timestamp,
+    /// The storage arc that this partitioned time is associated with.
+    ///
+    /// Any queries to fetch ops in a time range must be constrained by this arc.
+    arc_constraint: ArcLiteral,
 }
 
 #[derive(Debug)]
@@ -108,7 +113,7 @@ pub struct PartialSlice {
     /// That means a 0 size translates to [UNIT_TIME], and a 1 size translates to 2*[UNIT_TIME].
     size: u8,
     /// The combined hash over all the ops in this time slice.
-    hash: bytes::Bytes,
+    hash: bytes::BytesMut,
 }
 
 impl PartialSlice {
@@ -118,6 +123,11 @@ impl PartialSlice {
     fn end(&self) -> Timestamp {
         self.start
             + Duration::from_secs((1u64 << self.size) * UNIT_TIME.as_secs())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn hash(&self) -> &[u8] {
+        &self.hash
     }
 }
 
@@ -137,11 +147,12 @@ impl PartitionedTime {
     pub async fn try_from_store(
         factor: u8,
         current_time: Timestamp,
+        arc_constraint: ArcLiteral,
         store: DynOpStore,
     ) -> K2Result<Self> {
-        let mut pt = Self::new(factor)?;
+        let mut pt = Self::new(factor, arc_constraint)?;
 
-        pt.full_slices = store.slice_hash_count().await?;
+        pt.full_slices = store.slice_hash_count(arc_constraint).await?;
 
         // The end timestamp of the last full slice
         let full_slice_end_timestamp = pt.full_slice_end_timestamp();
@@ -156,7 +167,7 @@ impl PartitionedTime {
         }
 
         // Update the state for the current time. The stored slices might be out of date.
-        pt.update(current_time, store).await?;
+        pt.update(store, current_time).await?;
 
         Ok(pt)
     }
@@ -181,8 +192,8 @@ impl PartitionedTime {
     ///   - Update the `next_update_at` field to the next time an update is required.
     pub async fn update(
         &mut self,
-        current_time: Timestamp,
         store: DynOpStore,
+        current_time: Timestamp,
     ) -> K2Result<()> {
         // Check if there is enough time to allocate new full slices
         self.update_full_slice_hashes(store.clone(), current_time)
@@ -200,6 +211,98 @@ impl PartitionedTime {
 
         Ok(())
     }
+
+    /// Inform the [PartitionedTime] that some ops have been stored.
+    ///
+    /// It is expected that the caller ensures that the ops belong to the hash range managed by this
+    /// [PartitionedTime]. This method will update the hashes of the full and partial slices that
+    /// the incoming ops belong to.
+    ///
+    /// If the op happens to be new enough to not belong in a slice, then it will be ignored. The
+    /// op will be discovered later when a partial slice update adds a slice that includes the op.
+    pub(crate) async fn inform_ops_stored(
+        &mut self,
+        store: DynOpStore,
+        stored_ops: Vec<StoredOp>,
+    ) -> K2Result<()> {
+        let full_slice_end = self.full_slice_end_timestamp();
+
+        for op in stored_ops {
+            if op.timestamp < full_slice_end {
+                // This is a historical update. We don't really expect this to happen too often.
+                // If we're syncing because we've been offline then it's okay and we should
+                // try to detect that when it's happening but otherwise it'd be good to log a warning
+                // here.
+
+                let slice_id = op.timestamp.as_micros()
+                    / (self.full_slice_duration.as_micros() as i64);
+                let current_hash = store
+                    .retrieve_slice_hash(self.arc_constraint, slice_id as u64)
+                    .await?;
+                match current_hash {
+                    Some(hash) => {
+                        let mut hash = bytes::BytesMut::from(hash);
+                        // Combine the stored hash with the new op hash
+                        combine_hashes(&mut hash, op.op_id.0 .0);
+
+                        // and store the new value
+                        store
+                            .store_slice_hash(
+                                self.arc_constraint,
+                                slice_id as u64,
+                                hash.freeze(),
+                            )
+                            .await?;
+                    }
+                    None => {
+                        // If there was no hash stored, then store the new op hash
+                        store
+                            .store_slice_hash(
+                                self.arc_constraint,
+                                slice_id as u64,
+                                op.op_id.0 .0,
+                            )
+                            .await?;
+                    }
+                }
+            } else {
+                let end_of_partials = match self
+                    .partial_slices
+                    .last()
+                    .map(|last| last.end())
+                {
+                    Some(end) => end,
+                    None => {
+                        // If there are no partial slices yet, we can't update anything here.
+                        // This would only happen if the current time is close to the UNIX_TIMESTAMP.
+                        tracing::warn!("No partial slices yet, can't update partials. This is likely a configuration or clock issue.");
+                        continue;
+                    }
+                };
+
+                if op.timestamp >= end_of_partials {
+                    // This new op is not yet included in the partial slices. That's okay, there
+                    // is expected to be a small amount of recent time that isn't covered by
+                    // partial slices. This op will get included in a future update of the partials.
+                    continue;
+                }
+
+                // At this point, we know we're between the end of the full slices and the end of
+                // the partial slices. We can easily iterate backwards and check just the start
+                // bound of the partials to find out which partial slice this op belongs to.
+                for partial in self.partial_slices.iter_mut().rev() {
+                    if op.timestamp >= partial.start {
+                        combine_hashes(&mut partial.hash, op.op_id.0 .0);
+
+                        // Belongs in exactly one partial, stop after finding the right one.
+                        break;
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
 }
 
 // Private methods
@@ -208,7 +311,7 @@ impl PartitionedTime {
     ///
     /// This constructor just creates an instance with initial values, but it doesn't update the
     /// state with full and partial slices for the current time.
-    fn new(factor: u8) -> K2Result<Self> {
+    fn new(factor: u8, arc_constraint: ArcLiteral) -> K2Result<Self> {
         Ok(Self {
             factor,
             full_slices: 0,
@@ -223,13 +326,14 @@ impl PartitionedTime {
             min_recent_time: residual_duration_for_factor(factor - 1)?,
             // Immediately requires an update, any time in the past will do
             next_update_at: Timestamp::from_micros(0),
+            arc_constraint,
         })
     }
 
     /// The timestamp at which the last full slice ends.
     ///
     /// If there are no full slices, then this is the constant [UNIX_TIMESTAMP].
-    fn full_slice_end_timestamp(&self) -> Timestamp {
+    pub(crate) fn full_slice_end_timestamp(&self) -> Timestamp {
         let full_slices_duration = Duration::from_secs(
             self.full_slices * self.full_slice_duration.as_secs(),
         );
@@ -280,6 +384,7 @@ impl PartitionedTime {
             // Store the hash of the full slice
             let op_hashes = store
                 .retrieve_op_hashes_in_time_slice(
+                    self.arc_constraint,
                     full_slices_end_timestamp,
                     full_slices_end_timestamp + self.full_slice_duration,
                 )
@@ -288,7 +393,13 @@ impl PartitionedTime {
             let hash = combine_op_hashes(op_hashes);
 
             if !hash.is_empty() {
-                store.store_slice_hash(self.full_slices, hash).await?;
+                store
+                    .store_slice_hash(
+                        self.arc_constraint,
+                        self.full_slices,
+                        hash.freeze(),
+                    )
+                    .await?;
             }
 
             self.full_slices += 1;
@@ -377,7 +488,11 @@ impl PartitionedTime {
                         );
                     combine_op_hashes(
                         store
-                            .retrieve_op_hashes_in_time_slice(start, end)
+                            .retrieve_op_hashes_in_time_slice(
+                                self.arc_constraint,
+                                start,
+                                end,
+                            )
                             .await?,
                     )
                 }
@@ -387,6 +502,16 @@ impl PartitionedTime {
         }
 
         Ok(())
+    }
+
+    #[cfg(test)]
+    pub(crate) fn full_slice_duration(&self) -> Duration {
+        self.full_slice_duration
+    }
+
+    #[cfg(test)]
+    pub(crate) fn partials(&self) -> &[PartialSlice] {
+        &self.partial_slices
     }
 }
 
@@ -416,29 +541,44 @@ fn residual_duration_for_factor(factor: u8) -> K2Result<Duration> {
 ///
 /// Requires that the op hashes are already ordered.
 /// If the input is empty, then the output is an empty byte array.
-fn combine_op_hashes(hashes: Vec<OpId>) -> bytes::Bytes {
+fn combine_op_hashes(hashes: Vec<OpId>) -> bytes::BytesMut {
     let mut out = if let Some(first) = hashes.first() {
         bytes::BytesMut::zeroed(first.0.len())
     } else {
         // `Bytes::new` does not allocate, so if there was no input, then return an empty
         // byte array without allocating.
-        return bytes::Bytes::new();
+        return bytes::BytesMut::new();
     };
 
     let iter = hashes.into_iter().map(|x| x.0 .0);
     for hash in iter {
-        for (out_byte, hash_byte) in out.iter_mut().zip(hash.iter()) {
-            *out_byte ^= hash_byte;
-        }
+        combine_hashes(&mut out, hash);
     }
 
-    out.freeze()
+    out
+}
+
+fn combine_hashes(into: &mut bytes::BytesMut, other: bytes::Bytes) {
+    // Properly initialise the target from the source if the target is empty.
+    // Otherwise, the loop below would run 0 times.
+    if into.is_empty() && !other.is_empty() {
+        into.extend_from_slice(&other);
+        return;
+    }
+
+    if into.len() != other.len() {
+        tracing::debug!("Combining hashes of different lengths. This is undefined behaviour.")
+    }
+
+    for (into_byte, other_byte) in into.iter_mut().zip(other.iter()) {
+        *into_byte ^= other_byte;
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use kitsune2_api::OpStore;
+    use kitsune2_api::{OpStore, ARC_LITERAL_FULL};
     use kitsune2_memory::{Kitsune2MemoryOp, Kitsune2MemoryOpStore};
     use kitsune2_test_utils::enable_tracing;
     use std::sync::Arc;
@@ -477,7 +617,7 @@ mod tests {
     #[test]
     fn new() {
         let factor = 4;
-        let pt = PartitionedTime::new(factor).unwrap();
+        let pt = PartitionedTime::new(factor, ARC_LITERAL_FULL).unwrap();
 
         // Full slices would have size 2^4 = 16, so we should reserve space for at least one
         // of each smaller slice size
@@ -488,9 +628,14 @@ mod tests {
     async fn from_store() {
         let factor = 4;
         let store = Arc::new(Kitsune2MemoryOpStore::default());
-        let pt = PartitionedTime::try_from_store(factor, UNIX_TIMESTAMP, store)
-            .await
-            .unwrap();
+        let pt = PartitionedTime::try_from_store(
+            factor,
+            UNIX_TIMESTAMP,
+            ARC_LITERAL_FULL,
+            store,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(0, pt.full_slices);
         assert!(pt.partial_slices.is_empty());
@@ -502,9 +647,14 @@ mod tests {
             UNIX_TIMESTAMP + Duration::from_secs(UNIT_TIME.as_secs() + 1);
         let factor = 4;
         let store = Arc::new(Kitsune2MemoryOpStore::default());
-        let pt = PartitionedTime::try_from_store(factor, current_time, store)
-            .await
-            .unwrap();
+        let pt = PartitionedTime::try_from_store(
+            factor,
+            current_time,
+            ARC_LITERAL_FULL,
+            store,
+        )
+        .await
+        .unwrap();
 
         // Should allocate no full slices and one partial
         assert_eq!(0, pt.full_slices);
@@ -532,9 +682,14 @@ mod tests {
                 min_recent_time(factor).as_secs() + 1,
             );
         let store = Arc::new(Kitsune2MemoryOpStore::default());
-        let pt = PartitionedTime::try_from_store(factor, current_time, store)
-            .await
-            .unwrap();
+        let pt = PartitionedTime::try_from_store(
+            factor,
+            current_time,
+            ARC_LITERAL_FULL,
+            store,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(0, pt.full_slices);
         assert_eq!(factor as usize, pt.partial_slices.len());
@@ -553,9 +708,14 @@ mod tests {
                 + 1,
             );
         let store = Arc::new(Kitsune2MemoryOpStore::default());
-        let pt = PartitionedTime::try_from_store(factor, current_time, store)
-            .await
-            .unwrap();
+        let pt = PartitionedTime::try_from_store(
+            factor,
+            current_time,
+            ARC_LITERAL_FULL,
+            store,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(factor as usize + 1, pt.partial_slices.len());
         assert_eq!(pt.partial_slices[0].size, factor - 1);
@@ -573,9 +733,14 @@ mod tests {
                 2 * min_recent_time(factor).as_secs() + 1,
             );
         let store = Arc::new(Kitsune2MemoryOpStore::default());
-        let pt = PartitionedTime::try_from_store(factor, current_time, store)
-            .await
-            .unwrap();
+        let pt = PartitionedTime::try_from_store(
+            factor,
+            current_time,
+            ARC_LITERAL_FULL,
+            store,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(factor as usize * 2, pt.partial_slices.len());
 
@@ -612,9 +777,14 @@ mod tests {
             .await
             .unwrap();
 
-        let pt = PartitionedTime::try_from_store(factor, current_time, store)
-            .await
-            .unwrap();
+        let pt = PartitionedTime::try_from_store(
+            factor,
+            current_time,
+            ARC_LITERAL_FULL,
+            store,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(factor as usize, pt.partial_slices.len());
         let last_partial = pt.partial_slices.last().unwrap();
@@ -636,12 +806,24 @@ mod tests {
                 + 1,
             );
         let store = Arc::new(Kitsune2MemoryOpStore::default());
-        store.store_slice_hash(0, vec![1; 64].into()).await.unwrap();
-        store.store_slice_hash(1, vec![1; 64].into()).await.unwrap();
-
-        let pt = PartitionedTime::try_from_store(factor, current_time, store)
+        let arc_constraint = (0, 2);
+        store
+            .store_slice_hash(arc_constraint, 0, vec![1; 64].into())
             .await
             .unwrap();
+        store
+            .store_slice_hash(arc_constraint, 1, vec![1; 64].into())
+            .await
+            .unwrap();
+
+        let pt = PartitionedTime::try_from_store(
+            factor,
+            current_time,
+            arc_constraint,
+            store,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(2, pt.full_slices);
         assert_eq!(factor as usize, pt.partial_slices.len());
@@ -684,9 +866,11 @@ mod tests {
             .await
             .unwrap();
 
+        let arc_constraint = (0, 2);
         let pt = PartitionedTime::try_from_store(
             factor,
             current_time,
+            arc_constraint,
             store.clone(),
         )
         .await
@@ -697,9 +881,12 @@ mod tests {
         assert_eq!(factor as usize, pt.partial_slices.len());
 
         // The full slice should have been stored
-        assert_eq!(1, store.slice_hash_count().await.unwrap());
-        let full_slice_hash =
-            store.retrieve_slice_hash(0).await.unwrap().unwrap();
+        assert_eq!(1, store.slice_hash_count(arc_constraint).await.unwrap());
+        let full_slice_hash = store
+            .retrieve_slice_hash(arc_constraint, 0)
+            .await
+            .unwrap()
+            .unwrap();
         // The hashes should be combined using XOR
         assert_eq!(vec![7 ^ 23; 32], full_slice_hash);
 
@@ -755,9 +942,11 @@ mod tests {
             .await
             .unwrap();
 
+        let arc_constraint = (0, 2);
         let pt = PartitionedTime::try_from_store(
             factor,
             current_time,
+            arc_constraint,
             store.clone(),
         )
         .await
@@ -768,9 +957,12 @@ mod tests {
         assert_eq!(factor as usize, pt.partial_slices.len());
 
         // The full slice should have been stored
-        assert_eq!(1, store.slice_hash_count().await.unwrap());
-        let full_slice_hash =
-            store.retrieve_slice_hash(0).await.unwrap().unwrap();
+        assert_eq!(1, store.slice_hash_count(arc_constraint).await.unwrap());
+        let full_slice_hash = store
+            .retrieve_slice_hash(arc_constraint, 0)
+            .await
+            .unwrap()
+            .unwrap();
         // The hashes should be combined using XOR
         assert_eq!(vec![7 ^ 23; 32], full_slice_hash);
 
@@ -818,6 +1010,7 @@ mod tests {
         let mut pt = PartitionedTime::try_from_store(
             factor,
             current_time,
+            ARC_LITERAL_FULL,
             store.clone(),
         )
         .await
@@ -832,7 +1025,7 @@ mod tests {
                 current_time + Duration::from_secs(UNIT_TIME.as_secs() / 100);
             assert!(call_at < pt.next_update_at());
 
-            pt.update(call_at, store.clone()).await.unwrap();
+            pt.update(store.clone(), call_at).await.unwrap();
 
             assert_eq!(pt_original, pt);
         }
@@ -852,7 +1045,11 @@ mod tests {
             );
 
         let store = Arc::new(Kitsune2MemoryOpStore::default());
-        store.store_slice_hash(0, vec![1; 64].into()).await.unwrap();
+        let arc_constraint = (0, 2);
+        store
+            .store_slice_hash(arc_constraint, 0, vec![1; 64].into())
+            .await
+            .unwrap();
         store
             .process_incoming_ops(vec![
                 Kitsune2MemoryOp::new(
@@ -876,6 +1073,7 @@ mod tests {
         let mut pt = PartitionedTime::try_from_store(
             factor,
             current_time,
+            arc_constraint,
             store.clone(),
         )
         .await
@@ -897,7 +1095,7 @@ mod tests {
             .await
             .unwrap();
 
-        pt.update(current_time + UNIT_TIME, store.clone())
+        pt.update(store.clone(), current_time + UNIT_TIME)
             .await
             .unwrap();
 
@@ -944,9 +1142,11 @@ mod tests {
             .await
             .unwrap();
 
+        let arc_constraint = (0, 2);
         let mut pt = PartitionedTime::try_from_store(
             factor,
             current_times,
+            arc_constraint,
             store.clone(),
         )
         .await
@@ -955,7 +1155,11 @@ mod tests {
         assert_eq!(1, pt.full_slices);
         assert_eq!(
             vec![7 ^ 23; 32],
-            store.retrieve_slice_hash(0).await.unwrap().unwrap()
+            store
+                .retrieve_slice_hash(arc_constraint, 0)
+                .await
+                .unwrap()
+                .unwrap()
         );
 
         // Store a new op, currently in the first partial slice, but will be in the next full slice.
@@ -971,11 +1175,11 @@ mod tests {
             .unwrap();
 
         pt.update(
+            store.clone(),
             UNIX_TIMESTAMP
                 + 2 * full_slice_duration(factor)
                 + min_recent_time(factor)
                 + Duration::from_secs(1),
-            store.clone(),
         )
         .await
         .unwrap();
@@ -983,14 +1187,22 @@ mod tests {
         assert_eq!(2, pt.full_slices);
         assert_eq!(factor as usize, pt.partial_slices.len());
 
-        assert_eq!(2, store.slice_hash_count().await.unwrap());
+        assert_eq!(2, store.slice_hash_count(arc_constraint).await.unwrap());
         assert_eq!(
             vec![7 ^ 23; 32],
-            store.retrieve_slice_hash(0).await.unwrap().unwrap()
+            store
+                .retrieve_slice_hash(arc_constraint, 0)
+                .await
+                .unwrap()
+                .unwrap()
         );
         assert_eq!(
             vec![13; 32],
-            store.retrieve_slice_hash(1).await.unwrap().unwrap()
+            store
+                .retrieve_slice_hash(arc_constraint, 1)
+                .await
+                .unwrap()
+                .unwrap()
         );
     }
 
@@ -1002,9 +1214,11 @@ mod tests {
 
         let store = Arc::new(Kitsune2MemoryOpStore::default());
 
+        let arc_constraint = (0, 2);
         let mut pt = PartitionedTime::try_from_store(
             factor,
             current_time,
+            arc_constraint,
             store.clone(),
         )
         .await
@@ -1049,21 +1263,29 @@ mod tests {
             .await
             .unwrap();
 
-        pt.update(current_time + (2 * pt.full_slice_duration), store.clone())
+        pt.update(store.clone(), current_time + (2 * pt.full_slice_duration))
             .await
             .unwrap();
 
         assert_eq!(2, pt.full_slices);
         assert_eq!(factor as usize, pt.partial_slices.len());
 
-        assert_eq!(2, store.slice_hash_count().await.unwrap());
+        assert_eq!(2, store.slice_hash_count(arc_constraint).await.unwrap());
         assert_eq!(
             vec![7 ^ 23; 32],
-            store.retrieve_slice_hash(0).await.unwrap().unwrap()
+            store
+                .retrieve_slice_hash(arc_constraint, 0)
+                .await
+                .unwrap()
+                .unwrap()
         );
         assert_eq!(
             vec![11 ^ 37; 32],
-            store.retrieve_slice_hash(1).await.unwrap().unwrap()
+            store
+                .retrieve_slice_hash(arc_constraint, 1)
+                .await
+                .unwrap()
+                .unwrap()
         );
     }
 
@@ -1075,9 +1297,11 @@ mod tests {
         let current_time = Timestamp::now();
         let store = Arc::new(Kitsune2MemoryOpStore::default());
 
+        let arc_constraint = (0, 2);
         let mut pt = PartitionedTime::try_from_store(
             factor,
             current_time,
+            arc_constraint,
             store.clone(),
         )
         .await
@@ -1093,13 +1317,16 @@ mod tests {
             pt.full_slices as u128
         );
 
-        let slice_hash_count = store.slice_hash_count().await.unwrap();
+        let slice_hash_count =
+            store.slice_hash_count(arc_constraint).await.unwrap();
         // Should be nothing stored, because we haven't ever created any data.
         assert_eq!(0, slice_hash_count);
 
         // Getting some partial slice that doesn't have any data stored will just return `None`
-        let some_slice_hash =
-            store.retrieve_slice_hash(5203984823).await.unwrap();
+        let some_slice_hash = store
+            .retrieve_slice_hash(arc_constraint, 5203984823)
+            .await
+            .unwrap();
         assert!(some_slice_hash.is_none());
 
         // Now insert an op at the current time
@@ -1114,17 +1341,238 @@ mod tests {
             .await
             .unwrap();
         // and compute the new state in the future
-        pt.update(Timestamp::now() + pt.full_slice_duration, store.clone())
+        pt.update(store.clone(), Timestamp::now() + pt.full_slice_duration)
             .await
             .unwrap();
 
         // Then a single full slice should have been created at the current time
-        assert!(store.slice_hash_count().await.unwrap() > 15_000);
+        assert!(store.slice_hash_count(arc_constraint).await.unwrap() > 15_000);
         // and the count should match the number of full slices that the time partition claims to
         // have created.
         assert_eq!(
-            store.slice_hash_count().await.unwrap(),
+            store.slice_hash_count(arc_constraint).await.unwrap(),
             initial_full_slices_count + 1
+        );
+    }
+
+    #[tokio::test]
+    async fn inform_ops_stored_for_empty_full_slice() {
+        enable_tracing();
+
+        let factor = 14;
+        let current_time = Timestamp::now();
+        let store = Arc::new(Kitsune2MemoryOpStore::default());
+
+        let arc_constraint = (0, 32);
+        let mut pt = PartitionedTime::try_from_store(
+            factor,
+            current_time,
+            arc_constraint,
+            store.clone(),
+        )
+        .await
+        .unwrap();
+
+        let initial_hash =
+            store.retrieve_slice_hash(arc_constraint, 0).await.unwrap();
+        assert!(initial_hash.is_none());
+
+        // Receive an op into the first time slice
+        pt.inform_ops_stored(
+            store.clone(),
+            vec![StoredOp {
+                op_id: OpId::from(bytes::Bytes::copy_from_slice(&[
+                    11, 0, 0, 0,
+                ])),
+                timestamp: UNIX_TIMESTAMP,
+            }],
+        )
+        .await
+        .unwrap();
+
+        // The hash should be updated to include the new op
+        let updated_hash = store
+            .retrieve_slice_hash(arc_constraint, 0)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(vec![11, 0, 0, 0], updated_hash);
+    }
+
+    #[tokio::test]
+    async fn inform_ops_stored_for_existing_full_slice() {
+        enable_tracing();
+
+        let factor = 14;
+        let current_time = Timestamp::now();
+        let store = Arc::new(Kitsune2MemoryOpStore::default());
+        // Insert a single op in the first time slice
+        store
+            .process_incoming_ops(vec![Kitsune2MemoryOp::new(
+                OpId::from(bytes::Bytes::copy_from_slice(&[7, 0, 0, 0])),
+                UNIX_TIMESTAMP,
+                vec![],
+            )
+            .try_into()
+            .unwrap()])
+            .await
+            .unwrap();
+
+        let arc_constraint = (0, 32);
+        let mut pt = PartitionedTime::try_from_store(
+            factor,
+            current_time,
+            arc_constraint,
+            store.clone(),
+        )
+        .await
+        .unwrap();
+
+        let initial_hash = store
+            .retrieve_slice_hash(arc_constraint, 0)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(vec![7, 0, 0, 0], initial_hash);
+
+        // Receive a new op into the same time slice
+        pt.inform_ops_stored(
+            store.clone(),
+            vec![StoredOp {
+                op_id: OpId::from(bytes::Bytes::copy_from_slice(&[
+                    23, 0, 0, 0,
+                ])),
+                timestamp: UNIX_TIMESTAMP,
+            }],
+        )
+        .await
+        .unwrap();
+
+        // The hash should be updated to include the new op
+        let updated_hash = store
+            .retrieve_slice_hash(arc_constraint, 0)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(vec![7 ^ 23, 0, 0, 0], updated_hash);
+    }
+
+    #[tokio::test]
+    async fn inform_ops_stored_for_empty_partial_slice() {
+        enable_tracing();
+
+        let factor = 14;
+        let current_time =
+            UNIX_TIMESTAMP + min_recent_time(factor) + Duration::from_secs(3);
+        let store = Arc::new(Kitsune2MemoryOpStore::default());
+
+        let arc_constraint = (0, 32);
+        let mut pt = PartitionedTime::try_from_store(
+            factor,
+            current_time,
+            arc_constraint,
+            store.clone(),
+        )
+        .await
+        .unwrap();
+
+        // Ensure that all the partial slices are empty
+        assert!(pt.partial_slices.iter().all(|slice| slice.hash.is_empty()));
+
+        // Receive an op into the first and last time slices
+        pt.inform_ops_stored(
+            store.clone(),
+            vec![
+                StoredOp {
+                    op_id: OpId::from(bytes::Bytes::copy_from_slice(&[
+                        11, 0, 0, 0,
+                    ])),
+                    timestamp: UNIX_TIMESTAMP,
+                },
+                StoredOp {
+                    op_id: OpId::from(bytes::Bytes::copy_from_slice(&[
+                        29, 0, 0, 0,
+                    ])),
+                    timestamp: (current_time - Duration::from_secs(5)).unwrap(),
+                },
+            ],
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(vec![11, 0, 0, 0], pt.partial_slices.first().unwrap().hash);
+        assert_eq!(vec![29, 0, 0, 0], pt.partial_slices.last().unwrap().hash);
+    }
+
+    #[tokio::test]
+    async fn inform_ops_stored_for_existing_partial_slice() {
+        enable_tracing();
+
+        let factor = 14;
+        let current_time =
+            UNIX_TIMESTAMP + min_recent_time(factor) + Duration::from_secs(3);
+        let store = Arc::new(Kitsune2MemoryOpStore::default());
+        store
+            .process_incoming_ops(vec![
+                Kitsune2MemoryOp::new(
+                    OpId::from(bytes::Bytes::copy_from_slice(&[7, 0, 0, 0])),
+                    UNIX_TIMESTAMP + Duration::from_secs(10),
+                    vec![],
+                )
+                .try_into()
+                .unwrap(),
+                Kitsune2MemoryOp::new(
+                    OpId::from(bytes::Bytes::copy_from_slice(&[31, 0, 0, 0])),
+                    (current_time - Duration::from_secs(30)).unwrap(),
+                    vec![],
+                )
+                .try_into()
+                .unwrap(),
+            ])
+            .await
+            .unwrap();
+
+        let arc_constraint = (0, 32);
+        let mut pt = PartitionedTime::try_from_store(
+            factor,
+            current_time,
+            arc_constraint,
+            store.clone(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(vec![7, 0, 0, 0], pt.partial_slices.first().unwrap().hash);
+        assert_eq!(vec![31, 0, 0, 0], pt.partial_slices.last().unwrap().hash);
+
+        // Receive an op into the first and last time slices
+        pt.inform_ops_stored(
+            store.clone(),
+            vec![
+                StoredOp {
+                    op_id: OpId::from(bytes::Bytes::copy_from_slice(&[
+                        11, 0, 0, 0,
+                    ])),
+                    timestamp: UNIX_TIMESTAMP,
+                },
+                StoredOp {
+                    op_id: OpId::from(bytes::Bytes::copy_from_slice(&[
+                        29, 0, 0, 0,
+                    ])),
+                    timestamp: (current_time - Duration::from_secs(5)).unwrap(),
+                },
+            ],
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            vec![7 ^ 11, 0, 0, 0],
+            pt.partial_slices.first().unwrap().hash
+        );
+        assert_eq!(
+            vec![31 ^ 29, 0, 0, 0],
+            pt.partial_slices.last().unwrap().hash
         );
     }
 
@@ -1163,10 +1611,14 @@ mod tests {
     }
 
     fn min_recent_time(factor: u8) -> Duration {
-        PartitionedTime::new(factor).unwrap().min_recent_time
+        PartitionedTime::new(factor, ARC_LITERAL_FULL)
+            .unwrap()
+            .min_recent_time
     }
 
     fn full_slice_duration(factor: u8) -> Duration {
-        PartitionedTime::new(factor).unwrap().full_slice_duration
+        PartitionedTime::new(factor, ARC_LITERAL_FULL)
+            .unwrap()
+            .full_slice_duration
     }
 }

--- a/crates/dht/src/time.rs
+++ b/crates/dht/src/time.rs
@@ -233,6 +233,7 @@ impl PartitionedTime {
                 // If we're syncing because we've been offline then it's okay and we should
                 // try to detect that when it's happening but otherwise it'd be good to log a warning
                 // here.
+                tracing::info!("Historical update detected. Seeing many of these places load on our system, but it is expected if we've been offline or a network partition has been resolved.");
 
                 let slice_id = op.timestamp.as_micros()
                     / (self.full_slice_duration.as_micros() as i64);
@@ -512,6 +513,11 @@ impl PartitionedTime {
     #[cfg(test)]
     pub(crate) fn partials(&self) -> &[PartialSlice] {
         &self.partial_slices
+    }
+
+    #[cfg(test)]
+    pub(crate) fn arc_constraint(&self) -> &ArcLiteral {
+        &self.arc_constraint
     }
 }
 

--- a/crates/memory/src/op_store.rs
+++ b/crates/memory/src/op_store.rs
@@ -2,7 +2,8 @@ use crate::op_store::time_slice_hash_store::TimeSliceHashStore;
 use futures::future::BoxFuture;
 use futures::FutureExt;
 use kitsune2_api::{
-    K2Error, K2Result, MetaOp, OpId, OpStore, StoredOp, Timestamp,
+    arc_contains, ArcLiteral, K2Error, K2Result, MetaOp, OpId, OpStore,
+    StoredOp, Timestamp,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -96,6 +97,7 @@ impl OpStore for Kitsune2MemoryOpStore {
 
     fn retrieve_op_hashes_in_time_slice(
         &self,
+        arc: ArcLiteral,
         start: Timestamp,
         end: Timestamp,
     ) -> BoxFuture<'_, K2Result<Vec<OpId>>> {
@@ -104,7 +106,12 @@ impl OpStore for Kitsune2MemoryOpStore {
             Ok(self_lock
                 .op_list
                 .iter()
-                .filter(|(_, op)| op.timestamp >= start && op.timestamp < end)
+                .filter(|(_, op)| {
+                    let loc = op.op_id.loc();
+                    op.timestamp >= start
+                        && op.timestamp < end
+                        && arc_contains(arc, loc)
+                })
                 .map(|(op_id, _)| op_id.clone())
                 .collect())
         }
@@ -119,6 +126,7 @@ impl OpStore for Kitsune2MemoryOpStore {
     /// 1 would represent the combined hash of all known ops in the time slice `[period, 2*period)`.
     fn store_slice_hash(
         &self,
+        arc: ArcLiteral,
         slice_id: u64,
         slice_hash: bytes::Bytes,
     ) -> BoxFuture<'_, K2Result<()>> {
@@ -126,7 +134,7 @@ impl OpStore for Kitsune2MemoryOpStore {
             self.write()
                 .await
                 .time_slice_hashes
-                .insert(slice_id, slice_hash)
+                .insert(arc, slice_id, slice_hash)
         }
         .boxed()
     }
@@ -144,14 +152,17 @@ impl OpStore for Kitsune2MemoryOpStore {
     /// a peer might allocate a recent full slice before completing its initial sync. That situation
     /// could be created by a configuration that chooses small time-slices. However, in the general
     /// case, the highest stored id is more useful.
-    fn slice_hash_count(&self) -> BoxFuture<'_, K2Result<u64>> {
+    fn slice_hash_count(
+        &self,
+        arc: ArcLiteral,
+    ) -> BoxFuture<'_, K2Result<u64>> {
         // +1 to convert from a 0-based index to a count
         async move {
             Ok(self
                 .read()
                 .await
                 .time_slice_hashes
-                .highest_stored_id()
+                .highest_stored_id(&arc)
                 .map(|id| id + 1)
                 .unwrap_or_default())
         }
@@ -165,9 +176,16 @@ impl OpStore for Kitsune2MemoryOpStore {
     /// If the caller has never provided a value for this `slice_id`, return `None`.
     fn retrieve_slice_hash(
         &self,
+        arc: ArcLiteral,
         slice_id: u64,
     ) -> BoxFuture<'_, K2Result<Option<bytes::Bytes>>> {
-        async move { Ok(self.read().await.time_slice_hashes.get(slice_id)) }
-            .boxed()
+        async move {
+            Ok(self
+                .read()
+                .await
+                .time_slice_hashes
+                .get(&arc, slice_id))
+        }
+        .boxed()
     }
 }

--- a/crates/memory/src/op_store/time_slice_hash_store.rs
+++ b/crates/memory/src/op_store/time_slice_hash_store.rs
@@ -1,5 +1,5 @@
-use kitsune2_api::{K2Error, K2Result};
-use std::collections::BTreeMap;
+use kitsune2_api::{ArcLiteral, K2Error, K2Result};
+use std::collections::{BTreeMap, HashMap};
 
 /// In-memory store for time slice hashes.
 ///
@@ -11,13 +11,14 @@ use std::collections::BTreeMap;
 #[derive(Debug, Default)]
 #[cfg_attr(test, derive(Clone))]
 pub(super) struct TimeSliceHashStore {
-    inner: BTreeMap<u64, bytes::Bytes>,
+    inner: HashMap<ArcLiteral, BTreeMap<u64, bytes::Bytes>>,
 }
 
 impl TimeSliceHashStore {
     /// Insert a hash at the given slice id.
     pub(super) fn insert(
         &mut self,
+        arc: ArcLiteral,
         slice_id: u64,
         hash: bytes::Bytes,
     ) -> K2Result<()> {
@@ -30,17 +31,26 @@ impl TimeSliceHashStore {
             return Err(K2Error::other("Cannot insert empty combined hash"));
         }
 
-        self.inner.insert(slice_id, hash);
+        self.inner.entry(arc).or_default().insert(slice_id, hash);
 
         Ok(())
     }
 
-    pub(super) fn get(&self, slice_id: u64) -> Option<bytes::Bytes> {
-        self.inner.get(&slice_id).cloned()
+    pub(super) fn get(
+        &self,
+        arc: &ArcLiteral,
+        slice_id: u64,
+    ) -> Option<bytes::Bytes> {
+        self.inner
+            .get(arc)
+            .and_then(|by_arc| by_arc.get(&slice_id))
+            .cloned()
     }
 
-    pub fn highest_stored_id(&self) -> Option<u64> {
-        self.inner.iter().last().map(|(id, _)| *id)
+    pub fn highest_stored_id(&self, arc: &ArcLiteral) -> Option<u64> {
+        self.inner
+            .get(arc)
+            .and_then(|by_arc| by_arc.iter().last().map(|(id, _)| *id))
     }
 }
 
@@ -52,7 +62,7 @@ mod tests {
     fn create_empty() {
         let store = TimeSliceHashStore::default();
 
-        assert_eq!(None, store.highest_stored_id());
+        assert_eq!(None, store.highest_stored_id(&(0, 0)));
         assert!(store.inner.is_empty());
     }
 
@@ -60,7 +70,7 @@ mod tests {
     fn insert_empty_hash_into_empty() {
         let mut store = TimeSliceHashStore::default();
 
-        let e = store.insert(100, bytes::Bytes::new()).unwrap_err();
+        let e = store.insert((0, 2), 100, bytes::Bytes::new()).unwrap_err();
         assert_eq!(
             "Cannot insert empty combined hash (src: None)",
             e.to_string()
@@ -71,73 +81,163 @@ mod tests {
     fn insert_single_hash_into_empty() {
         let mut store = TimeSliceHashStore::default();
 
-        store.insert(100, vec![1, 2, 3].into()).unwrap();
+        let arc_constraint = (0, 2);
+        store
+            .insert(arc_constraint, 100, vec![1, 2, 3].into())
+            .unwrap();
 
         assert_eq!(1, store.inner.len());
         assert_eq!(
             bytes::Bytes::from_static(&[1, 2, 3]),
-            store.get(100).unwrap()
+            store.get(&arc_constraint, 100).unwrap()
         );
-        assert_eq!(Some(100), store.highest_stored_id());
+        assert_eq!(Some(100), store.highest_stored_id(&arc_constraint));
     }
 
     #[test]
     fn insert_many_sparse() {
         let mut store = TimeSliceHashStore::default();
 
-        store.insert(100, vec![1, 2, 3].into()).unwrap();
-        store.insert(105, vec![2, 3, 4].into()).unwrap();
-        store.insert(115, vec![3, 4, 5].into()).unwrap();
+        let arc_constraint = (0, 2);
+        store
+            .insert(arc_constraint, 100, vec![1, 2, 3].into())
+            .unwrap();
+        store
+            .insert(arc_constraint, 105, vec![2, 3, 4].into())
+            .unwrap();
+        store
+            .insert(arc_constraint, 115, vec![3, 4, 5].into())
+            .unwrap();
 
-        assert_eq!(3, store.inner.len());
+        assert_eq!(1, store.inner.len());
+        assert_eq!(3, store.inner[&arc_constraint].len());
         assert_eq!(
             bytes::Bytes::from_static(&[1, 2, 3]),
-            store.get(100).unwrap()
+            store.get(&arc_constraint, 100).unwrap()
         );
         assert_eq!(
             bytes::Bytes::from_static(&[2, 3, 4]),
-            store.get(105).unwrap()
+            store.get(&arc_constraint, 105).unwrap()
         );
         assert_eq!(
             bytes::Bytes::from_static(&[3, 4, 5]),
-            store.get(115).unwrap()
+            store.get(&arc_constraint, 115).unwrap()
         );
-        assert_eq!(Some(115), store.highest_stored_id());
+        assert_eq!(Some(115), store.highest_stored_id(&arc_constraint));
     }
 
     #[test]
     fn insert_many_in_sequence() {
         let mut store = TimeSliceHashStore::default();
 
-        store.insert(100, vec![1, 2, 3].into()).unwrap();
-        store.insert(101, vec![2, 3, 4].into()).unwrap();
-        store.insert(102, vec![3, 4, 5].into()).unwrap();
+        let arc_constraint = (0, 2);
+        store
+            .insert(arc_constraint, 100, vec![1, 2, 3].into())
+            .unwrap();
+        store
+            .insert(arc_constraint, 101, vec![2, 3, 4].into())
+            .unwrap();
+        store
+            .insert(arc_constraint, 102, vec![3, 4, 5].into())
+            .unwrap();
 
-        assert_eq!(3, store.inner.len());
+        assert_eq!(1, store.inner.len());
+        assert_eq!(3, store.inner[&arc_constraint].len());
 
         assert_eq!(
             bytes::Bytes::from_static(&[1, 2, 3]),
-            store.get(100).unwrap()
+            store.get(&arc_constraint, 100).unwrap()
         );
         assert_eq!(
             bytes::Bytes::from_static(&[2, 3, 4]),
-            store.get(101).unwrap()
+            store.get(&arc_constraint, 101).unwrap()
         );
         assert_eq!(
             bytes::Bytes::from_static(&[3, 4, 5]),
-            store.get(102).unwrap()
+            store.get(&arc_constraint, 102).unwrap()
         );
-        assert_eq!(Some(102), store.highest_stored_id());
+        assert_eq!(Some(102), store.highest_stored_id(&arc_constraint));
     }
 
     #[test]
     fn overwrite_existing_hash() {
         let mut store = TimeSliceHashStore::default();
 
-        store.insert(100, vec![1, 2, 3].into()).unwrap();
+        let arc_constraint = (0, 2);
+        store
+            .insert(arc_constraint, 100, vec![1, 2, 3].into())
+            .unwrap();
         assert_eq!(1, store.inner.len());
 
-        store.insert(100, vec![2, 3, 4].into()).unwrap();
+        store
+            .insert(arc_constraint, 100, vec![2, 3, 4].into())
+            .unwrap();
         assert_eq!(1, store.inner.len());
+    }
+
+    #[test]
+    fn overlapping_arcs_are_kept_separate() {
+        let mut store = TimeSliceHashStore::default();
+
+        let arc_constraint_1 = (0, 2);
+
+        // Twice the size of arc_constraint_1, starting at the same point
+        let arc_constraint_2 = (0, 4);
+
+        store
+            .insert(arc_constraint_1, 100, vec![1, 2, 3].into())
+            .unwrap();
+
+        store
+            .insert(arc_constraint_2, 100, vec![2, 3, 4].into())
+            .unwrap();
+
+        assert_eq!(2, store.inner.len());
+        assert_eq!(Some(100), store.highest_stored_id(&arc_constraint_1));
+        assert_eq!(vec![1, 2, 3], store.get(&arc_constraint_1, 100).unwrap());
+
+        assert_eq!(Some(100), store.highest_stored_id(&arc_constraint_2));
+        assert_eq!(vec![2, 3, 4], store.get(&arc_constraint_2, 100).unwrap());
+    }
+
+    #[test]
+    fn update_with_multiple_arcs() {
+        let mut store = TimeSliceHashStore::default();
+
+        let arc_constraint_1 = (0, 2);
+        let arc_constraint_2 = (2, 4);
+
+        store
+            .insert(arc_constraint_1, 0, vec![1, 2, 3].into())
+            .unwrap();
+        store
+            .insert(arc_constraint_1, 1, vec![2, 3, 4].into())
+            .unwrap();
+        store
+            .insert(arc_constraint_2, 0, vec![3, 2, 1].into())
+            .unwrap();
+        store
+            .insert(arc_constraint_2, 1, vec![4, 3, 2].into())
+            .unwrap();
+
+        assert_eq!(2, store.inner.len());
+        assert_eq!(Some(1), store.highest_stored_id(&arc_constraint_1));
+        assert_eq!(Some(1), store.highest_stored_id(&arc_constraint_2));
+
+        store
+            .insert(arc_constraint_1, 0, vec![1, 2, 5].into())
+            .unwrap();
+        store
+            .insert(arc_constraint_2, 1, vec![5, 3, 2].into())
+            .unwrap();
+
+        assert_eq!(2, store.inner.len());
+        assert_eq!(Some(1), store.highest_stored_id(&arc_constraint_1));
+        assert_eq!(vec![1, 2, 5], store.get(&arc_constraint_1, 0).unwrap());
+        assert_eq!(vec![2, 3, 4], store.get(&arc_constraint_1, 1).unwrap());
+
+        assert_eq!(Some(1), store.highest_stored_id(&arc_constraint_2));
+        assert_eq!(vec![3, 2, 1], store.get(&arc_constraint_2, 0).unwrap());
+        assert_eq!(vec![5, 3, 2], store.get(&arc_constraint_2, 1).unwrap());
     }
 }

--- a/crates/test_utils/src/lib.rs
+++ b/crates/test_utils/src/lib.rs
@@ -3,6 +3,7 @@
 /// This is intended to be used in tests, so it defaults to DEBUG level.
 pub fn enable_tracing() {
     let _ = tracing_subscriber::fmt()
+        .with_test_writer()
         .with_env_filter(
             tracing_subscriber::EnvFilter::builder()
                 .with_default_directive(tracing::Level::DEBUG.into())


### PR DESCRIPTION
Implements hash partitioning in terms of the existing time partitioning.

Things to pay particular attention to:
- The arc changes, looking at naming and whether we like the simple typesdefs vs structured types. E.g. `arc_contains` has to be defined as an associated function rather than a member method.
- The documentation on the hash space. It's a pretty significant deviation from how the hash space was managed in Kitsune2. My reasoning is that having the hash space change its partitioning is extra complexity and endless extra computation for little value. We can vary the argent size, so what really matters is just having small enough chunks that an agent covering one chunk is holding a small enough amount of data.
- All time slices are created up front, even if the combined agent arcs for this node won't need them. This could be made more efficient but is simple for this point in time. I think that will need to change because really numbers of partitions of the hash space take a while to create.