### PR TITLE
Transport Trait

### DIFF
--- a/crates/core/src/factories/mem_transport.rs
+++ b/crates/core/src/factories/mem_transport.rs
@@ -38,13 +38,13 @@ impl TransportFactory for MemTransportFactory {
         &self,
         builder: Arc<builder::Builder>,
         handler: Arc<TxImpHnd>,
-    ) -> BoxFut<'static, K2Result<Transport>> {
+    ) -> BoxFut<'static, K2Result<DynTransport>> {
         Box::pin(async move {
             let config = builder
                 .config
                 .get_module_config::<MemTransportConfig>(MOD_NAME)?;
             let imp = MemTransport::create(config, handler.clone()).await;
-            Ok(handler.gen_transport(imp))
+            Ok(DefaultTransport::create(&handler, imp))
         })
     }
 }

--- a/crates/core/src/factories/mem_transport/test.rs
+++ b/crates/core/src/factories/mem_transport/test.rs
@@ -192,7 +192,7 @@ impl TrackHnd {
     }
 }
 
-async fn gen_tx(hnd: DynTxHandler) -> Transport {
+async fn gen_tx(hnd: DynTxHandler) -> DynTransport {
     let builder = Arc::new(crate::default_builder());
     let hnd = TxImpHnd::new(hnd);
     builder


### PR DESCRIPTION
Instead of `Transport` directly being a struct, use our trait+trait-object pattern for test-ability.

There is no functional change in this PR, it is purely moving code around + renaming.