### PR TITLE
Consider persisting tombstones

### DIFF
--- a/crates/bootstrap_srv/src/test.rs
+++ b/crates/bootstrap_srv/src/test.rs
@@ -253,6 +253,33 @@ fn tombstone_old_is_ignored() {
 }
 
 #[test]
+fn tombstone_persists() {
+    let s = BootstrapSrv::new(Config::testing()).unwrap();
+
+    let _ = PutInfo {
+        addr: s.listen_addrs()[0],
+        is_tombstone: true,
+        ..Default::default()
+    }
+    .call()
+    .unwrap();
+
+    let _ = PutInfo {
+        addr: s.listen_addrs()[0],
+        created_at: now()
+            - std::time::Duration::from_secs(60).as_micros() as i64,
+        ..Default::default()
+    }
+    .call()
+    .unwrap();
+
+    let addr = format!("http://{:?}/bootstrap/{}", s.listen_addrs()[0], S1);
+    let res = ureq::get(&addr).call().unwrap().into_string().unwrap();
+    let res: Vec<DecodeAgent> = serde_json::from_str(&res).unwrap();
+    assert_eq!(0, res.len());
+}
+
+#[test]
 fn tombstone_deletes_correct_agent() {
     let s = BootstrapSrv::new(Config::testing()).unwrap();
 


### PR DESCRIPTION
Hey, your friendly neighborhood model checker here. Model checking showed me this seemingly unhandled case and I was wondering if you had considered it:

It looks to me like tombstones don't persist, they just remove an entry and "expire" immediately. If another entry later comes in which predates the tombstone, it is allowed to be stored. This test fails.

If this is true, and the current behavior is desired, it might be good as an extra line in the spec, since the usual meaning of "tombstone" would imply that this test should pass.