### PR TITLE
Config V2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -930,11 +930,13 @@ dependencies = [
  "base64",
  "bytes",
  "futures",
+ "kitsune2_test_utils",
  "prost",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
+ "tracing",
  "url",
 ]
 

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -18,7 +18,9 @@ prost = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+tracing = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
+kitsune2_test_utils = { workspace = true }
 tokio = { workspace = true, features = ["full"] }

--- a/crates/api/src/builder.rs
+++ b/crates/api/src/builder.rs
@@ -56,6 +56,8 @@ impl Builder {
             peer_store.default_config(config)?;
             fetch.default_config(config)?;
             transport.default_config(config)?;
+
+            config.mark_defaults_set();
         }
 
         Ok(self)
@@ -66,6 +68,7 @@ impl Builder {
         self,
         handler: kitsune::DynKitsuneHandler,
     ) -> K2Result<kitsune::DynKitsune> {
+        self.config.mark_runtime();
         let builder = Arc::new(self);
         builder.kitsune.create(builder.clone(), handler).await
     }

--- a/crates/api/src/builder.rs
+++ b/crates/api/src/builder.rs
@@ -39,24 +39,26 @@ impl Builder {
     /// Construct a default config given the configured module factories.
     /// Note, this should be called before freezing the Builder instance
     /// in an Arc<>.
-    pub fn set_default_config(&mut self) -> K2Result<()> {
-        let Self {
-            config,
-            verifier: _,
-            kitsune,
-            space,
-            peer_store,
-            fetch,
-            transport,
-        } = self;
+    pub fn with_default_config(mut self) -> K2Result<Self> {
+        {
+            let Self {
+                config,
+                verifier: _,
+                kitsune,
+                space,
+                peer_store,
+                fetch,
+                transport,
+            } = &mut self;
 
-        kitsune.default_config(config)?;
-        space.default_config(config)?;
-        peer_store.default_config(config)?;
-        fetch.default_config(config)?;
-        transport.default_config(config)?;
+            kitsune.default_config(config)?;
+            space.default_config(config)?;
+            peer_store.default_config(config)?;
+            fetch.default_config(config)?;
+            transport.default_config(config)?;
+        }
 
-        Ok(())
+        Ok(self)
     }
 
     /// This will generate an actual kitsune instance.

--- a/crates/api/src/config.rs
+++ b/crates/api/src/config.rs
@@ -77,7 +77,7 @@ impl Config {
         let mut updates = Vec::new();
         {
             let mut lock = self.0.lock().unwrap();
-            let old_map: &mut ConfigMap = &mut *lock;
+            let old_map: &mut ConfigMap = &mut lock;
             let new_map: &ConfigMap = &in_map;
             fn apply_map(
                 updates: &mut Vec<(ConfigUpdateCb, serde_json::Value)>,
@@ -101,7 +101,7 @@ impl Config {
                     },
                     ConfigMap::ConfigEntry(new_entry) => match old_map {
                         ConfigMap::ConfigMap(m) => {
-                            if m.len() > 0 {
+                            if !m.is_empty() {
                                 return Err(K2Error::other(
                                     "attempted to insert an entry where a map exists",
                                 ));
@@ -142,7 +142,7 @@ impl Config {
     ) -> K2Result<()> {
         let value = {
             let mut lock = self.0.lock().unwrap();
-            let mut cur: &mut ConfigMap = &mut *lock;
+            let mut cur: &mut ConfigMap = &mut lock;
             for path in path {
                 let key = path.to_string();
                 match cur {
@@ -156,7 +156,7 @@ impl Config {
             }
             match cur {
                 ConfigMap::ConfigMap(m) => {
-                    if m.len() > 0 {
+                    if !m.is_empty() {
                         return Err(K2Error::other(
                             "attempted to insert an entry where a map exists",
                         ));

--- a/crates/api/src/config.rs
+++ b/crates/api/src/config.rs
@@ -2,6 +2,7 @@
 
 use crate::*;
 use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
 
 /// helper transcode function
 fn tc<S: serde::Serialize, D: serde::de::DeserializeOwned>(
@@ -14,68 +15,166 @@ fn tc<S: serde::Serialize, D: serde::de::DeserializeOwned>(
     .map_err(|e| K2Error::other_src("decode", e))
 }
 
-/// Denotes a type used to configure a specific kitsune2 module.
-///
-/// Note, the types defined in this struct are specifically for configuration
-/// that cannot be changed at runtime, the likes of which might be found
-/// in a configuration file.
-///
-/// If a specific module has a config that can be changed at runtime, the
-/// component found in this type might be a `default_` prefixed version
-/// of it, then the runtime value can be altered through different means.
-///
-/// It is highly recommended that you expose this struct in your module
-/// docs to help devs using your module understand how to configure it.
-pub trait ModConfig:
-    'static
-    + Sized
-    + Default
-    + std::fmt::Debug
-    + serde::Serialize
-    + serde::de::DeserializeOwned
-    + Send
-    + Sync
-{
+/// A callback to be invoked if the config value is updated at runtime.
+pub type ConfigUpdateCb =
+    Arc<dyn Fn(serde_json::Value) + 'static + Send + Sync>;
+
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+#[serde(transparent, rename_all = "camelCase")]
+struct ConfigEntry {
+    pub value: serde_json::Value,
+    #[serde(skip, default)]
+    pub update_cb: Option<ConfigUpdateCb>,
+}
+
+impl std::fmt::Debug for ConfigEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.value.fmt(f)
+    }
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(untagged, rename_all = "camelCase")]
+enum ConfigMap {
+    ConfigMap(BTreeMap<String, Box<Self>>),
+    ConfigEntry(ConfigEntry),
+}
+
+impl Default for ConfigMap {
+    fn default() -> Self {
+        Self::ConfigMap(BTreeMap::new())
+    }
 }
 
 /// Kitsune configuration.
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
-pub struct Config(BTreeMap<String, serde_json::Value>);
+#[derive(Debug, serde::Serialize)]
+pub struct Config(Mutex<ConfigMap>);
+
+impl Default for Config {
+    fn default() -> Self {
+        Self(Mutex::new(ConfigMap::ConfigMap(BTreeMap::new())))
+    }
+}
 
 impl Config {
-    /// When kitsune2 is generating a default or example configuration
-    /// file, it will pass a mutable reference of this config struct to
-    /// the module factories that are configured to be used. Those factories
-    /// should call this function any number of times to add any default
-    /// configuration parameters to that file.
-    pub fn add_default_module_config<M: ModConfig>(
-        &mut self,
-        module_name: String,
+    /// Get a set of module config values from this config instance.
+    pub fn get_module_config<D: serde::de::DeserializeOwned>(
+        &self,
+    ) -> K2Result<D> {
+        let lock = self.0.lock().unwrap();
+        tc(&*lock)
+    }
+
+    /// Set any number of module config values on this config instance.
+    ///
+    /// This will error if trying to write an entry where a map currently
+    /// resides or visa-versa.
+    pub fn set_module_config<S: serde::Serialize>(
+        &self,
+        config: &S,
     ) -> K2Result<()> {
-        if self.0.contains_key(&module_name) {
-            return Err(K2Error::other(format!(
-                "Refusing to overwrite conflicting module name: {module_name}"
-            )));
+        let in_map: ConfigMap = tc(config)?;
+        let mut updates = Vec::new();
+        {
+            let mut lock = self.0.lock().unwrap();
+            let old_map: &mut ConfigMap = &mut *lock;
+            let new_map: &ConfigMap = &in_map;
+            fn apply_map(
+                updates: &mut Vec<(ConfigUpdateCb, serde_json::Value)>,
+                old_map: &mut ConfigMap,
+                new_map: &ConfigMap,
+            ) -> K2Result<()> {
+                match new_map {
+                    ConfigMap::ConfigMap(new_map) => match old_map {
+                        ConfigMap::ConfigMap(old_map) => {
+                            for (key, new_map) in new_map.iter() {
+                                let old_map =
+                                    old_map.entry(key.clone()).or_default();
+                                apply_map(updates, old_map, new_map)?;
+                            }
+                        }
+                        ConfigMap::ConfigEntry(_) => {
+                            return Err(K2Error::other(
+                                "attempted to insert a map where an entry exists",
+                            ));
+                        }
+                    },
+                    ConfigMap::ConfigEntry(new_entry) => match old_map {
+                        ConfigMap::ConfigMap(m) => {
+                            if m.len() > 0 {
+                                return Err(K2Error::other(
+                                    "attempted to insert an entry where a map exists",
+                                ));
+                            }
+                            *old_map =
+                                ConfigMap::ConfigEntry(new_entry.clone());
+                        }
+                        ConfigMap::ConfigEntry(old_entry) => {
+                            old_entry.value = new_entry.value.clone();
+                            if let Some(update_cb) = &old_entry.update_cb {
+                                updates.push((
+                                    update_cb.clone(),
+                                    new_entry.value.clone(),
+                                ));
+                            }
+                        }
+                    },
+                }
+                Ok(())
+            }
+            apply_map(&mut updates, old_map, new_map)?;
         }
-        self.0.insert(module_name, tc(&M::default())?);
+        for (update_cb, value) in updates {
+            update_cb(value);
+        }
         Ok(())
     }
 
-    /// When kitsune2 is initializing, it will call the factory function
-    /// for all of its modules with an immutable reference to this config
-    /// struct. Each of those modules may choose to call this function
-    /// to extract a module config. Note that this config is loaded from
-    /// disk and can be edited by humans, so the serialization on the module
-    /// config should be tolerant to missing properties, setting sane defaults.
-    /// A module may choose to warn about missing properties and should warn about extraneous properties.
-    pub fn get_module_config<M: ModConfig>(
+    /// Call this in your module constructor once for every parameter for
+    /// which you would like to receive runtime updates. This will immediately
+    /// invoke the callback with the current value to ensure this is atomic.
+    /// (If this is called before default initialization, that initial value
+    /// will be json Null.)
+    pub fn register_entry_update_cb<D: std::fmt::Display>(
         &self,
-        module_name: &str,
-    ) -> K2Result<M> {
-        self.0
-            .get(module_name)
-            .map(tc)
-            .unwrap_or_else(|| Ok(M::default()))
+        path: &[D],
+        update_cb: ConfigUpdateCb,
+    ) -> K2Result<()> {
+        let value = {
+            let mut lock = self.0.lock().unwrap();
+            let mut cur: &mut ConfigMap = &mut *lock;
+            for path in path {
+                let key = path.to_string();
+                match cur {
+                    ConfigMap::ConfigMap(m) => cur = m.entry(key).or_default(),
+                    ConfigMap::ConfigEntry(_) => {
+                        return Err(K2Error::other(
+                            "attempted to insert a map where an entry exists",
+                        ))
+                    }
+                }
+            }
+            match cur {
+                ConfigMap::ConfigMap(m) => {
+                    if m.len() > 0 {
+                        return Err(K2Error::other(
+                            "attempted to insert an entry where a map exists",
+                        ));
+                    }
+                    *cur = ConfigMap::ConfigEntry(ConfigEntry {
+                        value: serde_json::Value::Null,
+                        update_cb: Some(update_cb.clone()),
+                    });
+                    serde_json::Value::Null
+                }
+                ConfigMap::ConfigEntry(e) => {
+                    e.update_cb = Some(update_cb.clone());
+                    e.value.clone()
+                }
+            }
+        };
+        update_cb(value);
+        Ok(())
     }
 }
 
@@ -85,99 +184,52 @@ mod test {
 
     #[test]
     fn config_usage_example() {
-        #[derive(
-            Debug, Default, serde::Serialize, serde::Deserialize, PartialEq,
-        )]
-        struct Mod1 {
-            #[serde(default)]
-            p_a: u32,
-            #[serde(default)]
-            p_b: String,
+        #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
+        #[serde(rename_all = "camelCase")]
+        struct SubConfig {
+            pub apples: String,
+            pub bananas: u32,
         }
-
-        impl ModConfig for Mod1 {}
 
         #[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
-        #[serde(default)]
-        struct Mod2 {
-            #[serde(rename = "#p_c", skip_deserializing)]
-            doc_p_a: &'static str,
-            #[serde(default)]
-            p_c: u32,
-            #[serde(default)]
-            p_d: String,
+        #[serde(rename_all = "camelCase")]
+        struct ModConfig {
+            pub my_module: SubConfig,
         }
 
-        impl Default for Mod2 {
-            fn default() -> Self {
-                Self {
-                    doc_p_a: "This is a potential pattern for how to document config props.",
-                    p_c: 0,
-                    p_d: "".into(),
-                }
-            }
-        }
+        let c = Config::default();
 
-        impl ModConfig for Mod2 {}
+        let expect = ModConfig {
+            my_module: SubConfig {
+                apples: "red".to_string(),
+                bananas: 42,
+            },
+        };
 
-        let mut config = Config::default();
-        config
-            .add_default_module_config::<Mod1>("mod1".into())
-            .unwrap();
-        config
-            .add_default_module_config::<Mod2>("mod2".into())
-            .unwrap();
+        c.set_module_config(&expect).unwrap();
 
-        // output the "default" config
-        assert_eq!(
-            r##"{
-  "mod1": {
-    "p_a": 0,
-    "p_b": ""
-  },
-  "mod2": {
-    "#p_c": "This is a potential pattern for how to document config props.",
-    "p_c": 0,
-    "p_d": ""
-  }
-}"##,
-            serde_json::to_string_pretty(&config).unwrap()
-        );
+        println!("{}", serde_json::to_string_pretty(&c).unwrap());
 
-        // ensure we can load a weird config from disk
-        let config: Config = serde_json::from_str(
-            r#"{
-          "modBAD": { "foo": "bar" },
-          "mod1": { "p_b": "test-p_b" },
-          "mod2": { "p_c": 42, "p_d": "test-p_d", "extra": "foo" }
-        }"#,
-        )
+        let resp: ModConfig = c.get_module_config().unwrap();
+        assert_eq!(expect, resp);
+
+        use std::sync::atomic::*;
+        let update = Arc::new(AtomicU32::new(0));
+        let update2 = update.clone();
+        c.register_entry_update_cb(&["myModule", "bananas"], Arc::new(move |v| {
+            let v: u32 =
+                serde_json::from_str(&serde_json::to_string(&v).unwrap())
+                    .unwrap();
+            update2.store(v, Ordering::SeqCst);
+        }))
         .unwrap();
 
-        assert_eq!(
-            Mod1 {
-                p_a: 0,
-                p_b: "test-p_b".to_string(),
-            },
-            config.get_module_config::<Mod1>("mod1").unwrap(),
-        );
+        c.set_module_config(&serde_json::json!({
+            "myModule": {
+                "bananas": 99,
+            }
+        })).unwrap();
 
-        assert_eq!(
-            Mod2 {
-                p_c: 42,
-                p_d: "test-p_d".to_string(),
-                ..Default::default()
-            },
-            config.get_module_config::<Mod2>("mod2").unwrap(),
-        );
-
-        // unset mods get the default
-        assert_eq!(
-            Mod1 {
-                p_a: 0,
-                p_b: "".to_string(),
-            },
-            config.get_module_config::<Mod1>("NOT-SET").unwrap(),
-        );
+        assert_eq!(99, update.load(Ordering::SeqCst));
     }
 }

--- a/crates/api/src/config.rs
+++ b/crates/api/src/config.rs
@@ -216,19 +216,23 @@ mod test {
         use std::sync::atomic::*;
         let update = Arc::new(AtomicU32::new(0));
         let update2 = update.clone();
-        c.register_entry_update_cb(&["myModule", "bananas"], Arc::new(move |v| {
-            let v: u32 =
-                serde_json::from_str(&serde_json::to_string(&v).unwrap())
-                    .unwrap();
-            update2.store(v, Ordering::SeqCst);
-        }))
+        c.register_entry_update_cb(
+            &["myModule", "bananas"],
+            Arc::new(move |v| {
+                let v: u32 =
+                    serde_json::from_str(&serde_json::to_string(&v).unwrap())
+                        .unwrap();
+                update2.store(v, Ordering::SeqCst);
+            }),
+        )
         .unwrap();
 
         c.set_module_config(&serde_json::json!({
             "myModule": {
                 "bananas": 99,
             }
-        })).unwrap();
+        }))
+        .unwrap();
 
         assert_eq!(99, update.load(Ordering::SeqCst));
     }

--- a/crates/api/src/config.rs
+++ b/crates/api/src/config.rs
@@ -29,7 +29,10 @@ struct ConfigEntry {
 
 impl std::fmt::Debug for ConfigEntry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.value.fmt(f)
+        f.debug_struct("ConfigEntry")
+            .field("value", &self.value)
+            .field("has_update_cb", &self.update_cb.is_some())
+            .finish()
     }
 }
 

--- a/crates/core/src/factories.rs
+++ b/crates/core/src/factories.rs
@@ -9,6 +9,9 @@ pub use core_space::*;
 pub mod mem_peer_store;
 pub use mem_peer_store::MemPeerStoreFactory;
 
+#[cfg(test)]
+pub(crate) use mem_peer_store::test_utils;
+
 mod core_fetch;
 pub use core_fetch::*;
 

--- a/crates/core/src/factories.rs
+++ b/crates/core/src/factories.rs
@@ -6,8 +6,8 @@ pub use core_kitsune::*;
 mod core_space;
 pub use core_space::*;
 
-mod mem_peer_store;
-pub use mem_peer_store::*;
+pub mod mem_peer_store;
+pub use mem_peer_store::MemPeerStoreFactory;
 
 mod core_fetch;
 pub use core_fetch::*;

--- a/crates/core/src/factories/core_fetch.rs
+++ b/crates/core/src/factories/core_fetch.rs
@@ -48,7 +48,6 @@ use std::{
 
 use kitsune2_api::{
     builder,
-    config::ModConfig,
     fetch::{serialize_op_ids, DynFetch, DynFetchFactory, Fetch, FetchFactory},
     peer_store,
     transport::DynTransport,
@@ -118,8 +117,6 @@ impl Default for CoreFetchConfig {
         }
     }
 }
-
-impl ModConfig for CoreFetchConfig {}
 
 type FetchRequest = (OpId, AgentId);
 

--- a/crates/core/src/factories/core_fetch.rs
+++ b/crates/core/src/factories/core_fetch.rs
@@ -60,6 +60,38 @@ use tokio::{
 
 const MOD_NAME: &str = "Fetch";
 
+/// CoreFetch configuration types.
+pub mod config {
+    /// Configuration parameters for [CoreFetchFactory].
+    #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct CoreFetchConfig {
+        /// How many parallel op fetch requests can be made at once. Default: 2.  
+        pub parallel_request_count: u8,
+        /// Duration in ms to keep an unresponsive agent on the cool-down list. Default: 120_000.
+        pub cool_down_interval_ms: u64,
+    }
+
+    impl Default for CoreFetchConfig {
+        fn default() -> Self {
+            Self {
+                parallel_request_count: 2,
+                cool_down_interval_ms: 120_000,
+            }
+        }
+    }
+
+    /// Module-level configuration for CoreFetch.
+    #[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
+    #[serde(rename_all = "camelCase")]
+    pub struct CoreFetchModConfig {
+        /// CoreFetch configuration.
+        pub core_fetch: CoreFetchConfig,
+    }
+}
+
+use config::*;
+
 /// A production-ready fetch module.
 #[derive(Debug)]
 pub struct CoreFetchFactory {}
@@ -76,9 +108,7 @@ impl FetchFactory for CoreFetchFactory {
         &self,
         config: &mut kitsune2_api::config::Config,
     ) -> K2Result<()> {
-        config.add_default_module_config::<CoreFetchConfig>(
-            MOD_NAME.to_string(),
-        )?;
+        config.set_module_config(&CoreFetchModConfig::default())?;
         Ok(())
     }
 
@@ -90,31 +120,16 @@ impl FetchFactory for CoreFetchFactory {
         transport: DynTransport,
     ) -> BoxFut<'static, K2Result<DynFetch>> {
         Box::pin(async move {
-            let config = builder.config.get_module_config(MOD_NAME)?;
+            let config: CoreFetchModConfig =
+                builder.config.get_module_config()?;
             let out: DynFetch = Arc::new(CoreFetch::new(
-                config, space_id, peer_store, transport,
+                config.core_fetch,
+                space_id,
+                peer_store,
+                transport,
             ));
             Ok(out)
         })
-    }
-}
-
-/// Configuration parameters for [CoreFetchFactory].
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CoreFetchConfig {
-    /// How many parallel op fetch requests can be made at once. Default: 2.  
-    pub parallel_request_count: u8,
-    /// Duration in ms to keep an unresponsive agent on the cool-down list. Default: 120_000.
-    pub cool_down_interval_ms: u64,
-}
-
-impl Default for CoreFetchConfig {
-    fn default() -> Self {
-        Self {
-            parallel_request_count: 2,
-            cool_down_interval_ms: 120_000,
-        }
     }
 }
 

--- a/crates/core/src/factories/core_fetch.rs
+++ b/crates/core/src/factories/core_fetch.rs
@@ -62,7 +62,7 @@ const MOD_NAME: &str = "Fetch";
 
 /// CoreFetch configuration types.
 pub mod config {
-    /// Configuration parameters for [CoreFetchFactory].
+    /// Configuration parameters for [CoreFetchFactory](super::CoreFetchFactory).
     #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct CoreFetchConfig {

--- a/crates/core/src/factories/core_fetch/test.rs
+++ b/crates/core/src/factories/core_fetch/test.rs
@@ -91,7 +91,7 @@ impl Transport for MockTransport {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn fetch_queue() {
-    let builder = Arc::new(default_builder());
+    let builder = Arc::new(default_builder().with_default_config().unwrap());
     let peer_store = builder.peer_store.create(builder.clone()).await.unwrap();
     let mock_transport = MockTransport::new(false);
     let config = CoreFetchConfig::default();
@@ -177,7 +177,7 @@ async fn fetch_queue() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn happy_multi_op_fetch_from_single_agent() {
-    let builder = Arc::new(default_builder());
+    let builder = Arc::new(default_builder().with_default_config().unwrap());
     let peer_store = builder.peer_store.create(builder.clone()).await.unwrap();
     let config = CoreFetchConfig::default();
     let mock_transport = MockTransport::new(false);
@@ -236,7 +236,7 @@ async fn happy_multi_op_fetch_from_single_agent() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn happy_multi_op_fetch_from_multiple_agents() {
-    let builder = Arc::new(default_builder());
+    let builder = Arc::new(default_builder().with_default_config().unwrap());
     let peer_store = builder.peer_store.create(builder.clone()).await.unwrap();
     let config = CoreFetchConfig {
         parallel_request_count: 5,
@@ -347,7 +347,7 @@ async fn happy_multi_op_fetch_from_multiple_agents() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn ops_are_cleared_when_agent_not_in_peer_store() {
-    let builder = Arc::new(default_builder());
+    let builder = Arc::new(default_builder().with_default_config().unwrap());
     let peer_store = builder.peer_store.create(builder.clone()).await.unwrap();
     let config = CoreFetchConfig::default();
     let mock_transport = MockTransport::new(false);
@@ -379,7 +379,7 @@ async fn ops_are_cleared_when_agent_not_in_peer_store() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn unresponsive_agents_are_put_on_cool_down_list() {
-    let builder = Arc::new(default_builder());
+    let builder = Arc::new(default_builder().with_default_config().unwrap());
     let peer_store = builder.peer_store.create(builder.clone()).await.unwrap();
     let config = CoreFetchConfig::default();
     let mock_transport = MockTransport::new(true);
@@ -430,7 +430,7 @@ async fn unresponsive_agents_are_put_on_cool_down_list() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn add_ops_for_multiple_unresponsive_agents() {
-    let builder = Arc::new(default_builder());
+    let builder = Arc::new(default_builder().with_default_config().unwrap());
     let peer_store = builder.peer_store.create(builder.clone()).await.unwrap();
     let config = CoreFetchConfig::default();
     let mock_transport = MockTransport::new(true);
@@ -531,7 +531,7 @@ async fn add_ops_for_multiple_unresponsive_agents() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn agent_cooling_down_is_removed_from_list() {
-    let builder = Arc::new(default_builder());
+    let builder = Arc::new(default_builder().with_default_config().unwrap());
     let peer_store = builder.peer_store.create(builder.clone()).await.unwrap();
     let config = CoreFetchConfig {
         cool_down_interval_ms: 10,

--- a/crates/core/src/factories/core_kitsune.rs
+++ b/crates/core/src/factories/core_kitsune.rs
@@ -4,15 +4,6 @@ use kitsune2_api::{config::*, kitsune::*, *};
 use std::collections::HashMap;
 use std::sync::Arc;
 
-const MOD_NAME: &str = "CoreKitsune";
-
-/// Configuration parameters for [CoreKitsuneFactory].
-#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CoreKitsuneConfig {}
-
-impl ModConfig for CoreKitsuneConfig {}
-
 /// The core kitsune implementation provided by Kitsune2.
 /// You probably will have no reason to use something other than this.
 /// This abstraction is mainly here for testing purposes.
@@ -28,9 +19,7 @@ impl CoreKitsuneFactory {
 }
 
 impl KitsuneFactory for CoreKitsuneFactory {
-    fn default_config(&self, config: &mut Config) -> K2Result<()> {
-        config
-            .add_default_module_config::<CoreKitsuneConfig>(MOD_NAME.into())?;
+    fn default_config(&self, _config: &mut Config) -> K2Result<()> {
         Ok(())
     }
 
@@ -40,11 +29,8 @@ impl KitsuneFactory for CoreKitsuneFactory {
         handler: DynKitsuneHandler,
     ) -> BoxFut<'static, K2Result<DynKitsune>> {
         Box::pin(async move {
-            let config = builder
-                .config
-                .get_module_config::<CoreKitsuneConfig>(MOD_NAME)?;
             let out: DynKitsune =
-                Arc::new(CoreKitsune::new(builder.clone(), config, handler));
+                Arc::new(CoreKitsune::new(builder.clone(), handler));
             Ok(out)
         })
     }
@@ -64,7 +50,6 @@ struct CoreKitsune {
 impl CoreKitsune {
     pub fn new(
         builder: Arc<builder::Builder>,
-        _config: CoreKitsuneConfig,
         handler: DynKitsuneHandler,
     ) -> Self {
         Self {

--- a/crates/core/src/factories/core_kitsune.rs
+++ b/crates/core/src/factories/core_kitsune.rs
@@ -132,7 +132,12 @@ mod test {
 
         let k: DynKitsuneHandler = Arc::new(K);
 
-        let k = crate::default_builder().build(k).await.unwrap();
+        let k = crate::default_builder()
+            .with_default_config()
+            .unwrap()
+            .build(k)
+            .await
+            .unwrap();
 
         k.space(bytes::Bytes::from_static(b"space1").into())
             .await

--- a/crates/core/src/factories/core_space.rs
+++ b/crates/core/src/factories/core_space.rs
@@ -3,15 +3,6 @@
 use kitsune2_api::{config::*, space::*, *};
 use std::sync::Arc;
 
-const MOD_NAME: &str = "CoreSpace";
-
-/// Configuration parameters for [CoreSpaceFactory].
-#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct CoreSpaceConfig {}
-
-impl ModConfig for CoreSpaceConfig {}
-
 /// The core space implementation provided by Kitsune2.
 /// You probably will have no reason to use something other than this.
 /// This abstraction is mainly here for testing purposes.
@@ -27,8 +18,7 @@ impl CoreSpaceFactory {
 }
 
 impl SpaceFactory for CoreSpaceFactory {
-    fn default_config(&self, config: &mut Config) -> K2Result<()> {
-        config.add_default_module_config::<CoreSpaceConfig>(MOD_NAME.into())?;
+    fn default_config(&self, _config: &mut Config) -> K2Result<()> {
         Ok(())
     }
 
@@ -39,11 +29,8 @@ impl SpaceFactory for CoreSpaceFactory {
         _space: SpaceId,
     ) -> BoxFut<'static, K2Result<DynSpace>> {
         Box::pin(async move {
-            let config = builder
-                .config
-                .get_module_config::<CoreSpaceConfig>(MOD_NAME)?;
             let peer_store = builder.peer_store.create(builder.clone()).await?;
-            let out: DynSpace = Arc::new(CoreSpace::new(config, peer_store));
+            let out: DynSpace = Arc::new(CoreSpace::new(peer_store));
             Ok(out)
         })
     }
@@ -55,10 +42,7 @@ struct CoreSpace {
 }
 
 impl CoreSpace {
-    pub fn new(
-        _config: CoreSpaceConfig,
-        peer_store: peer_store::DynPeerStore,
-    ) -> Self {
+    pub fn new(peer_store: peer_store::DynPeerStore) -> Self {
         Self { peer_store }
     }
 }

--- a/crates/core/src/factories/mem_peer_store.rs
+++ b/crates/core/src/factories/mem_peer_store.rs
@@ -6,7 +6,7 @@ use std::sync::{Arc, Mutex};
 
 /// MemPeerStore configuration types.
 pub mod config {
-    /// Configuration parameters for [MemPeerStoreFactory]
+    /// Configuration parameters for [MemPeerStoreFactory](super::MemPeerStoreFactory).
     #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
     #[serde(rename_all = "camelCase")]
     pub struct MemPeerStoreConfig {

--- a/crates/core/src/factories/mem_peer_store/test.rs
+++ b/crates/core/src/factories/mem_peer_store/test.rs
@@ -5,7 +5,7 @@ use kitsune2_api::id::Id;
 fn create() -> Inner {
     Inner::new(
         MemPeerStoreConfig {
-            prune_interval: std::time::Duration::from_secs(10),
+            prune_interval_s: 10,
         },
         std::time::Instant::now(),
     )

--- a/crates/core/src/factories/mem_peer_store/test.rs
+++ b/crates/core/src/factories/mem_peer_store/test.rs
@@ -3,7 +3,12 @@ use kitsune2_api::id::Id;
 
 #[inline(always)]
 fn create() -> Inner {
-    Inner::new(MemPeerStoreConfig::default(), std::time::Instant::now())
+    Inner::new(
+        MemPeerStoreConfig {
+            prune_interval: std::time::Duration::from_secs(10),
+        },
+        std::time::Instant::now(),
+    )
 }
 
 const AGENT_1: AgentId = AgentId(Id(bytes::Bytes::from_static(b"agent1")));


### PR DESCRIPTION
- Does away with the `ModConfig` trait.
- We now just take anything Serializable for the `set_module_config` api.
- and can get anything that implements DeserializeOwned for the `get_module_config` api.
- Now supports runtime config alteration through `register_entry_update_cb` api.
- And adds some warnings for "this param may be unused" and "nobody's listening to this runtime update".