### PR TITLE
Op store split metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1031,7 +1031,6 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
- "sha2",
  "tokio",
  "tracing",
  "ureq",

--- a/crates/api/src/op_store.rs
+++ b/crates/api/src/op_store.rs
@@ -3,7 +3,6 @@
 use crate::{
     builder, config, BoxFut, DhtArc, K2Result, OpId, SpaceId, Timestamp,
 };
-use bytes::Bytes;
 use futures::future::BoxFuture;
 #[cfg(feature = "mockall")]
 use mockall::automock;
@@ -19,22 +18,14 @@ pub struct MetaOp {
     pub op_id: OpId,
 
     /// The actual op data.
-    pub op_data: Vec<u8>,
+    pub op_data: bytes::Bytes,
 }
 
 include!("../proto/gen/kitsune2.op_store.rs");
 
-impl From<MetaOp> for Op {
-    fn from(value: MetaOp) -> Self {
-        Self {
-            data: value.op_data.into(),
-        }
-    }
-}
-
-impl From<MetaOp> for Bytes {
-    fn from(value: MetaOp) -> Self {
-        value.op_data.into()
+impl From<bytes::Bytes> for Op {
+    fn from(value: bytes::Bytes) -> Self {
+        Self { data: value }
     }
 }
 
@@ -54,12 +45,12 @@ pub struct StoredOp {
     ///
     /// Note that this means any op implementation must include a consistent timestamp in the op
     /// data so that it can be provided back to Kitsune.
-    pub timestamp: Timestamp,
+    pub created_at: Timestamp,
 }
 
 impl Ord for StoredOp {
     fn cmp(&self, other: &Self) -> Ordering {
-        (&self.timestamp, &self.op_id).cmp(&(&other.timestamp, &other.op_id))
+        (&self.created_at, &self.op_id).cmp(&(&other.created_at, &other.op_id))
     }
 }
 
@@ -78,7 +69,7 @@ pub trait OpStore: 'static + Send + Sync + std::fmt::Debug {
     /// if it is able to process them.
     fn process_incoming_ops(
         &self,
-        op_list: Vec<Bytes>,
+        op_list: Vec<bytes::Bytes>,
     ) -> BoxFuture<'_, K2Result<()>>;
 
     /// Retrieve a batch of ops from the host by time range.
@@ -151,18 +142,12 @@ pub type DynOpStoreFactory = Arc<dyn OpStoreFactory>;
 
 #[cfg(test)]
 mod test {
-    use crate::MetaOp;
-
     use super::*;
     use prost::Message;
 
     #[test]
     fn happy_meta_op_encode_decode() {
-        let meta_op = MetaOp {
-            op_id: OpId::from(bytes::Bytes::from_static(b"some_op_id")),
-            op_data: vec![1; 128],
-        };
-        let op = Op::from(meta_op);
+        let op = Op::from(bytes::Bytes::from(vec![1; 128]));
         let op_enc = op.encode_to_vec();
         let op_dec = Op::decode(op_enc.as_slice()).unwrap();
 

--- a/crates/api/src/op_store.rs
+++ b/crates/api/src/op_store.rs
@@ -70,7 +70,7 @@ pub trait OpStore: 'static + Send + Sync + std::fmt::Debug {
     fn process_incoming_ops(
         &self,
         op_list: Vec<bytes::Bytes>,
-    ) -> BoxFuture<'_, K2Result<()>>;
+    ) -> BoxFuture<'_, K2Result<Vec<OpId>>>;
 
     /// Retrieve a batch of ops from the host by time range.
     ///

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -34,5 +34,4 @@ ed25519-dalek = { workspace = true, features = ["rand_core"] }
 kitsune2_api = { workspace = true, features = ["mockall"] }
 kitsune2_test_utils = { workspace = true }
 rand = { workspace = true }
-sha2 = { workspace = true }
 tokio = { workspace = true, features = ["full"] }

--- a/crates/core/src/factories/core_fetch.rs
+++ b/crates/core/src/factories/core_fetch.rs
@@ -424,7 +424,9 @@ impl CoreFetch {
                     tracing::error!("could not read ops from store: {err}");
                     continue;
                 }
-                Ok(ops) => ops,
+                Ok(ops) => {
+                    ops.into_iter().map(|op| op.op_data).collect::<Vec<_>>()
+                }
             };
 
             if ops.is_empty() {

--- a/crates/core/src/factories/core_fetch/message_handler.rs
+++ b/crates/core/src/factories/core_fetch/message_handler.rs
@@ -188,12 +188,9 @@ mod test {
         let peer = Url::from_str("wss://127.0.0.1:1").unwrap();
 
         let op = make_op(vec![0]);
-        let received_ops = vec![op];
-        let request_message = serialize_response_message(received_ops.clone());
-        let expected_ops_data = received_ops
-            .into_iter()
-            .map(|op| Bytes::from(op.op_data))
-            .collect::<Vec<_>>();
+        let expected_ops_data = vec![op.into()];
+        let request_message =
+            serialize_response_message(expected_ops_data.clone());
 
         let task_handle = tokio::task::spawn(async move {
             let ops = incoming_response_rx

--- a/crates/core/src/factories/core_fetch/test.rs
+++ b/crates/core/src/factories/core_fetch/test.rs
@@ -3,9 +3,9 @@ mod outgoing_request_queue;
 
 #[cfg(test)]
 pub(crate) mod utils {
-    use crate::factories::Kitsune2MemoryOp;
+    use crate::factories::MemoryOp;
     use bytes::Bytes;
-    use kitsune2_api::{id::Id, AgentId, MetaOp, OpId, Timestamp};
+    use kitsune2_api::{id::Id, AgentId, OpId, Timestamp};
     use rand::Rng;
 
     pub fn random_id() -> Id {
@@ -33,25 +33,7 @@ pub(crate) mod utils {
         ops
     }
 
-    pub fn hash_op(input: &bytes::Bytes) -> OpId {
-        use sha2::{Digest, Sha256};
-        let mut hasher = Sha256::new();
-        hasher.update(input);
-        let result = hasher.finalize();
-        let hash_bytes = bytes::Bytes::from(result.to_vec());
-        hash_bytes.into()
-    }
-
-    pub fn make_op(data: Vec<u8>) -> MetaOp {
-        let op_id = hash_op(&data.clone().into());
-        MetaOp {
-            op_id: op_id.clone(),
-            op_data: serde_json::to_vec(&Kitsune2MemoryOp::new(
-                op_id,
-                Timestamp::now(),
-                data,
-            ))
-            .unwrap(),
-        }
+    pub fn make_op(data: Vec<u8>) -> MemoryOp {
+        MemoryOp::new(Timestamp::now(), data)
     }
 }

--- a/crates/core/src/factories/core_fetch/test/incoming_request_queue.rs
+++ b/crates/core/src/factories/core_fetch/test/incoming_request_queue.rs
@@ -14,7 +14,7 @@ use kitsune2_api::{
     },
     id::Id,
     transport::MockTransport,
-    K2Error, MetaOp, SpaceId, Url,
+    K2Error, SpaceId, Url,
 };
 use kitsune2_test_utils::enable_tracing;
 use prost::Message;
@@ -213,18 +213,8 @@ async fn fail_to_respond_once_then_succeed() {
             let response =
                 Response::decode(K2FetchMessage::decode(data).unwrap().data)
                     .unwrap();
-            let ops = response
-                .ops
-                .into_iter()
-                .map(|op| {
-                    let memory_op =
-                        serde_json::from_slice::<MemoryOp>(&op.data).unwrap();
-                    MetaOp {
-                        op_id: memory_op.compute_op_id(),
-                        op_data: op.data,
-                    }
-                })
-                .collect::<Vec<_>>();
+            let ops: Vec<MemoryOp> =
+                response.ops.into_iter().map(Into::into).collect::<Vec<_>>();
             responses_sent.lock().unwrap().push((ops, peer));
             Box::pin(async move { Ok(()) })
         }

--- a/crates/core/src/factories/core_fetch/test/incoming_request_queue.rs
+++ b/crates/core/src/factories/core_fetch/test/incoming_request_queue.rs
@@ -2,11 +2,8 @@ use super::utils::random_op_id;
 use crate::{
     default_test_builder,
     factories::{
-        core_fetch::{
-            test::utils::{hash_op, make_op},
-            CoreFetch, CoreFetchConfig,
-        },
-        Kitsune2MemoryOp, MemOpStoreFactory,
+        core_fetch::{test::utils::make_op, CoreFetch, CoreFetchConfig},
+        MemOpStoreFactory, MemoryOp,
     },
 };
 use bytes::Bytes;
@@ -98,10 +95,12 @@ async fn respond_to_multiple_requests() {
         mock_transport.clone(),
     );
 
-    let requested_op_ids_1 =
-        serialize_request_message(vec![op_1.op_id.clone(), op_2.op_id.clone()]);
+    let requested_op_ids_1 = serialize_request_message(vec![
+        op_1.compute_op_id(),
+        op_2.compute_op_id(),
+    ]);
     let requested_op_ids_2 =
-        serialize_request_message(vec![op_3.op_id.clone(), random_op_id()]);
+        serialize_request_message(vec![op_3.compute_op_id(), random_op_id()]);
     fetch
         .message_handler
         .recv_module_msg(
@@ -218,13 +217,11 @@ async fn fail_to_respond_once_then_succeed() {
                 .ops
                 .into_iter()
                 .map(|op| {
-                    let op_data =
-                        serde_json::from_slice::<Kitsune2MemoryOp>(&op.data)
-                            .unwrap();
-                    let op_id = hash_op(&bytes::Bytes::from(op_data.payload));
+                    let memory_op =
+                        serde_json::from_slice::<MemoryOp>(&op.data).unwrap();
                     MetaOp {
-                        op_id,
-                        op_data: op.data.into(),
+                        op_id: memory_op.compute_op_id(),
+                        op_data: op.data,
                     }
                 })
                 .collect::<Vec<_>>();
@@ -251,7 +248,7 @@ async fn fail_to_respond_once_then_succeed() {
     );
 
     // Handle op request.
-    let data = serialize_request_message(vec![op.op_id]);
+    let data = serialize_request_message(vec![op.compute_op_id()]);
     fetch
         .message_handler
         .recv_module_msg(

--- a/crates/core/src/factories/mem_op_store.rs
+++ b/crates/core/src/factories/mem_op_store.rs
@@ -1,7 +1,6 @@
 //! The mem op store implementation provided by Kitsune2.
 
 use crate::factories::mem_op_store::time_slice_hash_store::TimeSliceHashStore;
-use bytes::Bytes;
 use futures::future::BoxFuture;
 use kitsune2_api::builder::Builder;
 use kitsune2_api::config::Config;
@@ -15,6 +14,9 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 
 mod time_slice_hash_store;
+
+#[cfg(test)]
+mod test;
 
 /// The mem op store implementation provided by Kitsune2.
 #[derive(Debug)]
@@ -48,56 +50,91 @@ impl OpStoreFactory for MemOpStoreFactory {
 /// This is a stub implementation of an op that will be serialized
 /// via serde_json (with inefficient encoding of the payload) to be
 /// used for testing purposes.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Kitsune2MemoryOp {
-    /// The id (hash) of the op
-    pub op_id: OpId,
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MemoryOp {
     /// The creation timestamp of this op
-    pub timestamp: Timestamp,
-    /// The payload of the op
-    pub payload: Vec<u8>,
+    pub created_at: Timestamp,
+    /// The data for the op
+    pub op_data: Vec<u8>,
 }
 
-impl Kitsune2MemoryOp {
-    /// Create a new [Kitsune2MemoryOp]
-    pub fn new(op_id: OpId, timestamp: Timestamp, payload: Vec<u8>) -> Self {
+impl MemoryOp {
+    /// Create a new [MemoryOp].
+    pub fn new(timestamp: Timestamp, payload: Vec<u8>) -> Self {
         Self {
-            op_id,
-            timestamp,
-            payload,
+            created_at: timestamp,
+            op_data: payload,
         }
+    }
+
+    /// Compute the op id for this op.
+    ///
+    /// Note that this produces predictable op ids for testing purposes.
+    /// It is simply the first 32 bytes of the op data.
+    pub fn compute_op_id(&self) -> OpId {
+        let mut value =
+            self.op_data.as_slice()[..32.min(self.op_data.len())].to_vec();
+        value.resize(32, 0);
+        OpId::from(bytes::Bytes::from(value))
     }
 }
 
-impl From<Kitsune2MemoryOp> for StoredOp {
-    fn from(value: Kitsune2MemoryOp) -> Self {
-        StoredOp {
-            op_id: value.op_id,
-            timestamp: value.timestamp,
-        }
-    }
-}
-
-impl From<Bytes> for Kitsune2MemoryOp {
-    fn from(value: Bytes) -> Self {
+impl From<bytes::Bytes> for MemoryOp {
+    fn from(value: bytes::Bytes) -> Self {
         serde_json::from_slice(&value)
-            .expect("failed to deserialize Kitsune2MemoryOp from Op")
+            .expect("failed to deserialize MemoryOp from bytes")
     }
 }
 
-impl From<Kitsune2MemoryOp> for Bytes {
-    fn from(value: Kitsune2MemoryOp) -> Self {
+impl From<MemoryOp> for bytes::Bytes {
+    fn from(value: MemoryOp) -> Self {
         serde_json::to_vec(&value)
-            .expect("failed to serialize Op to Kitsune2MemoryOp")
+            .expect("failed to serialize MemoryOp to bytes")
             .into()
     }
 }
 
-impl TryFrom<Op> for Kitsune2MemoryOp {
+/// This is the storage record for an op with computed fields.
+///
+/// Test data should create [MemoryOp]s and not be aware of this type.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct MemoryOpRecord {
+    /// The id (hash) of the op
+    pub op_id: OpId,
+    /// The creation timestamp of this op
+    pub created_at: Timestamp,
+    /// The timestamp at which this op was stored by us
+    pub stored_at: Timestamp,
+    /// The data for the op
+    pub op_data: Vec<u8>,
+}
+
+impl From<bytes::Bytes> for MemoryOpRecord {
+    fn from(value: bytes::Bytes) -> Self {
+        let inner: MemoryOp = value.into();
+        Self {
+            op_id: inner.compute_op_id(),
+            created_at: inner.created_at,
+            stored_at: Timestamp::now(),
+            op_data: inner.op_data,
+        }
+    }
+}
+
+impl From<MemoryOp> for StoredOp {
+    fn from(value: MemoryOp) -> Self {
+        StoredOp {
+            op_id: value.compute_op_id(),
+            created_at: value.created_at,
+        }
+    }
+}
+
+impl TryFrom<Op> for MemoryOp {
     type Error = serde_json::Error;
 
     fn try_from(value: Op) -> Result<Self, Self::Error> {
-        serde_json::from_slice(&value.data)
+        Ok(value.data.into())
     }
 }
 
@@ -126,20 +163,20 @@ impl std::ops::Deref for Kitsune2MemoryOpStore {
 
 #[derive(Debug, Default)]
 struct Kitsune2MemoryOpStoreInner {
-    op_list: HashMap<OpId, Kitsune2MemoryOp>,
+    op_list: HashMap<OpId, MemoryOpRecord>,
     time_slice_hashes: TimeSliceHashStore,
 }
 
 impl OpStore for Kitsune2MemoryOpStore {
     fn process_incoming_ops(
         &self,
-        op_list: Vec<Bytes>,
+        op_list: Vec<bytes::Bytes>,
     ) -> BoxFuture<'_, K2Result<()>> {
         Box::pin(async move {
             let ops_to_add = op_list
                 .iter()
-                .map(|op| -> serde_json::Result<(OpId, Kitsune2MemoryOp)> {
-                    let op = Kitsune2MemoryOp::from(op.clone());
+                .map(|op| -> serde_json::Result<(OpId, MemoryOpRecord)> {
+                    let op = MemoryOpRecord::from(op.clone());
                     Ok((op.op_id.clone(), op))
                 })
                 .collect::<Result<Vec<_>, _>>().map_err(|e| {
@@ -164,8 +201,8 @@ impl OpStore for Kitsune2MemoryOpStore {
                 .iter()
                 .filter(|(_, op)| {
                     let loc = op.op_id.loc();
-                    op.timestamp >= start
-                        && op.timestamp < end
+                    op.created_at >= start
+                        && op.created_at < end
                         && arc.contains(loc)
                 })
                 .map(|(op_id, _)| op_id.clone())
@@ -184,8 +221,11 @@ impl OpStore for Kitsune2MemoryOpStore {
                 .filter_map(|op_id| {
                     self_lock.op_list.get(op_id).map(|op| MetaOp {
                         op_id: op.op_id.clone(),
-                        op_data: serde_json::to_vec(op)
-                            .expect("Failed to serialize op"),
+                        op_data: MemoryOp {
+                            created_at: op.created_at,
+                            op_data: op.op_data.clone(),
+                        }
+                        .into(),
                     })
                 })
                 .collect())

--- a/crates/core/src/factories/mem_op_store.rs
+++ b/crates/core/src/factories/mem_op_store.rs
@@ -130,11 +130,9 @@ impl From<MemoryOp> for StoredOp {
     }
 }
 
-impl TryFrom<Op> for MemoryOp {
-    type Error = serde_json::Error;
-
-    fn try_from(value: Op) -> Result<Self, Self::Error> {
-        Ok(value.data.into())
+impl From<Op> for MemoryOp {
+    fn from(value: Op) -> Self {
+        value.data.into()
     }
 }
 

--- a/crates/core/src/factories/mem_op_store.rs
+++ b/crates/core/src/factories/mem_op_store.rs
@@ -171,7 +171,7 @@ impl OpStore for Kitsune2MemoryOpStore {
     fn process_incoming_ops(
         &self,
         op_list: Vec<bytes::Bytes>,
-    ) -> BoxFuture<'_, K2Result<()>> {
+    ) -> BoxFuture<'_, K2Result<Vec<OpId>>> {
         Box::pin(async move {
             let ops_to_add = op_list
                 .iter()
@@ -183,8 +183,12 @@ impl OpStore for Kitsune2MemoryOpStore {
                 K2Error::other_src("Failed to deserialize op data, are you using `Kitsune2MemoryOp`s?", e)
             })?;
 
+            let op_ids = ops_to_add
+                .iter()
+                .map(|(op_id, _)| op_id.clone())
+                .collect::<Vec<_>>();
             self.write().await.op_list.extend(ops_to_add);
-            Ok(())
+            Ok(op_ids)
         })
     }
 

--- a/crates/core/src/factories/mem_op_store/test.rs
+++ b/crates/core/src/factories/mem_op_store/test.rs
@@ -1,0 +1,25 @@
+use crate::factories::mem_op_store::Kitsune2MemoryOpStore;
+use crate::factories::MemoryOp;
+use kitsune2_api::{DynOpStore, SpaceId, Timestamp};
+use std::sync::Arc;
+
+#[tokio::test]
+async fn process_and_retrieve_op() {
+    let op_store: DynOpStore = Arc::new(Kitsune2MemoryOpStore::new(
+        SpaceId::from(bytes::Bytes::from_static(b"test")),
+    ));
+
+    let op = MemoryOp::new(Timestamp::now(), vec![1, 2, 3]);
+    let op_id = op.compute_op_id();
+    op_store
+        .process_incoming_ops(vec![op.clone().into()])
+        .await
+        .unwrap();
+
+    let retrieved = op_store.retrieve_ops(vec![op_id.clone()]).await.unwrap();
+    assert_eq!(retrieved.len(), 1);
+    assert_eq!(retrieved[0].op_id, op_id);
+
+    let out: MemoryOp = serde_json::from_slice(&retrieved[0].op_data).unwrap();
+    assert_eq!(op, out);
+}

--- a/crates/dht/src/dht/tests/harness.rs
+++ b/crates/dht/src/dht/tests/harness.rs
@@ -5,7 +5,7 @@ use crate::{Dht, DhtSnapshotNextAction};
 use kitsune2_api::{
     AgentId, DhtArc, DynOpStore, K2Result, OpId, StoredOp, Timestamp,
 };
-use kitsune2_core::factories::Kitsune2MemoryOp;
+use kitsune2_core::factories::MemoryOp;
 use rand::RngCore;
 use std::collections::HashMap;
 
@@ -49,7 +49,7 @@ impl DhtSyncHarness {
 
     pub(crate) async fn inject_ops(
         &mut self,
-        op_list: Vec<Kitsune2MemoryOp>,
+        op_list: Vec<MemoryOp>,
     ) -> K2Result<()> {
         self.store
             .process_incoming_ops(
@@ -375,13 +375,13 @@ async fn transfer_ops(
         .retrieve_ops(requested_ops)
         .await?
         .into_iter()
-        .map(Into::into)
+        .map(|op| op.op_data)
         .collect::<Vec<_>>();
     target.process_incoming_ops(selected.clone()).await?;
 
     let stored_ops = selected
         .into_iter()
-        .map(|op| Kitsune2MemoryOp::from(op).into())
+        .map(|op| MemoryOp::from(op).into())
         .collect::<Vec<StoredOp>>();
     target_dht.inform_ops_stored(stored_ops).await?;
 


### PR DESCRIPTION
The op store should ingest only op data. Hashes should be computed when data arrives so that we aren't trusting somebody else to do our hashing. The rest of this PR is consequences from trying to achieve that.

Within the op store, we want to be able to store more fields than the op contains. Like `stored_at` which I'm using on the gossip PR for incremental sync. That means we need to keep the op data model and the model the op store uses internally as separate types.

The big fiddle here was that I couldn't use the hash function that was added with the fetch queue inside the mem op store without destroying the DHT tests. Those need predictable IDs to get the ops into different parts of the DHT to test the location logic. I could spend time trying to find op data that places the ops in the right locations but predictable IDs seemed so much simpler for testing. So I'm just using the first 32 bytes of the op data as the id. If there isn't enough op data, then pad with 0.