### PR TITLE
Integrate fetch with gossip

### DIFF
--- a/crates/api/src/fetch.rs
+++ b/crates/api/src/fetch.rs
@@ -1,8 +1,8 @@
 //! Kitsune2 fetch types.
 
 use crate::{
-    builder, config, peer_store::DynPeerStore, transport::DynTransport,
-    AgentId, BoxFut, DynOpStore, K2Result, OpId, SpaceId,
+    builder, config, transport::DynTransport, BoxFut, DynOpStore, K2Result,
+    OpId, SpaceId, Url,
 };
 use bytes::{Bytes, BytesMut};
 use k2_fetch_message::FetchMessageType;
@@ -85,7 +85,7 @@ pub trait Fetch: 'static + Send + Sync + std::fmt::Debug {
     fn request_ops(
         &self,
         op_ids: Vec<OpId>,
-        from: AgentId,
+        source: Url,
     ) -> BoxFut<'_, K2Result<()>>;
 }
 
@@ -103,7 +103,6 @@ pub trait FetchFactory: 'static + Send + Sync + std::fmt::Debug {
         &self,
         builder: Arc<builder::Builder>,
         space_id: SpaceId,
-        peer_store: DynPeerStore,
         op_store: DynOpStore,
         transport: DynTransport,
     ) -> BoxFut<'static, K2Result<DynFetch>>;

--- a/crates/api/src/gossip.rs
+++ b/crates/api/src/gossip.rs
@@ -1,5 +1,6 @@
 //! Gossip related types.
 
+use crate::fetch::DynFetch;
 use crate::peer_store::DynPeerStore;
 use crate::space::DynSpace;
 use crate::transport::DynTransport;
@@ -31,6 +32,7 @@ pub trait GossipFactory: 'static + Send + Sync + std::fmt::Debug {
         peer_meta_store: DynPeerMetaStore,
         op_store: DynOpStore,
         transport: DynTransport,
+        fetch: DynFetch,
     ) -> BoxFut<'static, K2Result<DynGossip>>;
 }
 

--- a/crates/api/src/id.rs
+++ b/crates/api/src/id.rs
@@ -266,6 +266,30 @@ pub fn encode_ids(
     ids.into_iter().map(|id| id.deref().0.clone()).collect()
 }
 
+/// Decode a list of bytes into a list of typed IDs.
+///
+/// # Example
+///
+/// For example, a list of [AgentId]s can be decoded from a list of bytes.
+///
+/// ```
+/// use bytes::Bytes;
+/// use kitsune2_api::AgentId;
+/// use kitsune2_api::id::decode_ids;
+///
+/// let agents = vec![
+///     Bytes::from_static(b"agent1"),
+///     Bytes::from_static(b"agent2"),
+/// ];
+///
+/// let decoded_agents = decode_ids::<AgentId>(agents);
+/// ```
+pub fn decode_ids<T: From<Id>>(
+    ids: impl IntoIterator<Item = bytes::Bytes>,
+) -> Vec<T> {
+    ids.into_iter().map(Id).map(Into::into).collect()
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/crates/api/src/op_store.rs
+++ b/crates/api/src/op_store.rs
@@ -24,7 +24,7 @@ pub struct MetaOp {
 
 include!("../proto/gen/kitsune2.op_store.rs");
 
-impl From<bytes::Bytes> for Op {
+impl From<Bytes> for Op {
     fn from(value: Bytes) -> Self {
         Self { data: value }
     }

--- a/crates/core/src/factories/core_fetch/test.rs
+++ b/crates/core/src/factories/core_fetch/test.rs
@@ -6,8 +6,8 @@ mod outgoing_request_queue;
 pub(crate) mod utils {
     use crate::factories::MemoryOp;
     use bytes::Bytes;
-    use kitsune2_api::{id::Id, AgentId, OpId, Timestamp};
-    use rand::Rng;
+    use kitsune2_api::{id::Id, AgentId, OpId, Timestamp, Url};
+    use rand::{Rng, RngCore};
 
     pub fn random_id() -> Id {
         let mut rng = rand::thread_rng();
@@ -23,6 +23,11 @@ pub(crate) mod utils {
 
     pub fn random_agent_id() -> AgentId {
         AgentId(random_id())
+    }
+
+    pub fn random_peer_url() -> Url {
+        let id = rand::thread_rng().next_u32();
+        Url::from_str(format!("ws://test:80/{id}")).unwrap()
     }
 
     pub fn create_op_list(num_ops: u16) -> Vec<OpId> {

--- a/crates/core/src/factories/core_fetch/test/incoming_request_queue.rs
+++ b/crates/core/src/factories/core_fetch/test/incoming_request_queue.rs
@@ -33,7 +33,6 @@ struct TestCase {
 async fn setup_test() -> TestCase {
     let builder =
         Arc::new(default_test_builder().with_default_config().unwrap());
-    let peer_store = builder.peer_store.create(builder.clone()).await.unwrap();
     let op_store = MemOpStoreFactory::create()
         .create(builder.clone(), TEST_SPACE_ID)
         .await
@@ -45,7 +44,6 @@ async fn setup_test() -> TestCase {
     let fetch = CoreFetch::new(
         config.clone(),
         TEST_SPACE_ID,
-        peer_store.clone(),
         op_store.clone(),
         mock_transport.clone(),
     );
@@ -195,7 +193,6 @@ async fn no_response_sent_when_no_ops_found() {
 async fn fail_to_respond_once_then_succeed() {
     let builder =
         Arc::new(default_test_builder().with_default_config().unwrap());
-    let peer_store = builder.peer_store.create(builder.clone()).await.unwrap();
     let op_store = MemOpStoreFactory::create()
         .create(builder.clone(), TEST_SPACE_ID)
         .await
@@ -237,13 +234,8 @@ async fn fail_to_respond_once_then_succeed() {
         .unwrap();
     let agent_url = Url::from_str("wss://127.0.0.1:1").unwrap();
 
-    let fetch = CoreFetch::new(
-        config.clone(),
-        TEST_SPACE_ID,
-        peer_store.clone(),
-        op_store,
-        mock_transport,
-    );
+    let fetch =
+        CoreFetch::new(config.clone(), TEST_SPACE_ID, op_store, mock_transport);
 
     // Receive incoming request.
     let data = serialize_request_message(vec![op.compute_op_id()]);

--- a/crates/core/src/factories/core_gossip.rs
+++ b/crates/core/src/factories/core_gossip.rs
@@ -1,5 +1,6 @@
 use kitsune2_api::builder::Builder;
 use kitsune2_api::config::Config;
+use kitsune2_api::fetch::DynFetch;
 use kitsune2_api::peer_store::DynPeerStore;
 use kitsune2_api::space::DynSpace;
 use kitsune2_api::transport::{DynTransport, TxBaseHandler, TxModuleHandler};
@@ -39,6 +40,7 @@ impl GossipFactory for CoreGossipStubFactory {
         _peer_meta_store: DynPeerMetaStore,
         _op_store: DynOpStore,
         _transport: DynTransport,
+        _fetch: DynFetch,
     ) -> BoxFut<'static, K2Result<DynGossip>> {
         let out: DynGossip = Arc::new(CoreGossipStub);
         Box::pin(async move { Ok(out) })

--- a/crates/core/src/factories/core_gossip/test.rs
+++ b/crates/core/src/factories/core_gossip/test.rs
@@ -25,6 +25,12 @@ async fn create_gossip_instance() {
         .create(builder.clone(), Arc::new(NoopTxHandler))
         .await
         .unwrap();
+    let peer_store = builder.peer_store.create(builder.clone()).await.unwrap();
+    let op_store = builder
+        .op_store
+        .create(builder.clone(), space_id.clone())
+        .await
+        .unwrap();
     factory
         .create(
             builder.clone(),
@@ -39,18 +45,24 @@ async fn create_gossip_instance() {
                 )
                 .await
                 .unwrap(),
-            builder.peer_store.create(builder.clone()).await.unwrap(),
+            peer_store.clone(),
             builder
                 .peer_meta_store
                 .create(builder.clone())
                 .await
                 .unwrap(),
+            op_store.clone(),
+            tx.clone(),
             builder
-                .op_store
-                .create(builder.clone(), space_id)
+                .fetch
+                .create(
+                    builder.clone(),
+                    space_id.clone(),
+                    op_store.clone(),
+                    tx.clone(),
+                )
                 .await
                 .unwrap(),
-            tx,
         )
         .await
         .unwrap();

--- a/crates/gossip/src/gossip.rs
+++ b/crates/gossip/src/gossip.rs
@@ -9,6 +9,8 @@ use crate::state::{GossipRoundState, RoundStage};
 use crate::{K2GossipConfig, K2GossipModConfig, MOD_NAME};
 use bytes::Bytes;
 use kitsune2_api::agent::{AgentInfoSigned, DynVerifier};
+use kitsune2_api::fetch::DynFetch;
+use kitsune2_api::id::decode_ids;
 use kitsune2_api::peer_store::DynPeerStore;
 use kitsune2_api::space::{DynSpace, Space};
 use kitsune2_api::transport::{DynTransport, TxBaseHandler, TxModuleHandler};
@@ -50,6 +52,7 @@ impl GossipFactory for K2GossipFactory {
         peer_meta_store: DynPeerMetaStore,
         op_store: DynOpStore,
         transport: DynTransport,
+        fetch: DynFetch,
     ) -> kitsune2_api::BoxFut<'static, K2Result<DynGossip>> {
         Box::pin(async move {
             let config: K2GossipConfig = builder.config.get_module_config()?;
@@ -62,6 +65,7 @@ impl GossipFactory for K2GossipFactory {
                 peer_meta_store,
                 op_store,
                 transport,
+                fetch,
                 builder.verifier.clone(),
             ));
 
@@ -106,6 +110,7 @@ struct K2Gossip {
     peer_store: DynPeerStore,
     peer_meta_store: Arc<K2PeerMetaStore>,
     op_store: DynOpStore,
+    fetch: DynFetch,
     agent_verifier: DynVerifier,
     response_tx: Sender<GossipResponse>,
     _response_task: Arc<DropAbortHandle>,
@@ -122,6 +127,7 @@ impl K2Gossip {
         peer_meta_store: DynPeerMetaStore,
         op_store: DynOpStore,
         transport: DynTransport,
+        fetch: DynFetch,
         agent_verifier: DynVerifier,
     ) -> K2Gossip {
         let (response_tx, mut rx) =
@@ -159,6 +165,7 @@ impl K2Gossip {
                 space_id.clone(),
             )),
             op_store,
+            fetch,
             agent_verifier,
             response_tx,
             _response_task: Arc::new(DropAbortHandle {
@@ -402,8 +409,11 @@ impl K2Gossip {
                 )
                 .await?;
 
-                // TODO Send to fetch queue
-                println!("Discovered op ids: {:?}", accept.new_ops);
+                // Send discovered ops to the fetch queue
+                self.fetch
+                    .request_ops(decode_ids(accept.new_ops), from_peer.clone())
+                    .await?;
+
                 self.peer_meta_store
                     .set_new_ops_bookmark(
                         from_peer.clone(),
@@ -446,8 +456,9 @@ impl K2Gossip {
                 )
                 .await?;
 
-                // TODO Send to fetch queue
-                println!("Discovered op ids: {:?}", no_diff.new_ops);
+                self.fetch
+                    .request_ops(decode_ids(no_diff.new_ops), from_peer.clone())
+                    .await?;
                 self.peer_meta_store
                     .set_new_ops_bookmark(
                         from_peer.clone(),
@@ -714,9 +725,11 @@ mod test {
     use kitsune2_api::builder::Builder;
     use kitsune2_api::space::SpaceHandler;
     use kitsune2_api::transport::{TxHandler, TxSpaceHandler};
+    use kitsune2_api::OpId;
     use kitsune2_core::factories::MemoryOp;
     use kitsune2_core::{default_test_builder, Ed25519LocalAgent};
     use kitsune2_test_utils::enable_tracing;
+    use std::time::Duration;
 
     #[derive(Debug, Clone)]
     struct GossipTestHarness {
@@ -778,6 +791,43 @@ mod test {
             })
             .await
             .unwrap();
+        }
+
+        async fn wait_for_ops(&self, op_ids: Vec<OpId>) -> Vec<MemoryOp> {
+            tokio::time::timeout(Duration::from_millis(100), {
+                let this = self.clone();
+                async move {
+                    loop {
+                        tokio::time::sleep(Duration::from_millis(10)).await;
+
+                        let ops = this
+                            .op_store
+                            .retrieve_ops(op_ids.clone())
+                            .await
+                            .unwrap();
+
+                        if ops.len() != op_ids.len() {
+                            tracing::info!(
+                                "Have {}/{} requested ops",
+                                ops.len(),
+                                op_ids.len()
+                            );
+                            continue;
+                        }
+
+                        return ops
+                            .into_iter()
+                            .map(|op| {
+                                let out: MemoryOp = op.op_data.into();
+
+                                out
+                            })
+                            .collect::<Vec<_>>();
+                    }
+                }
+            })
+            .await
+            .unwrap()
         }
     }
 
@@ -845,6 +895,16 @@ mod test {
                     .unwrap(),
                 op_store.clone(),
                 transport.clone(),
+                self.builder
+                    .fetch
+                    .create(
+                        self.builder.clone(),
+                        self.space_id.clone(),
+                        op_store.clone(),
+                        transport.clone(),
+                    )
+                    .await
+                    .unwrap(),
                 self.builder.verifier.clone(),
             );
 
@@ -930,25 +990,21 @@ mod test {
         let factory = TestGossipFactory::create(space.clone()).await;
         let harness_1 = factory.new_instance().await;
         let agent_1 = harness_1.join_local_agent().await;
+        let op_1 = MemoryOp::new(Timestamp::now(), vec![1; 128]);
+        let op_id_1 = op_1.compute_op_id();
         harness_1
             .op_store
-            .process_incoming_ops(vec![MemoryOp::new(
-                Timestamp::now(),
-                vec![1; 128],
-            )
-            .into()])
+            .process_incoming_ops(vec![op_1.clone().into()])
             .await
             .unwrap();
 
         let harness_2 = factory.new_instance().await;
         harness_2.join_local_agent().await;
+        let op_2 = MemoryOp::new(Timestamp::now(), vec![2; 128]);
+        let op_id_2 = op_2.compute_op_id();
         harness_2
             .op_store
-            .process_incoming_ops(vec![MemoryOp::new(
-                Timestamp::now(),
-                vec![2; 128],
-            )
-            .into()])
+            .process_incoming_ops(vec![op_2.clone().into()])
             .await
             .unwrap();
 
@@ -958,8 +1014,12 @@ mod test {
             .await
             .unwrap();
 
-        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+        let received_ops = harness_1.wait_for_ops(vec![op_id_2]).await;
+        assert_eq!(1, received_ops.len());
+        assert_eq!(op_2, received_ops[0]);
 
-        // TODO fetch ops and assert that the op stores get updated.
+        let received_ops = harness_2.wait_for_ops(vec![op_id_1]).await;
+        assert_eq!(1, received_ops.len());
+        assert_eq!(op_1, received_ops[0]);
     }
 }


### PR DESCRIPTION
Most of this is renaming because the gossip isn't working with `AgentId`s, it's working with `Url`s.

When we gossip, we aren't gossiping with a single agent. I could list all peers and map a peer url back to an agent id... but then that agent might move and just because we can use the agent id to look up a peer url, that doesn't mean it's the right one.
On the other hand, when we store a peer url, there's no guarantee that the URL stays valid.

I think it's slightly better to fetch from a specific node by its `Url` and have to drop requests if that peer isn't handing us back ops, than it is to track by agent id which may or may not provide a Url that has the ops we originally discovered.

