### PR TITLE
Add core fetch integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,6 +1073,7 @@ dependencies = [
  "bytes",
  "futures",
  "kitsune2_api",
+ "rand",
  "tracing",
  "tracing-subscriber",
 ]

--- a/crates/core/src/factories/core_fetch/back_off.rs
+++ b/crates/core/src/factories/core_fetch/back_off.rs
@@ -120,7 +120,7 @@ impl BackOff {
 #[cfg(test)]
 mod test {
     use crate::factories::core_fetch::back_off::BackOffList;
-    use crate::factories::core_fetch::test::utils::random_peer_url;
+    use crate::factories::core_fetch::test::test_utils::random_peer_url;
 
     #[test]
     fn back_off() {

--- a/crates/core/src/factories/core_fetch/message_handler.rs
+++ b/crates/core/src/factories/core_fetch/message_handler.rs
@@ -24,14 +24,15 @@ impl TxModuleHandler for FetchMessageHandler {
         _module: String,
         data: bytes::Bytes,
     ) -> K2Result<()> {
+        tracing::debug!("receiving module message from {peer}");
         let fetch = K2FetchMessage::decode(data).map_err(|err| {
             K2Error::other_src(
                 format!("could not decode module message from {peer}"),
                 err,
             )
         })?;
-        match FetchMessageType::try_from(fetch.fetch_message_type) {
-            Ok(FetchMessageType::Request) => {
+        match fetch.fetch_message_type() {
+            FetchMessageType::Request => {
                 let request =
                     FetchRequest::decode(fetch.data).map_err(|err| {
                         K2Error::other_src(
@@ -48,7 +49,7 @@ impl TxModuleHandler for FetchMessageHandler {
                         )
                     })
             }
-            Ok(FetchMessageType::Response) => {
+            FetchMessageType::Response => {
                 let response =
                     FetchResponse::decode(fetch.data).map_err(|err| {
                         K2Error::other_src(
@@ -77,7 +78,7 @@ impl TxBaseHandler for FetchMessageHandler {}
 #[cfg(test)]
 mod test {
     use super::FetchMessageHandler;
-    use crate::factories::core_fetch::test::utils::{make_op, random_op_id};
+    use crate::factories::core_fetch::test::test_utils::make_op;
     use bytes::Bytes;
     use kitsune2_api::{
         fetch::{
@@ -88,6 +89,7 @@ mod test {
         transport::TxModuleHandler,
         SpaceId, Url,
     };
+    use kitsune2_test_utils::id::random_op_id;
     use prost::Message;
     use std::time::Duration;
 

--- a/crates/core/src/factories/core_fetch/test.rs
+++ b/crates/core/src/factories/core_fetch/test.rs
@@ -3,38 +3,22 @@ mod incoming_response_queue;
 mod outgoing_request_queue;
 
 #[cfg(test)]
-pub(crate) mod utils {
+pub(crate) mod test_utils {
     use crate::factories::MemoryOp;
-    use bytes::Bytes;
-    use kitsune2_api::{id::Id, AgentId, OpId, Timestamp, Url};
-    use rand::{Rng, RngCore};
-
-    pub fn random_id() -> Id {
-        let mut rng = rand::thread_rng();
-        let mut bytes = [0u8; 32];
-        rng.fill(&mut bytes);
-        let bytes = Bytes::from(bytes.to_vec());
-        Id(bytes)
-    }
-
-    pub fn random_op_id() -> OpId {
-        OpId(random_id())
-    }
-
-    pub fn random_agent_id() -> AgentId {
-        AgentId(random_id())
-    }
+    use kitsune2_api::{OpId, Timestamp, Url};
+    use kitsune2_test_utils::id::random_op_id;
+    use rand::RngCore;
 
     pub fn random_peer_url() -> Url {
         let id = rand::thread_rng().next_u32();
         Url::from_str(format!("ws://test:80/{id}")).unwrap()
     }
 
-    pub fn create_op_list(num_ops: u16) -> Vec<OpId> {
-        let mut ops = Vec::new();
+    pub fn create_op_id_list(num_ops: u16) -> Vec<OpId> {
+        let mut ops = Vec::with_capacity(num_ops as usize);
         for _ in 0..num_ops {
-            let op = random_op_id();
-            ops.push(op.clone());
+            let op_id = random_op_id();
+            ops.push(op_id);
         }
         ops
     }

--- a/crates/core/src/factories/core_space/test.rs
+++ b/crates/core/src/factories/core_space/test.rs
@@ -1,5 +1,5 @@
 use kitsune2_api::{kitsune::*, space::*, *};
-use kitsune2_test_utils::agent::*;
+use kitsune2_test_utils::{agent::*, space::TEST_SPACE_ID};
 use std::sync::{Arc, Mutex};
 
 macro_rules! iter_check {
@@ -54,7 +54,7 @@ async fn space_local_agent_join_leave() {
     let bob = Arc::new(TestLocalAgent::default()) as agent::DynLocalAgent;
     let ned = Arc::new(TestLocalAgent::default()) as agent::DynLocalAgent;
 
-    let s1 = k1.space(TEST_SPACE.clone()).await.unwrap();
+    let s1 = k1.space(TEST_SPACE_ID.clone()).await.unwrap();
 
     s1.local_agent_join(bob.clone()).await.unwrap();
     s1.local_agent_join(ned.clone()).await.unwrap();
@@ -153,7 +153,7 @@ async fn space_notify_send_recv() {
     .build(k)
     .await
     .unwrap();
-    let s1 = k1.space(TEST_SPACE.clone()).await.unwrap();
+    let s1 = k1.space(TEST_SPACE_ID.clone()).await.unwrap();
     let u1 = u_r.recv().await.unwrap();
 
     let k: DynKitsuneHandler = Arc::new(K(recv.clone(), u_s.clone()));
@@ -166,7 +166,7 @@ async fn space_notify_send_recv() {
     .build(k)
     .await
     .unwrap();
-    let s2 = k2.space(TEST_SPACE.clone()).await.unwrap();
+    let s2 = k2.space(TEST_SPACE_ID.clone()).await.unwrap();
     let u2 = u_r.recv().await.unwrap();
 
     println!("url: {u1}, {u2}");
@@ -198,7 +198,7 @@ async fn space_notify_send_recv() {
     let (t, f, s, d) = recv.lock().unwrap().remove(0);
     assert_eq!(bob.agent(), &t);
     assert_eq!(ned.agent(), &f);
-    assert_eq!(TEST_SPACE, s);
+    assert_eq!(TEST_SPACE_ID, s);
     assert_eq!("hello", String::from_utf8_lossy(&d));
 
     s2.send_notify(
@@ -212,7 +212,7 @@ async fn space_notify_send_recv() {
     let (t, f, s, d) = recv.lock().unwrap().remove(0);
     assert_eq!(ned.agent(), &t);
     assert_eq!(bob.agent(), &f);
-    assert_eq!(TEST_SPACE, s);
+    assert_eq!(TEST_SPACE_ID, s);
     assert_eq!("world", String::from_utf8_lossy(&d));
 }
 
@@ -297,7 +297,7 @@ async fn space_local_agent_periodic_re_sign_and_bootstrap() {
 
     let bob = Arc::new(TestLocalAgent::default()) as agent::DynLocalAgent;
 
-    let s1 = k1.space(TEST_SPACE.clone()).await.unwrap();
+    let s1 = k1.space(TEST_SPACE_ID.clone()).await.unwrap();
 
     s1.local_agent_join(bob.clone()).await.unwrap();
 

--- a/crates/core/tests/fetch.rs
+++ b/crates/core/tests/fetch.rs
@@ -1,0 +1,270 @@
+use kitsune2_api::{
+    builder::Builder,
+    fetch::DynFetch,
+    transport::{DynTransport, TxBaseHandler, TxHandler},
+    BoxFut, DynOpStore, OpId, Timestamp, Url,
+};
+use kitsune2_core::{
+    default_test_builder,
+    factories::{
+        core_fetch::config::{CoreFetchConfig, CoreFetchModConfig},
+        MemoryOp,
+    },
+};
+use kitsune2_test_utils::{enable_tracing, random_bytes, space::TEST_SPACE_ID};
+use std::{sync::Arc, time::Duration};
+
+#[derive(Debug)]
+struct MockTxHandler {
+    peer_url: std::sync::Mutex<Url>,
+}
+impl TxBaseHandler for MockTxHandler {
+    fn new_listening_address(&self, this_url: Url) -> BoxFut<'static, ()> {
+        *(self.peer_url.lock().unwrap()) = this_url;
+        Box::pin(async {})
+    }
+}
+impl TxHandler for MockTxHandler {}
+
+fn create_op_list(num_ops: u16) -> (Vec<MemoryOp>, Vec<OpId>) {
+    let mut ops = Vec::new();
+    let mut op_ids = Vec::new();
+    for _ in 0..num_ops {
+        let op = MemoryOp::new(Timestamp::now(), random_bytes(32));
+        let op_id = op.compute_op_id();
+        ops.push(op);
+        op_ids.push(op_id);
+    }
+    (ops, op_ids)
+}
+
+struct Peer {
+    builder: Arc<Builder>,
+    op_store: DynOpStore,
+    transport: DynTransport,
+    peer_url: Url,
+    fetch: Option<DynFetch>,
+}
+
+async fn make_peer(
+    fetch_config: Option<CoreFetchModConfig>,
+    create_fetch: bool,
+) -> Peer {
+    let builder =
+        Arc::new(default_test_builder().with_default_config().unwrap());
+    let op_store = builder
+        .op_store
+        .create(builder.clone(), TEST_SPACE_ID)
+        .await
+        .unwrap();
+    let tx_handler = Arc::new(MockTxHandler {
+        peer_url: std::sync::Mutex::new(
+            // Placeholder URL which will be overwritten when the transport is created.
+            Url::from_str("ws://127.0.0.1:80").unwrap(),
+        ),
+    });
+    let transport = builder
+        .transport
+        .create(builder.clone(), tx_handler.clone())
+        .await
+        .unwrap();
+    let peer_url = tx_handler.peer_url.lock().unwrap().clone();
+    if let Some(config) = fetch_config {
+        builder.config.set_module_config(&config).unwrap();
+    }
+    let fetch = if create_fetch {
+        Some(
+            builder
+                .fetch
+                .create(
+                    builder.clone(),
+                    TEST_SPACE_ID,
+                    op_store.clone(),
+                    transport.clone(),
+                )
+                .await
+                .unwrap(),
+        )
+    } else {
+        None
+    };
+
+    Peer {
+        builder,
+        op_store,
+        transport,
+        peer_url,
+        fetch,
+    }
+}
+
+async fn assert_ops_arrived_in_store(op_store: DynOpStore, op_ids: Vec<OpId>) {
+    tokio::time::timeout(Duration::from_millis(100), async {
+        loop {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            let ops_now_alice =
+                op_store.retrieve_ops(op_ids.clone()).await.unwrap();
+            let ops_now_bob =
+                op_store.retrieve_ops(op_ids.clone()).await.unwrap();
+            if ops_now_alice.len() == op_ids.len()
+                && ops_now_bob.len() == op_ids.len()
+            {
+                break;
+            }
+        }
+    })
+    .await
+    .unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn two_peer_fetch() {
+    enable_tracing();
+    let Peer {
+        fetch: fetch_alice,
+        op_store: op_store_alice,
+        peer_url: peer_url_alice,
+        ..
+    } = make_peer(None, true).await;
+    let fetch_alice = fetch_alice.unwrap();
+    let Peer {
+        fetch: fetch_bob,
+        op_store: op_store_bob,
+        peer_url: peer_url_bob,
+        ..
+    } = make_peer(None, true).await;
+    let fetch_bob = fetch_bob.unwrap();
+
+    let num_of_ops = 1;
+    let (requested_ops_alice, requested_op_ids_alice) =
+        create_op_list(num_of_ops);
+    let (requested_ops_bob, requested_op_ids_bob) = create_op_list(num_of_ops);
+
+    // Insert requested ops in Alice's and Bob's op store.
+    op_store_alice
+        .process_incoming_ops(
+            requested_ops_alice
+                .clone()
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+        )
+        .await
+        .unwrap();
+    op_store_bob
+        .process_incoming_ops(
+            requested_ops_bob
+                .clone()
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+        )
+        .await
+        .unwrap();
+
+    // Alice and Bob should not hold any of the ops to be requested from each other.
+    let ops_in_store_alice = op_store_alice
+        .retrieve_ops(requested_op_ids_bob.clone())
+        .await
+        .unwrap();
+    assert_eq!(ops_in_store_alice, vec![]);
+
+    let ops_in_store_bob = op_store_bob
+        .retrieve_ops(requested_op_ids_alice.clone())
+        .await
+        .unwrap();
+    assert_eq!(ops_in_store_bob, vec![]);
+
+    // Alice requests the ops from Bob.
+    fetch_alice
+        .request_ops(requested_op_ids_bob.clone(), peer_url_bob)
+        .await
+        .unwrap();
+    // Bob requests the ops from Alice.
+    fetch_bob
+        .request_ops(requested_op_ids_alice.clone(), peer_url_alice)
+        .await
+        .unwrap();
+
+    // Wait until Alice has fetched Bob's and Bob has fetched Alice's ops.
+    futures::future::join_all(vec![
+        assert_ops_arrived_in_store(op_store_alice, requested_op_ids_bob),
+        assert_ops_arrived_in_store(op_store_bob, requested_op_ids_alice),
+    ])
+    .await;
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn bob_comes_online_after_being_unresponsive() {
+    enable_tracing();
+    let fetch_config_alice = CoreFetchModConfig {
+        core_fetch: CoreFetchConfig {
+            first_back_off_interval_ms: 10,
+            re_insert_outgoing_request_delay_ms: 10,
+            ..Default::default()
+        },
+    };
+    let Peer {
+        fetch: fetch_alice,
+        op_store: op_store_alice,
+        transport: _transport_alice,
+        ..
+    } = make_peer(Some(fetch_config_alice), true).await;
+    let fetch_alice = fetch_alice.unwrap();
+
+    // Make Bob without fetch.
+    let Peer {
+        op_store: op_store_bob,
+        transport: transport_bob,
+        peer_url: peer_url_bob,
+        builder: builder_bob,
+        ..
+    } = make_peer(None, false).await;
+
+    let num_of_ops = 100;
+    let (requested_ops_bob, requested_op_ids_bob) = create_op_list(num_of_ops);
+
+    // Add Bob's ops to his store.
+    op_store_bob
+        .process_incoming_ops(
+            requested_ops_bob
+                .clone()
+                .into_iter()
+                .map(Into::into)
+                .collect(),
+        )
+        .await
+        .unwrap();
+
+    // Alice requests the ops from Bob.
+    fetch_alice
+        .request_ops(requested_op_ids_bob.clone(), peer_url_bob)
+        .await
+        .unwrap();
+
+    // Let some time pass for Alice to attempt sending a request to Bob
+    // and put him on the back off list.
+    tokio::time::sleep(Duration::from_millis(10)).await;
+
+    // Alice could not fetch ops from Bob.
+    let ops_in_store_alice = op_store_alice
+        .retrieve_ops(requested_op_ids_bob.clone())
+        .await
+        .unwrap();
+    assert_eq!(ops_in_store_alice, vec![]);
+
+    // Bob comes online. Fetch is kept to keep message handler live.
+    let _fetch_bob = builder_bob
+        .fetch
+        .create(
+            builder_bob.clone(),
+            TEST_SPACE_ID,
+            op_store_bob.clone(),
+            transport_bob,
+        )
+        .await
+        .unwrap();
+
+    // Wait until Alice has fetched Bob's ops.
+    assert_ops_arrived_in_store(op_store_alice, requested_op_ids_bob).await;
+}

--- a/crates/test_utils/Cargo.toml
+++ b/crates/test_utils/Cargo.toml
@@ -8,5 +8,6 @@ edition = "2021"
 bytes = { workspace = true }
 futures = { workspace = true }
 kitsune2_api = { workspace = true }
+rand = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/crates/test_utils/src/agent.rs
+++ b/crates/test_utils/src/agent.rs
@@ -1,11 +1,9 @@
-//! Test Utility helpers around agents and agent info.
+//! Test utilities associated with agents and agent info.
 
 use kitsune2_api::*;
 use std::sync::{Arc, Mutex};
 
-/// A default test space id.
-pub const TEST_SPACE: SpaceId =
-    SpaceId(id::Id(bytes::Bytes::from_static(b"test-space")));
+use crate::space::TEST_SPACE_ID;
 
 /// The test signature bytes.
 pub const TEST_SIG: &[u8] = b"test-signature";
@@ -139,7 +137,7 @@ impl AgentBuilder {
         a: A,
     ) -> Arc<agent::AgentInfoSigned> {
         let agent = self.agent.unwrap_or_else(|| a.agent().clone());
-        let space = self.space.unwrap_or_else(|| TEST_SPACE.clone());
+        let space = self.space.unwrap_or_else(|| TEST_SPACE_ID.clone());
         let created_at = self.created_at.unwrap_or_else(Timestamp::now);
         let expires_at = self.expires_at.unwrap_or_else(|| {
             created_at + std::time::Duration::from_secs(60 * 20)

--- a/crates/test_utils/src/id.rs
+++ b/crates/test_utils/src/id.rs
@@ -1,0 +1,21 @@
+//! Test utilities associated with ids.
+
+use bytes::Bytes;
+use kitsune2_api::{id::Id, AgentId, OpId};
+
+use crate::random_bytes;
+
+/// Create a random id.
+pub fn random_id() -> Id {
+    Id(Bytes::from(random_bytes(32)))
+}
+
+/// Create a random agent id.
+pub fn random_agent_id() -> AgentId {
+    AgentId(random_id())
+}
+
+/// Create a random op id.
+pub fn random_op_id() -> OpId {
+    OpId(random_id())
+}

--- a/crates/test_utils/src/lib.rs
+++ b/crates/test_utils/src/lib.rs
@@ -1,5 +1,7 @@
 #![deny(missing_docs)]
-//! Test Utilities to help with testing Kitsune2.
+//! Test utilities to help with testing Kitsune2.
+
+use rand::RngCore;
 
 /// Enable tracing with the RUST_LOG environment variable.
 ///
@@ -15,5 +17,14 @@ pub fn enable_tracing() {
         .try_init();
 }
 
+/// Create random bytes of a specified length.
+pub fn random_bytes(length: u16) -> Vec<u8> {
+    let mut rng = rand::thread_rng();
+    let mut bytes = vec![0; length as usize];
+    rng.fill_bytes(&mut bytes);
+    bytes
+}
+
 pub mod agent;
+pub mod id;
 pub mod space;

--- a/crates/test_utils/src/space.rs
+++ b/crates/test_utils/src/space.rs
@@ -1,4 +1,4 @@
-//! Test tools associated with Kitsune spaces.
+//! Test utilities associated with spaces.
 
 use bytes::Bytes;
 use kitsune2_api::{id::Id, SpaceId};


### PR DESCRIPTION
Adds two integration tests of the fetch module:
* One simple happy test of a recent gossip kind
* One where one peer isn't online at first and put on back-off, then comes online and fetch succeeds

More suggestions?

Also removes peer store from other tests.

resolves #65 