### PR TITLE
Integrate dht model

### DIFF
--- a/crates/api/src/op_store.rs
+++ b/crates/api/src/op_store.rs
@@ -110,6 +110,7 @@ pub trait OpStore: 'static + Send + Sync + std::fmt::Debug {
     /// # Returns
     ///
     /// As many op ids as can be returned within the `limit_bytes` limit.
+    // TODO Must respect an arc set because it is used within gossip!
     fn retrieve_op_ids_bounded(
         &self,
         start: Timestamp,

--- a/crates/api/src/op_store.rs
+++ b/crates/api/src/op_store.rs
@@ -120,7 +120,7 @@ pub trait OpStore: 'static + Send + Sync + std::fmt::Debug {
     fn store_slice_hash(
         &self,
         arc: DhtArc,
-        slice_id: u64,
+        slice_index: u64,
         slice_hash: Bytes,
     ) -> BoxFuture<'_, K2Result<()>>;
 
@@ -135,7 +135,7 @@ pub trait OpStore: 'static + Send + Sync + std::fmt::Debug {
     fn retrieve_slice_hash(
         &self,
         arc: DhtArc,
-        slice_id: u64,
+        slice_index: u64,
     ) -> BoxFuture<'_, K2Result<Option<Bytes>>>;
 
     /// Retrieve all slice hashes for a given arc.

--- a/crates/core/src/factories/core_space.rs
+++ b/crates/core/src/factories/core_space.rs
@@ -241,7 +241,6 @@ impl Space for CoreSpace {
     ) -> BoxFut<'_, K2Result<()>> {
         Box::pin(async move {
             // set some starting values
-            local_agent.set_tgt_storage_arc_hint(DhtArc::Empty);
             local_agent.set_cur_storage_arc(DhtArc::Empty);
 
             // update our local map

--- a/crates/core/src/factories/mem_op_store.rs
+++ b/crates/core/src/factories/mem_op_store.rs
@@ -298,14 +298,15 @@ impl OpStore for Kitsune2MemoryOpStore {
     fn store_slice_hash(
         &self,
         arc: DhtArc,
-        slice_id: u64,
+        slice_index: u64,
         slice_hash: bytes::Bytes,
     ) -> BoxFuture<'_, K2Result<()>> {
         Box::pin(async move {
-            self.write()
-                .await
-                .time_slice_hashes
-                .insert(arc, slice_id, slice_hash)
+            self.write().await.time_slice_hashes.insert(
+                arc,
+                slice_index,
+                slice_hash,
+            )
         })
     }
 
@@ -343,10 +344,10 @@ impl OpStore for Kitsune2MemoryOpStore {
     fn retrieve_slice_hash(
         &self,
         arc: DhtArc,
-        slice_id: u64,
+        slice_index: u64,
     ) -> BoxFuture<'_, K2Result<Option<bytes::Bytes>>> {
         Box::pin(async move {
-            Ok(self.read().await.time_slice_hashes.get(&arc, slice_id))
+            Ok(self.read().await.time_slice_hashes.get(&arc, slice_index))
         })
     }
 

--- a/crates/dht/src/arc_set.rs
+++ b/crates/dht/src/arc_set.rs
@@ -150,7 +150,7 @@ impl ArcSet {
     }
 
     /// Check whether a given sector index is included in this arc set.
-    pub(crate) fn includes_sector_index(&self, value: u32) -> bool {
+    pub fn includes_sector_index(&self, value: u32) -> bool {
         self.inner.contains(&value)
     }
 }

--- a/crates/dht/src/arc_set.rs
+++ b/crates/dht/src/arc_set.rs
@@ -10,7 +10,7 @@ use kitsune2_api::{DhtArc, K2Error, K2Result};
 use std::collections::HashSet;
 
 /// Represents a set of [DhtArc]s.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(test, derive(PartialEq))]
 pub struct ArcSet {
     inner: HashSet<u32>,

--- a/crates/dht/src/dht.rs
+++ b/crates/dht/src/dht.rs
@@ -22,6 +22,7 @@ use crate::arc_set::ArcSet;
 use crate::HashPartition;
 use kitsune2_api::{DynOpStore, K2Error, K2Result, OpId, StoredOp, Timestamp};
 use snapshot::{DhtSnapshot, SnapshotDiff};
+use std::fmt::Formatter;
 
 pub mod snapshot;
 #[cfg(test)]
@@ -34,6 +35,14 @@ mod tests;
 pub struct Dht {
     partition: HashPartition,
     store: DynOpStore,
+}
+
+impl std::fmt::Debug for Dht {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Dht")
+            .field("partition", &self.partition)
+            .finish()
+    }
 }
 
 /// The next action to take after comparing two DHT snapshots.

--- a/crates/dht/src/dht/snapshot.rs
+++ b/crates/dht/src/dht/snapshot.rs
@@ -11,7 +11,7 @@ use std::collections::{HashMap, HashSet};
 ///
 /// This is largely opaque to the user of the [crate::dht::Dht] model. It is intended to be sent
 /// between nodes to compare their DHT states and compared with [DhtSnapshot::compare].
-#[derive(Debug, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub enum DhtSnapshot {
     /// The default, smallest snapshot type.
     ///

--- a/crates/dht/src/hash.rs
+++ b/crates/dht/src/hash.rs
@@ -84,6 +84,9 @@ pub struct HashPartition {
 
 impl std::fmt::Debug for HashPartition {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Note that `sectors` are not included by default because it is a large amount of
+        // information to see on in logs. If you need to debug the stored data, then consider
+        // using the query methods to understand what is present.
         f.debug_struct("HashPartition")
             .field("size", &self.size)
             .finish()

--- a/crates/dht/src/hash.rs
+++ b/crates/dht/src/hash.rs
@@ -66,13 +66,12 @@ use crate::{TimePartition, SECTOR_SIZE};
 use kitsune2_api::{
     DhtArc, DynOpStore, K2Error, K2Result, StoredOp, Timestamp,
 };
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 /// A partition of the hash space into sectors.
 ///
 /// Partitions the hash structure into a fixed number of sectors. Each sector is
 /// responsible for managing the time slices for that sector using a [TimePartition].
-#[derive(Debug)]
 pub struct HashPartition {
     /// This is just a convenience for internal function use.
     /// This should always be exactly `(u32::MAX / self.partitioned_hashes.len()) + 1`.
@@ -81,6 +80,14 @@ pub struct HashPartition {
     ///
     /// That is, (2**0, 2**1, etc). It is currently always 512 and is not configurable.
     sectors: Vec<TimePartition>,
+}
+
+impl std::fmt::Debug for HashPartition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HashPartition")
+            .field("size", &self.size)
+            .finish()
+    }
 }
 
 pub(crate) type PartialTimeSliceDetails =
@@ -364,9 +371,8 @@ impl HashPartition {
         sector_indices: Vec<u32>,
         store: DynOpStore,
     ) -> K2Result<(HashMap<u32, HashMap<u64, bytes::Bytes>>, Timestamp)> {
-        let sectors_indices = sector_indices
-            .into_iter()
-            .collect::<std::collections::HashSet<_>>();
+        let sectors_indices =
+            sector_indices.into_iter().collect::<HashSet<_>>();
 
         let mut out = HashMap::new();
 
@@ -416,7 +422,7 @@ impl HashPartition {
             for ring_index in &ring_indices {
                 let hash = sector.partial_slice_hash(*ring_index)?;
 
-                // Important to capture that the ring didn't match even if the hash is empty and
+                // Important to capture that the ring didn't match even if the hash is empty, and
                 // therefore we won't communicate this sector.
                 let entry = out.entry(*ring_index).or_insert_with(HashMap::new);
                 if !hash.is_empty() {

--- a/crates/gossip/README.md
+++ b/crates/gossip/README.md
@@ -1,0 +1,25 @@
+
+```mermaid
+---
+title: Gossip Protocol
+---
+stateDiagram-v2
+    [*] --> init: Initiator sends agent ids, arc set and bookmark
+    init --> accept: Acceptor sends init fields + missing agents, new op ids, new bookmark, and a snapshot
+    
+    accept --> no_diff: Initiator snapshot matches + missing agents, new ops, new bookmark
+    accept --> disc_sector_diff: Initiator sends disc diff + missing agents, new ops, new bookmark
+    accept --> ring_sector_details_diff: Initiator sends ring diff + missing agents, new ops, new bookmark
+    
+    no_diff --> agents: Acceptors send agents
+    
+    disc_sector_diff --> disc_sector_details_diff: Acceptor sends disc diff
+    disc_sector_details_diff --> disc_sector_details_diff_response: Initiator sends disc diff + hashes
+    disc_sector_details_diff_response --> hashes: Acceptor sends hashes
+    
+    ring_sector_details_diff --> ring_sector_details_diff_response: Acceptor sends ring diff + hashes
+    ring_sector_details_diff_response --> hashes: Initiator sends hashes
+    
+    hashes --> [*]
+    agents --> [*]
+```

--- a/crates/gossip/README.md
+++ b/crates/gossip/README.md
@@ -7,7 +7,7 @@ stateDiagram-v2
     [*] --> init: Initiator sends agent ids, arc set and bookmark
     init --> accept: Acceptor sends init fields + missing agents, new op ids, new bookmark, and a snapshot
     
-    accept --> no_diff: Initiator snapshot matches + missing agents, new ops, new bookmark
+    accept --> no_diff: Initiator snapshot matches, send missing agents, new ops, new bookmark
     accept --> disc_sectors_diff: Initiator sends disc diff + missing agents, new ops, new bookmark
     accept --> ring_sector_details_diff: Initiator sends ring diff + missing agents, new ops, new bookmark
     

--- a/crates/gossip/README.md
+++ b/crates/gossip/README.md
@@ -8,12 +8,14 @@ stateDiagram-v2
     init --> accept: Acceptor sends init fields + missing agents, new op ids, new bookmark, and a snapshot
     
     accept --> no_diff: Initiator snapshot matches + missing agents, new ops, new bookmark
-    accept --> disc_sector_diff: Initiator sends disc diff + missing agents, new ops, new bookmark
+    accept --> disc_sectors_diff: Initiator sends disc diff + missing agents, new ops, new bookmark
     accept --> ring_sector_details_diff: Initiator sends ring diff + missing agents, new ops, new bookmark
     
-    no_diff --> agents: Acceptors send agents
+    no_diff --> agents: Acceptor send agents
+    disc_sectors_diff --> agents: Acceptor cannot compare, so sends only agents
+    ring_sector_details_diff --> agents: Acceptor cannot compare, so sends only agents 
     
-    disc_sector_diff --> disc_sector_details_diff: Acceptor sends disc diff
+    disc_sectors_diff --> disc_sector_details_diff: Acceptor sends disc diff
     disc_sector_details_diff --> disc_sector_details_diff_response: Initiator sends disc diff + hashes
     disc_sector_details_diff_response --> hashes: Acceptor sends hashes
     

--- a/crates/gossip/proto/gen/kitsune2.gossip.rs
+++ b/crates/gossip/proto/gen/kitsune2.gossip.rs
@@ -143,6 +143,8 @@ pub struct K2GossipInitiateMessage {
 ///
 /// Acceptable responses:
 /// - `K2GossipNoDiffMessage`
+/// - `K2GossipDiscSectorsDiffMessage`
+/// - `K2GossipRingSectorDetailsDiffMessage`
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct K2GossipAcceptMessage {
     #[prost(bytes = "bytes", tag = "1")]
@@ -209,6 +211,8 @@ pub struct K2GossipNoDiffMessage {
 /// A Kitsune2 gossip disc sectors diff protocol message.
 ///
 /// Acceptable responses:
+/// - `K2GossipDiscSectorDetailsDiffMessage`
+/// - `K2GossipAgentsMessage`
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct K2GossipDiscSectorsDiffMessage {
     #[prost(bytes = "bytes", tag = "1")]
@@ -253,6 +257,7 @@ pub struct SnapshotDiscSectorDetailsMessage {
 /// A Kitsune2 gossip disc sector details diff protocol message.
 ///
 /// Acceptable responses:
+/// - `K2GossipDiscSectorDetailsDiffResponseMessage`
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct K2GossipDiscSectorDetailsDiffMessage {
     #[prost(bytes = "bytes", tag = "1")]
@@ -266,6 +271,7 @@ pub struct K2GossipDiscSectorDetailsDiffMessage {
 /// A Kitsune2 gossip disc sector details diff protocol message.
 ///
 /// Acceptable responses:
+/// - `K2GossipHashesMessage`
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct K2GossipDiscSectorDetailsDiffResponseMessage {
     #[prost(bytes = "bytes", tag = "1")]
@@ -295,6 +301,8 @@ pub struct SnapshotRingSectorDetailsMessage {
 /// A Kitsune2 gossip ring sector details diff protocol message.
 ///
 /// Acceptable responses:
+/// - `K2GossipRingSectorDetailsDiffResponseMessage`
+/// - `K2GossipAgentsMessage`
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct K2GossipRingSectorDetailsDiffMessage {
     #[prost(bytes = "bytes", tag = "1")]
@@ -307,6 +315,7 @@ pub struct K2GossipRingSectorDetailsDiffMessage {
 /// A Kitsune2 gossip ring sector details diff response protocol message.
 ///
 /// Acceptable responses:
+/// - `K2GossipHashesMessage`
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct K2GossipRingSectorDetailsDiffResponseMessage {
     #[prost(bytes = "bytes", tag = "1")]

--- a/crates/gossip/proto/gen/kitsune2.gossip.rs
+++ b/crates/gossip/proto/gen/kitsune2.gossip.rs
@@ -11,6 +11,8 @@ pub struct K2GossipMessage {
 }
 /// Nested message and enum types in `K2GossipMessage`.
 pub mod k2_gossip_message {
+    /// / These enum variants correspond to `K2Gossip*Message` types,
+    /// / e.g. `INITIATE` -> `K2GossipInitiateMessage`.
     #[derive(
         Clone,
         Copy,

--- a/crates/gossip/proto/gen/kitsune2.gossip.rs
+++ b/crates/gossip/proto/gen/kitsune2.gossip.rs
@@ -11,8 +11,8 @@ pub struct K2GossipMessage {
 }
 /// Nested message and enum types in `K2GossipMessage`.
 pub mod k2_gossip_message {
-    /// / These enum variants correspond to `K2Gossip*Message` types,
-    /// / e.g. `INITIATE` -> `K2GossipInitiateMessage`.
+    /// These enum variants correspond to `K2Gossip*Message` types,
+    /// e.g. `INITIATE` -> `K2GossipInitiateMessage`.
     #[derive(
         Clone,
         Copy,
@@ -112,7 +112,7 @@ pub struct AcceptResponseMessage {
     /// The agent infos for the agents that were sent back in the missing_agents list in the acceptor's response.
     #[prost(bytes = "bytes", repeated, tag = "2")]
     pub provided_agents: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
-    /// Ops that we have stored since the timestamp provided by the acceptors in `new_since`.
+    /// Ops that we have stored since the timestamp provided by the acceptor in `new_since`.
     #[prost(bytes = "bytes", repeated, tag = "3")]
     pub new_ops: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
     /// Provide a new bookmark for the initiator. Any new ops will have been returned in `new_ops`
@@ -279,7 +279,7 @@ pub struct K2GossipDiscSectorDetailsDiffResponseMessage {
     #[prost(bytes = "bytes", tag = "1")]
     pub session_id: ::prost::bytes::Bytes,
     #[prost(bytes = "bytes", repeated, tag = "10")]
-    pub maybe_missing_ids: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
+    pub missing_ids: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
     #[prost(message, optional, tag = "20")]
     pub snapshot: ::core::option::Option<SnapshotDiscSectorDetailsMessage>,
 }
@@ -323,7 +323,7 @@ pub struct K2GossipRingSectorDetailsDiffResponseMessage {
     #[prost(bytes = "bytes", tag = "1")]
     pub session_id: ::prost::bytes::Bytes,
     #[prost(bytes = "bytes", repeated, tag = "10")]
-    pub maybe_missing_ids: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
+    pub missing_ids: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
     #[prost(message, optional, tag = "20")]
     pub snapshot: ::core::option::Option<SnapshotRingSectorDetailsMessage>,
 }
@@ -335,7 +335,7 @@ pub struct K2GossipHashesMessage {
     #[prost(bytes = "bytes", tag = "1")]
     pub session_id: ::prost::bytes::Bytes,
     #[prost(bytes = "bytes", repeated, tag = "10")]
-    pub maybe_missing_ids: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
+    pub missing_ids: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
 }
 /// A Kitsune2 gossip agents protocol message.
 ///

--- a/crates/gossip/proto/gen/kitsune2.gossip.rs
+++ b/crates/gossip/proto/gen/kitsune2.gossip.rs
@@ -33,10 +33,16 @@ pub mod k2_gossip_message {
         NoDiff = 3,
         /// A gossip disc sectors diff protocol message.
         DiscSectorsDiff = 4,
+        /// A gossip disc sector details diff protocol message.
+        DiscSectorDetailsDiff = 5,
+        /// A gossip disc sector details diff response protocol message.
+        DiscSectorDetailsResponseDiff = 6,
         /// A gossip ring sector details diff protocol message.
-        RingSectorDetailsDiff = 5,
+        RingSectorDetailsDiff = 7,
+        /// A gossip hashes protocol message.
+        Hashes = 8,
         /// A gossip agents protocol message.
-        Agents = 6,
+        Agents = 9,
     }
     impl GossipMessageType {
         /// String value of the enum field names used in the ProtoBuf definition.
@@ -50,7 +56,12 @@ pub mod k2_gossip_message {
                 Self::Accept => "ACCEPT",
                 Self::NoDiff => "NO_DIFF",
                 Self::DiscSectorsDiff => "DISC_SECTORS_DIFF",
+                Self::DiscSectorDetailsDiff => "DISC_SECTOR_DETAILS_DIFF",
+                Self::DiscSectorDetailsResponseDiff => {
+                    "DISC_SECTOR_DETAILS_RESPONSE_DIFF"
+                }
                 Self::RingSectorDetailsDiff => "RING_SECTOR_DETAILS_DIFF",
+                Self::Hashes => "HASHES",
                 Self::Agents => "AGENTS",
             }
         }
@@ -62,7 +73,12 @@ pub mod k2_gossip_message {
                 "ACCEPT" => Some(Self::Accept),
                 "NO_DIFF" => Some(Self::NoDiff),
                 "DISC_SECTORS_DIFF" => Some(Self::DiscSectorsDiff),
+                "DISC_SECTOR_DETAILS_DIFF" => Some(Self::DiscSectorDetailsDiff),
+                "DISC_SECTOR_DETAILS_RESPONSE_DIFF" => {
+                    Some(Self::DiscSectorDetailsResponseDiff)
+                }
                 "RING_SECTOR_DETAILS_DIFF" => Some(Self::RingSectorDetailsDiff),
+                "HASHES" => Some(Self::Hashes),
                 "AGENTS" => Some(Self::Agents),
                 _ => None,
             }
@@ -209,6 +225,23 @@ pub mod k2_gossip_disc_sectors_diff_message {
         pub disc_sector_hashes: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
     }
 }
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DiscSliceHashes {
+    #[prost(uint64, repeated, tag = "1")]
+    pub slice_indices: ::prost::alloc::vec::Vec<u64>,
+    #[prost(bytes = "bytes", repeated, tag = "2")]
+    pub hashes: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
+}
+/// Message representation of kitsune2_dht::DhtSnapshot::DiscSectorDetails
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SnapshotDiscSectorDetailsMessage {
+    #[prost(int64, tag = "1")]
+    pub disc_boundary: i64,
+    #[prost(uint32, repeated, tag = "2")]
+    pub sector_indices: ::prost::alloc::vec::Vec<u32>,
+    #[prost(message, repeated, tag = "3")]
+    pub disc_slice_hashes: ::prost::alloc::vec::Vec<DiscSliceHashes>,
+}
 /// A Kitsune2 gossip disc sector details diff protocol message.
 ///
 /// Acceptable responses:
@@ -216,30 +249,23 @@ pub mod k2_gossip_disc_sectors_diff_message {
 pub struct K2GossipDiscSectorDetailsDiffMessage {
     #[prost(bytes = "bytes", tag = "1")]
     pub session_id: ::prost::bytes::Bytes,
-    #[prost(message, optional, tag = "10")]
-    pub snapshot: ::core::option::Option<
-        k2_gossip_disc_sector_details_diff_message::SnapshotDiscSectorDetailsMessage,
-    >,
+    /// The agent infos for the agents that were sent back in the missing_agents list of the previous message.
+    #[prost(bytes = "bytes", repeated, tag = "10")]
+    pub provided_agents: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
+    #[prost(message, optional, tag = "20")]
+    pub snapshot: ::core::option::Option<SnapshotDiscSectorDetailsMessage>,
 }
-/// Nested message and enum types in `K2GossipDiscSectorDetailsDiffMessage`.
-pub mod k2_gossip_disc_sector_details_diff_message {
-    #[derive(Clone, PartialEq, ::prost::Message)]
-    pub struct DiscSliceHashes {
-        #[prost(uint32, repeated, tag = "1")]
-        pub slice_indices: ::prost::alloc::vec::Vec<u32>,
-        #[prost(bytes = "bytes", repeated, tag = "2")]
-        pub hash: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
-    }
-    /// Message representation of kitsune2_dht::DhtSnapshot::DiscSectorDetails
-    #[derive(Clone, PartialEq, ::prost::Message)]
-    pub struct SnapshotDiscSectorDetailsMessage {
-        #[prost(int64, tag = "1")]
-        pub disc_boundary: i64,
-        #[prost(uint32, repeated, tag = "2")]
-        pub sector_indices: ::prost::alloc::vec::Vec<u32>,
-        #[prost(message, repeated, tag = "3")]
-        pub disc_slice_hashes: ::prost::alloc::vec::Vec<DiscSliceHashes>,
-    }
+/// A Kitsune2 gossip disc sector details diff protocol message.
+///
+/// Acceptable responses:
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct K2GossipDiscSectorDetailsDiffResponseMessage {
+    #[prost(bytes = "bytes", tag = "1")]
+    pub session_id: ::prost::bytes::Bytes,
+    #[prost(bytes = "bytes", repeated, tag = "10")]
+    pub maybe_missing_ids: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
+    #[prost(message, optional, tag = "20")]
+    pub snapshot: ::core::option::Option<SnapshotDiscSectorDetailsMessage>,
 }
 /// A Kitsune2 gossip ring sector details diff protocol message.
 ///
@@ -274,6 +300,16 @@ pub mod k2_gossip_ring_sector_details_diff_message {
         #[prost(message, repeated, tag = "3")]
         pub ring_sector_hashes: ::prost::alloc::vec::Vec<RingSectorHashes>,
     }
+}
+/// A Kitsune2 gossip hashes protocol message.
+///
+/// This message is a final message when used in a gossip round.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct K2GossipHashesMessage {
+    #[prost(bytes = "bytes", tag = "1")]
+    pub session_id: ::prost::bytes::Bytes,
+    #[prost(bytes = "bytes", repeated, tag = "10")]
+    pub maybe_missing_ids: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
 }
 /// A Kitsune2 gossip agents protocol message.
 ///

--- a/crates/gossip/proto/gen/kitsune2.gossip.rs
+++ b/crates/gossip/proto/gen/kitsune2.gossip.rs
@@ -76,60 +76,6 @@ pub struct ArcSetMessage {
     #[prost(uint32, repeated, tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u32>,
 }
-/// Message representation of kitsune2_dht::DhtSnapshot::Minimal
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct SnapshotMinimalMessage {
-    #[prost(int64, tag = "1")]
-    pub disc_boundary: i64,
-    #[prost(bytes = "bytes", tag = "2")]
-    pub disc_top_hash: ::prost::bytes::Bytes,
-    #[prost(bytes = "bytes", repeated, tag = "3")]
-    pub ring_top_hashes: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
-}
-/// Message representation of kitsune2_dht::DhtSnapshot::DiscSectors
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct SnapshotDiscSectorsMessage {
-    #[prost(int64, tag = "1")]
-    pub disc_boundary: i64,
-    #[prost(uint32, repeated, tag = "2")]
-    pub disc_sectors: ::prost::alloc::vec::Vec<u32>,
-    #[prost(bytes = "bytes", repeated, tag = "3")]
-    pub disc_sector_hashes: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct DiscSliceHashes {
-    #[prost(uint32, repeated, tag = "1")]
-    pub slice_indices: ::prost::alloc::vec::Vec<u32>,
-    #[prost(bytes = "bytes", repeated, tag = "2")]
-    pub hash: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
-}
-/// Message representation of kitsune2_dht::DhtSnapshot::DiscSectorDetails
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct SnapshotDiscSectorDetailsMessage {
-    #[prost(int64, tag = "1")]
-    pub disc_boundary: i64,
-    #[prost(uint32, repeated, tag = "2")]
-    pub sector_indices: ::prost::alloc::vec::Vec<u32>,
-    #[prost(message, repeated, tag = "3")]
-    pub disc_slice_hashes: ::prost::alloc::vec::Vec<DiscSliceHashes>,
-}
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct RingSectorHashes {
-    #[prost(uint32, repeated, tag = "1")]
-    pub sector_indices: ::prost::alloc::vec::Vec<u32>,
-    #[prost(bytes = "bytes", repeated, tag = "2")]
-    pub hashes: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
-}
-/// Message representation of kitsune2_dht::DhtSnapshot::RingSectorDetails
-#[derive(Clone, PartialEq, ::prost::Message)]
-pub struct SnapshotRingSectorDetailsMessage {
-    #[prost(int64, tag = "1")]
-    pub disc_boundary: i64,
-    #[prost(uint32, repeated, tag = "2")]
-    pub ring_indices: ::prost::alloc::vec::Vec<u32>,
-    #[prost(message, repeated, tag = "3")]
-    pub ring_sector_hashes: ::prost::alloc::vec::Vec<RingSectorHashes>,
-}
 /// Common fields to be sent in response to an accept message
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct AcceptResponseMessage {
@@ -202,7 +148,22 @@ pub struct K2GossipAcceptMessage {
     pub updated_new_since: i64,
     /// The DHT snapshot of the acceptor.
     #[prost(message, optional, tag = "30")]
-    pub snapshot: ::core::option::Option<SnapshotMinimalMessage>,
+    pub snapshot: ::core::option::Option<
+        k2_gossip_accept_message::SnapshotMinimalMessage,
+    >,
+}
+/// Nested message and enum types in `K2GossipAcceptMessage`.
+pub mod k2_gossip_accept_message {
+    /// Message representation of kitsune2_dht::DhtSnapshot::Minimal
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct SnapshotMinimalMessage {
+        #[prost(int64, tag = "1")]
+        pub disc_boundary: i64,
+        #[prost(bytes = "bytes", tag = "2")]
+        pub disc_top_hash: ::prost::bytes::Bytes,
+        #[prost(bytes = "bytes", repeated, tag = "3")]
+        pub ring_top_hashes: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
+    }
 }
 /// A Kitsune2 gossip no diff protocol message.
 ///
@@ -231,7 +192,54 @@ pub struct K2GossipDiscSectorsDiffMessage {
     #[prost(message, optional, tag = "2")]
     pub accept_response: ::core::option::Option<AcceptResponseMessage>,
     #[prost(message, optional, tag = "10")]
-    pub snapshot: ::core::option::Option<SnapshotDiscSectorsMessage>,
+    pub snapshot: ::core::option::Option<
+        k2_gossip_disc_sectors_diff_message::SnapshotDiscSectorsMessage,
+    >,
+}
+/// Nested message and enum types in `K2GossipDiscSectorsDiffMessage`.
+pub mod k2_gossip_disc_sectors_diff_message {
+    /// Message representation of kitsune2_dht::DhtSnapshot::DiscSectors
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct SnapshotDiscSectorsMessage {
+        #[prost(int64, tag = "1")]
+        pub disc_boundary: i64,
+        #[prost(uint32, repeated, tag = "2")]
+        pub disc_sectors: ::prost::alloc::vec::Vec<u32>,
+        #[prost(bytes = "bytes", repeated, tag = "3")]
+        pub disc_sector_hashes: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
+    }
+}
+/// A Kitsune2 gossip disc sector details diff protocol message.
+///
+/// Acceptable responses:
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct K2GossipDiscSectorDetailsDiffMessage {
+    #[prost(bytes = "bytes", tag = "1")]
+    pub session_id: ::prost::bytes::Bytes,
+    #[prost(message, optional, tag = "10")]
+    pub snapshot: ::core::option::Option<
+        k2_gossip_disc_sector_details_diff_message::SnapshotDiscSectorDetailsMessage,
+    >,
+}
+/// Nested message and enum types in `K2GossipDiscSectorDetailsDiffMessage`.
+pub mod k2_gossip_disc_sector_details_diff_message {
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct DiscSliceHashes {
+        #[prost(uint32, repeated, tag = "1")]
+        pub slice_indices: ::prost::alloc::vec::Vec<u32>,
+        #[prost(bytes = "bytes", repeated, tag = "2")]
+        pub hash: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
+    }
+    /// Message representation of kitsune2_dht::DhtSnapshot::DiscSectorDetails
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct SnapshotDiscSectorDetailsMessage {
+        #[prost(int64, tag = "1")]
+        pub disc_boundary: i64,
+        #[prost(uint32, repeated, tag = "2")]
+        pub sector_indices: ::prost::alloc::vec::Vec<u32>,
+        #[prost(message, repeated, tag = "3")]
+        pub disc_slice_hashes: ::prost::alloc::vec::Vec<DiscSliceHashes>,
+    }
 }
 /// A Kitsune2 gossip ring sector details diff protocol message.
 ///
@@ -243,7 +251,29 @@ pub struct K2GossipRingSectorDetailsDiffMessage {
     #[prost(message, optional, tag = "2")]
     pub accept_response: ::core::option::Option<AcceptResponseMessage>,
     #[prost(message, optional, tag = "10")]
-    pub snapshot: ::core::option::Option<SnapshotRingSectorDetailsMessage>,
+    pub snapshot: ::core::option::Option<
+        k2_gossip_ring_sector_details_diff_message::SnapshotRingSectorDetailsMessage,
+    >,
+}
+/// Nested message and enum types in `K2GossipRingSectorDetailsDiffMessage`.
+pub mod k2_gossip_ring_sector_details_diff_message {
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct RingSectorHashes {
+        #[prost(uint32, repeated, tag = "1")]
+        pub sector_indices: ::prost::alloc::vec::Vec<u32>,
+        #[prost(bytes = "bytes", repeated, tag = "2")]
+        pub hashes: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
+    }
+    /// Message representation of kitsune2_dht::DhtSnapshot::RingSectorDetails
+    #[derive(Clone, PartialEq, ::prost::Message)]
+    pub struct SnapshotRingSectorDetailsMessage {
+        #[prost(int64, tag = "1")]
+        pub disc_boundary: i64,
+        #[prost(uint32, repeated, tag = "2")]
+        pub ring_indices: ::prost::alloc::vec::Vec<u32>,
+        #[prost(message, repeated, tag = "3")]
+        pub ring_sector_hashes: ::prost::alloc::vec::Vec<RingSectorHashes>,
+    }
 }
 /// A Kitsune2 gossip agents protocol message.
 ///

--- a/crates/gossip/proto/gen/kitsune2.gossip.rs
+++ b/crates/gossip/proto/gen/kitsune2.gossip.rs
@@ -36,13 +36,15 @@ pub mod k2_gossip_message {
         /// A gossip disc sector details diff protocol message.
         DiscSectorDetailsDiff = 5,
         /// A gossip disc sector details diff response protocol message.
-        DiscSectorDetailsResponseDiff = 6,
+        DiscSectorDetailsDiffResponse = 6,
         /// A gossip ring sector details diff protocol message.
         RingSectorDetailsDiff = 7,
+        /// A gossip ring sector details diff response protocol message.
+        RingSectorDetailsDiffResponse = 8,
         /// A gossip hashes protocol message.
-        Hashes = 8,
+        Hashes = 9,
         /// A gossip agents protocol message.
-        Agents = 9,
+        Agents = 10,
     }
     impl GossipMessageType {
         /// String value of the enum field names used in the ProtoBuf definition.
@@ -57,10 +59,13 @@ pub mod k2_gossip_message {
                 Self::NoDiff => "NO_DIFF",
                 Self::DiscSectorsDiff => "DISC_SECTORS_DIFF",
                 Self::DiscSectorDetailsDiff => "DISC_SECTOR_DETAILS_DIFF",
-                Self::DiscSectorDetailsResponseDiff => {
-                    "DISC_SECTOR_DETAILS_RESPONSE_DIFF"
+                Self::DiscSectorDetailsDiffResponse => {
+                    "DISC_SECTOR_DETAILS_DIFF_RESPONSE"
                 }
                 Self::RingSectorDetailsDiff => "RING_SECTOR_DETAILS_DIFF",
+                Self::RingSectorDetailsDiffResponse => {
+                    "RING_SECTOR_DETAILS_DIFF_RESPONSE"
+                }
                 Self::Hashes => "HASHES",
                 Self::Agents => "AGENTS",
             }
@@ -74,10 +79,13 @@ pub mod k2_gossip_message {
                 "NO_DIFF" => Some(Self::NoDiff),
                 "DISC_SECTORS_DIFF" => Some(Self::DiscSectorsDiff),
                 "DISC_SECTOR_DETAILS_DIFF" => Some(Self::DiscSectorDetailsDiff),
-                "DISC_SECTOR_DETAILS_RESPONSE_DIFF" => {
-                    Some(Self::DiscSectorDetailsResponseDiff)
+                "DISC_SECTOR_DETAILS_DIFF_RESPONSE" => {
+                    Some(Self::DiscSectorDetailsDiffResponse)
                 }
                 "RING_SECTOR_DETAILS_DIFF" => Some(Self::RingSectorDetailsDiff),
+                "RING_SECTOR_DETAILS_DIFF_RESPONSE" => {
+                    Some(Self::RingSectorDetailsDiffResponse)
+                }
                 "HASHES" => Some(Self::Hashes),
                 "AGENTS" => Some(Self::Agents),
                 _ => None,
@@ -267,6 +275,23 @@ pub struct K2GossipDiscSectorDetailsDiffResponseMessage {
     #[prost(message, optional, tag = "20")]
     pub snapshot: ::core::option::Option<SnapshotDiscSectorDetailsMessage>,
 }
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RingSectorHashes {
+    #[prost(uint32, repeated, tag = "1")]
+    pub sector_indices: ::prost::alloc::vec::Vec<u32>,
+    #[prost(bytes = "bytes", repeated, tag = "2")]
+    pub hashes: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
+}
+/// Message representation of kitsune2_dht::DhtSnapshot::RingSectorDetails
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SnapshotRingSectorDetailsMessage {
+    #[prost(int64, tag = "1")]
+    pub disc_boundary: i64,
+    #[prost(uint32, repeated, tag = "2")]
+    pub ring_indices: ::prost::alloc::vec::Vec<u32>,
+    #[prost(message, repeated, tag = "3")]
+    pub ring_sector_hashes: ::prost::alloc::vec::Vec<RingSectorHashes>,
+}
 /// A Kitsune2 gossip ring sector details diff protocol message.
 ///
 /// Acceptable responses:
@@ -274,32 +299,22 @@ pub struct K2GossipDiscSectorDetailsDiffResponseMessage {
 pub struct K2GossipRingSectorDetailsDiffMessage {
     #[prost(bytes = "bytes", tag = "1")]
     pub session_id: ::prost::bytes::Bytes,
-    #[prost(message, optional, tag = "2")]
-    pub accept_response: ::core::option::Option<AcceptResponseMessage>,
     #[prost(message, optional, tag = "10")]
-    pub snapshot: ::core::option::Option<
-        k2_gossip_ring_sector_details_diff_message::SnapshotRingSectorDetailsMessage,
-    >,
+    pub accept_response: ::core::option::Option<AcceptResponseMessage>,
+    #[prost(message, optional, tag = "20")]
+    pub snapshot: ::core::option::Option<SnapshotRingSectorDetailsMessage>,
 }
-/// Nested message and enum types in `K2GossipRingSectorDetailsDiffMessage`.
-pub mod k2_gossip_ring_sector_details_diff_message {
-    #[derive(Clone, PartialEq, ::prost::Message)]
-    pub struct RingSectorHashes {
-        #[prost(uint32, repeated, tag = "1")]
-        pub sector_indices: ::prost::alloc::vec::Vec<u32>,
-        #[prost(bytes = "bytes", repeated, tag = "2")]
-        pub hashes: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
-    }
-    /// Message representation of kitsune2_dht::DhtSnapshot::RingSectorDetails
-    #[derive(Clone, PartialEq, ::prost::Message)]
-    pub struct SnapshotRingSectorDetailsMessage {
-        #[prost(int64, tag = "1")]
-        pub disc_boundary: i64,
-        #[prost(uint32, repeated, tag = "2")]
-        pub ring_indices: ::prost::alloc::vec::Vec<u32>,
-        #[prost(message, repeated, tag = "3")]
-        pub ring_sector_hashes: ::prost::alloc::vec::Vec<RingSectorHashes>,
-    }
+/// A Kitsune2 gossip ring sector details diff response protocol message.
+///
+/// Acceptable responses:
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct K2GossipRingSectorDetailsDiffResponseMessage {
+    #[prost(bytes = "bytes", tag = "1")]
+    pub session_id: ::prost::bytes::Bytes,
+    #[prost(bytes = "bytes", repeated, tag = "10")]
+    pub maybe_missing_ids: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
+    #[prost(message, optional, tag = "20")]
+    pub snapshot: ::core::option::Option<SnapshotRingSectorDetailsMessage>,
 }
 /// A Kitsune2 gossip hashes protocol message.
 ///

--- a/crates/gossip/proto/gen/kitsune2.gossip.rs
+++ b/crates/gossip/proto/gen/kitsune2.gossip.rs
@@ -31,8 +31,12 @@ pub mod k2_gossip_message {
         Accept = 2,
         /// A gossip no diff protocol message.
         NoDiff = 3,
+        /// A gossip disc sectors diff protocol message.
+        DiscSectorsDiff = 4,
+        /// A gossip ring sector details diff protocol message.
+        RingSectorDetailsDiff = 5,
         /// A gossip agents protocol message.
-        Agents = 4,
+        Agents = 6,
     }
     impl GossipMessageType {
         /// String value of the enum field names used in the ProtoBuf definition.
@@ -45,6 +49,8 @@ pub mod k2_gossip_message {
                 Self::Initiate => "INITIATE",
                 Self::Accept => "ACCEPT",
                 Self::NoDiff => "NO_DIFF",
+                Self::DiscSectorsDiff => "DISC_SECTORS_DIFF",
+                Self::RingSectorDetailsDiff => "RING_SECTOR_DETAILS_DIFF",
                 Self::Agents => "AGENTS",
             }
         }
@@ -55,6 +61,8 @@ pub mod k2_gossip_message {
                 "INITIATE" => Some(Self::Initiate),
                 "ACCEPT" => Some(Self::Accept),
                 "NO_DIFF" => Some(Self::NoDiff),
+                "DISC_SECTORS_DIFF" => Some(Self::DiscSectorsDiff),
+                "RING_SECTOR_DETAILS_DIFF" => Some(Self::RingSectorDetailsDiff),
                 "AGENTS" => Some(Self::Agents),
                 _ => None,
             }
@@ -68,6 +76,78 @@ pub struct ArcSetMessage {
     #[prost(uint32, repeated, tag = "1")]
     pub value: ::prost::alloc::vec::Vec<u32>,
 }
+/// Message representation of kitsune2_dht::DhtSnapshot::Minimal
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SnapshotMinimalMessage {
+    #[prost(int64, tag = "1")]
+    pub disc_boundary: i64,
+    #[prost(bytes = "bytes", tag = "2")]
+    pub disc_top_hash: ::prost::bytes::Bytes,
+    #[prost(bytes = "bytes", repeated, tag = "3")]
+    pub ring_top_hashes: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
+}
+/// Message representation of kitsune2_dht::DhtSnapshot::DiscSectors
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SnapshotDiscSectorsMessage {
+    #[prost(int64, tag = "1")]
+    pub disc_boundary: i64,
+    #[prost(uint32, repeated, tag = "2")]
+    pub disc_sectors: ::prost::alloc::vec::Vec<u32>,
+    #[prost(bytes = "bytes", repeated, tag = "3")]
+    pub disc_sector_hashes: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct DiscSliceHashes {
+    #[prost(uint32, repeated, tag = "1")]
+    pub slice_indices: ::prost::alloc::vec::Vec<u32>,
+    #[prost(bytes = "bytes", repeated, tag = "2")]
+    pub hash: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
+}
+/// Message representation of kitsune2_dht::DhtSnapshot::DiscSectorDetails
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SnapshotDiscSectorDetailsMessage {
+    #[prost(int64, tag = "1")]
+    pub disc_boundary: i64,
+    #[prost(uint32, repeated, tag = "2")]
+    pub sector_indices: ::prost::alloc::vec::Vec<u32>,
+    #[prost(message, repeated, tag = "3")]
+    pub disc_slice_hashes: ::prost::alloc::vec::Vec<DiscSliceHashes>,
+}
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RingSectorHashes {
+    #[prost(uint32, repeated, tag = "1")]
+    pub sector_indices: ::prost::alloc::vec::Vec<u32>,
+    #[prost(bytes = "bytes", repeated, tag = "2")]
+    pub hashes: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
+}
+/// Message representation of kitsune2_dht::DhtSnapshot::RingSectorDetails
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct SnapshotRingSectorDetailsMessage {
+    #[prost(int64, tag = "1")]
+    pub disc_boundary: i64,
+    #[prost(uint32, repeated, tag = "2")]
+    pub ring_indices: ::prost::alloc::vec::Vec<u32>,
+    #[prost(message, repeated, tag = "3")]
+    pub ring_sector_hashes: ::prost::alloc::vec::Vec<RingSectorHashes>,
+}
+/// Common fields to be sent in response to an accept message
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct AcceptResponseMessage {
+    /// Agent ids of agents that were mentioned in the acceptor's participating_agents list
+    /// that we do not have in our peer store.
+    #[prost(bytes = "bytes", repeated, tag = "1")]
+    pub missing_agents: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
+    /// The agent infos for the agents that were sent back in the missing_agents list in the acceptor's response.
+    #[prost(bytes = "bytes", repeated, tag = "2")]
+    pub provided_agents: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
+    /// Ops that we have stored since the timestamp provided by the acceptors in `new_since`.
+    #[prost(bytes = "bytes", repeated, tag = "3")]
+    pub new_ops: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
+    /// Provide a new bookmark for the initiator. Any new ops will have been returned in `new_ops`
+    /// and the acceptor should use this new timestamp in their `new_since` next time they gossip with us.
+    #[prost(int64, tag = "4")]
+    pub updated_new_since: i64,
+}
 /// A Kitsune2 gossip initiation protocol message.
 ///
 /// Acceptable responses:
@@ -76,7 +156,7 @@ pub struct ArcSetMessage {
 pub struct K2GossipInitiateMessage {
     #[prost(bytes = "bytes", tag = "1")]
     pub session_id: ::prost::bytes::Bytes,
-    /// The agent ids of the agents from the initiator who are in the in the peer store for the space where gossip is running.
+    /// The agent ids of the agents from the initiator who are in the peer store for the space where gossip is running.
     #[prost(bytes = "bytes", repeated, tag = "10")]
     pub participating_agents: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
     /// The DHT sectors covered by the union of the agents in the participating_agents list.
@@ -97,7 +177,7 @@ pub struct K2GossipInitiateMessage {
 pub struct K2GossipAcceptMessage {
     #[prost(bytes = "bytes", tag = "1")]
     pub session_id: ::prost::bytes::Bytes,
-    /// The agent ids of the agents from the acceptor who are in the in the peer store for the space where gossip is running.
+    /// The agent ids of the agents from the acceptor who are in the peer store for the space where gossip is running.
     #[prost(bytes = "bytes", repeated, tag = "10")]
     pub participating_agents: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
     /// The DHT sectors covered by the union of the agents in the participating_agents list.
@@ -120,6 +200,9 @@ pub struct K2GossipAcceptMessage {
     /// and the initiator should use this new timestamp in their `new_since` next time they gossip with us.
     #[prost(int64, tag = "23")]
     pub updated_new_since: i64,
+    /// The DHT snapshot of the acceptor.
+    #[prost(message, optional, tag = "30")]
+    pub snapshot: ::core::option::Option<SnapshotMinimalMessage>,
 }
 /// A Kitsune2 gossip no diff protocol message.
 ///
@@ -132,23 +215,35 @@ pub struct K2GossipAcceptMessage {
 pub struct K2GossipNoDiffMessage {
     #[prost(bytes = "bytes", tag = "1")]
     pub session_id: ::prost::bytes::Bytes,
-    /// Agent ids of agents that were mentioned in the acceptor's participating_agents list
-    /// that we do not have in our peer store.
-    #[prost(bytes = "bytes", repeated, tag = "10")]
-    pub missing_agents: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
-    /// The agent infos for the agents that were sent back in the missing_agents list in the acceptor's response.
-    #[prost(bytes = "bytes", repeated, tag = "11")]
-    pub provided_agents: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
-    /// Ops that we have stored since the timestamp provided by the acceptors in `new_since`.
-    #[prost(bytes = "bytes", repeated, tag = "20")]
-    pub new_ops: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,
-    /// Provide a new bookmark for the initiator. Any new ops will have been returned in `new_ops`
-    /// and the acceptor should use this new timestamp in their `new_since` next time they gossip with us.
-    #[prost(int64, tag = "21")]
-    pub updated_new_since: i64,
+    #[prost(message, optional, tag = "2")]
+    pub accept_response: ::core::option::Option<AcceptResponseMessage>,
     /// Set when the initiator could not compare the acceptor's DHT diff with their own.
-    #[prost(bool, tag = "30")]
+    #[prost(bool, tag = "10")]
     pub cannot_compare: bool,
+}
+/// A Kitsune2 gossip disc sectors diff protocol message.
+///
+/// Acceptable responses:
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct K2GossipDiscSectorsDiffMessage {
+    #[prost(bytes = "bytes", tag = "1")]
+    pub session_id: ::prost::bytes::Bytes,
+    #[prost(message, optional, tag = "2")]
+    pub accept_response: ::core::option::Option<AcceptResponseMessage>,
+    #[prost(message, optional, tag = "10")]
+    pub snapshot: ::core::option::Option<SnapshotDiscSectorsMessage>,
+}
+/// A Kitsune2 gossip ring sector details diff protocol message.
+///
+/// Acceptable responses:
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct K2GossipRingSectorDetailsDiffMessage {
+    #[prost(bytes = "bytes", tag = "1")]
+    pub session_id: ::prost::bytes::Bytes,
+    #[prost(message, optional, tag = "2")]
+    pub accept_response: ::core::option::Option<AcceptResponseMessage>,
+    #[prost(message, optional, tag = "10")]
+    pub snapshot: ::core::option::Option<SnapshotRingSectorDetailsMessage>,
 }
 /// A Kitsune2 gossip agents protocol message.
 ///

--- a/crates/gossip/proto/gossip.proto
+++ b/crates/gossip/proto/gossip.proto
@@ -16,8 +16,14 @@ message K2GossipMessage {
     // A gossip no diff protocol message.
     NO_DIFF = 3;
 
+    // A gossip disc sectors diff protocol message.
+    DISC_SECTORS_DIFF = 4;
+
+    // A gossip ring sector details diff protocol message.
+    RING_SECTOR_DETAILS_DIFF = 5;
+
     // A gossip agents protocol message.
-    AGENTS = 4;
+    AGENTS = 6;
   }
 
   // The type of this message.
@@ -33,6 +39,61 @@ message ArcSetMessage {
   repeated uint32 value = 1;
 }
 
+// Message representation of kitsune2_dht::DhtSnapshot::Minimal
+message SnapshotMinimalMessage {
+  int64 disc_boundary = 1;
+  bytes disc_top_hash = 2;
+  repeated bytes ring_top_hashes = 3;
+}
+
+// Message representation of kitsune2_dht::DhtSnapshot::DiscSectors
+message SnapshotDiscSectorsMessage {
+  int64 disc_boundary = 1;
+  repeated uint32 disc_sectors = 2;
+  repeated bytes disc_sector_hashes = 3;
+}
+
+message DiscSliceHashes {
+  repeated uint32 slice_indices = 1;
+  repeated bytes hash = 2;
+}
+
+// Message representation of kitsune2_dht::DhtSnapshot::DiscSectorDetails
+message SnapshotDiscSectorDetailsMessage {
+  int64 disc_boundary = 1;
+  repeated uint32 sector_indices = 2;
+  repeated DiscSliceHashes disc_slice_hashes = 3;
+}
+
+message RingSectorHashes {
+  repeated uint32 sector_indices = 1;
+  repeated bytes hashes = 2;
+}
+
+// Message representation of kitsune2_dht::DhtSnapshot::RingSectorDetails
+message SnapshotRingSectorDetailsMessage {
+  int64 disc_boundary = 1;
+  repeated uint32 ring_indices = 2;
+  repeated RingSectorHashes ring_sector_hashes = 3;
+}
+
+// Common fields to be sent in response to an accept message
+message AcceptResponseMessage {
+  // Agent ids of agents that were mentioned in the acceptor's participating_agents list
+  // that we do not have in our peer store.
+  repeated bytes missing_agents = 1;
+
+  // The agent infos for the agents that were sent back in the missing_agents list in the acceptor's response.
+  repeated bytes provided_agents = 2;
+
+  // Ops that we have stored since the timestamp provided by the acceptors in `new_since`.
+  repeated bytes new_ops = 3;
+
+  // Provide a new bookmark for the initiator. Any new ops will have been returned in `new_ops`
+  // and the acceptor should use this new timestamp in their `new_since` next time they gossip with us.
+  int64 updated_new_since = 4;
+}
+
 // A Kitsune2 gossip initiation protocol message.
 //
 // Acceptable responses:
@@ -40,7 +101,7 @@ message ArcSetMessage {
 message K2GossipInitiateMessage {
   bytes session_id = 1;
 
-  // The agent ids of the agents from the initiator who are in the in the peer store for the space where gossip is running.
+  // The agent ids of the agents from the initiator who are in the peer store for the space where gossip is running.
   repeated bytes participating_agents = 10;
 
   // The DHT sectors covered by the union of the agents in the participating_agents list.
@@ -60,7 +121,7 @@ message K2GossipInitiateMessage {
 message K2GossipAcceptMessage {
   bytes session_id = 1;
 
-  // The agent ids of the agents from the acceptor who are in the in the peer store for the space where gossip is running.
+  // The agent ids of the agents from the acceptor who are in the peer store for the space where gossip is running.
   repeated bytes participating_agents = 10;
 
   // The DHT sectors covered by the union of the agents in the participating_agents list.
@@ -83,7 +144,8 @@ message K2GossipAcceptMessage {
   // and the initiator should use this new timestamp in their `new_since` next time they gossip with us.
   int64 updated_new_since = 23;
 
-  // TODO Send DHT snapshot diff.
+  // The DHT snapshot of the acceptor.
+  optional SnapshotMinimalMessage snapshot = 30;
 }
 
 // A Kitsune2 gossip no diff protocol message.
@@ -96,22 +158,32 @@ message K2GossipAcceptMessage {
 message K2GossipNoDiffMessage {
   bytes session_id = 1;
 
-  // Agent ids of agents that were mentioned in the acceptor's participating_agents list
-  // that we do not have in our peer store.
-  repeated bytes missing_agents = 10;
-
-  // The agent infos for the agents that were sent back in the missing_agents list in the acceptor's response.
-  repeated bytes provided_agents = 11;
-
-  // Ops that we have stored since the timestamp provided by the acceptors in `new_since`.
-  repeated bytes new_ops = 20;
-
-  // Provide a new bookmark for the initiator. Any new ops will have been returned in `new_ops`
-  // and the acceptor should use this new timestamp in their `new_since` next time they gossip with us.
-  int64 updated_new_since = 21;
+  AcceptResponseMessage accept_response = 2;
 
   // Set when the initiator could not compare the acceptor's DHT diff with their own.
-  bool cannot_compare = 30;
+  bool cannot_compare = 10;
+}
+
+// A Kitsune2 gossip disc sectors diff protocol message.
+//
+// Acceptable responses:
+message K2GossipDiscSectorsDiffMessage {
+  bytes session_id = 1;
+
+  AcceptResponseMessage accept_response = 2;
+
+  SnapshotDiscSectorsMessage snapshot = 10;
+}
+
+// A Kitsune2 gossip ring sector details diff protocol message.
+//
+// Acceptable responses:
+message K2GossipRingSectorDetailsDiffMessage {
+  bytes session_id = 1;
+
+  AcceptResponseMessage accept_response = 2;
+
+  SnapshotRingSectorDetailsMessage snapshot = 10;
 }
 
 // A Kitsune2 gossip agents protocol message.

--- a/crates/gossip/proto/gossip.proto
+++ b/crates/gossip/proto/gossip.proto
@@ -4,6 +4,8 @@ package kitsune2.gossip;
 
 // A Kitsune2 gossip protocol message.
 message K2GossipMessage {
+  /// These enum variants correspond to `K2Gossip*Message` types,
+  /// e.g. `INITIATE` -> `K2GossipInitiateMessage`.
   enum GossipMessageType {
     UNSPECIFIED = 0;
 

--- a/crates/gossip/proto/gossip.proto
+++ b/crates/gossip/proto/gossip.proto
@@ -92,6 +92,8 @@ message K2GossipInitiateMessage {
 //
 // Acceptable responses:
 // - `K2GossipNoDiffMessage`
+// - `K2GossipDiscSectorsDiffMessage`
+// - `K2GossipRingSectorDetailsDiffMessage`
 message K2GossipAcceptMessage {
   // Message representation of kitsune2_dht::DhtSnapshot::Minimal
   message SnapshotMinimalMessage {
@@ -148,6 +150,8 @@ message K2GossipNoDiffMessage {
 // A Kitsune2 gossip disc sectors diff protocol message.
 //
 // Acceptable responses:
+// - `K2GossipDiscSectorDetailsDiffMessage`
+// - `K2GossipAgentsMessage`
 message K2GossipDiscSectorsDiffMessage {
   // Message representation of kitsune2_dht::DhtSnapshot::DiscSectors
   message SnapshotDiscSectorsMessage {
@@ -178,8 +182,8 @@ message SnapshotDiscSectorDetailsMessage {
 // A Kitsune2 gossip disc sector details diff protocol message.
 //
 // Acceptable responses:
+// - `K2GossipDiscSectorDetailsDiffResponseMessage`
 message K2GossipDiscSectorDetailsDiffMessage {
-
   bytes session_id = 1;
 
   // The agent infos for the agents that were sent back in the missing_agents list of the previous message.
@@ -191,6 +195,7 @@ message K2GossipDiscSectorDetailsDiffMessage {
 // A Kitsune2 gossip disc sector details diff protocol message.
 //
 // Acceptable responses:
+// - `K2GossipHashesMessage`
 message K2GossipDiscSectorDetailsDiffResponseMessage {
   bytes session_id = 1;
 
@@ -214,6 +219,8 @@ message SnapshotRingSectorDetailsMessage {
 // A Kitsune2 gossip ring sector details diff protocol message.
 //
 // Acceptable responses:
+// - `K2GossipRingSectorDetailsDiffResponseMessage`
+// - `K2GossipAgentsMessage`
 message K2GossipRingSectorDetailsDiffMessage {
 
   bytes session_id = 1;
@@ -226,6 +233,7 @@ message K2GossipRingSectorDetailsDiffMessage {
 // A Kitsune2 gossip ring sector details diff response protocol message.
 //
 // Acceptable responses:
+// - `K2GossipHashesMessage`
 message K2GossipRingSectorDetailsDiffResponseMessage {
   bytes session_id = 1;
 

--- a/crates/gossip/proto/gossip.proto
+++ b/crates/gossip/proto/gossip.proto
@@ -23,16 +23,19 @@ message K2GossipMessage {
     DISC_SECTOR_DETAILS_DIFF = 5;
 
     // A gossip disc sector details diff response protocol message.
-    DISC_SECTOR_DETAILS_RESPONSE_DIFF = 6;
+    DISC_SECTOR_DETAILS_DIFF_RESPONSE = 6;
 
     // A gossip ring sector details diff protocol message.
     RING_SECTOR_DETAILS_DIFF = 7;
 
+    // A gossip ring sector details diff response protocol message.
+    RING_SECTOR_DETAILS_DIFF_RESPONSE = 8;
+
     // A gossip hashes protocol message.
-    HASHES = 8;
+    HASHES = 9;
 
     // A gossip agents protocol message.
-    AGENTS = 9;
+    AGENTS = 10;
   }
 
   // The type of this message.
@@ -196,27 +199,39 @@ message K2GossipDiscSectorDetailsDiffResponseMessage {
   SnapshotDiscSectorDetailsMessage snapshot = 20;
 }
 
+message RingSectorHashes {
+  repeated uint32 sector_indices = 1;
+  repeated bytes hashes = 2;
+}
+
+// Message representation of kitsune2_dht::DhtSnapshot::RingSectorDetails
+message SnapshotRingSectorDetailsMessage {
+  int64 disc_boundary = 1;
+  repeated uint32 ring_indices = 2;
+  repeated RingSectorHashes ring_sector_hashes = 3;
+}
+
 // A Kitsune2 gossip ring sector details diff protocol message.
 //
 // Acceptable responses:
 message K2GossipRingSectorDetailsDiffMessage {
-  message RingSectorHashes {
-    repeated uint32 sector_indices = 1;
-    repeated bytes hashes = 2;
-  }
-
-  // Message representation of kitsune2_dht::DhtSnapshot::RingSectorDetails
-  message SnapshotRingSectorDetailsMessage {
-    int64 disc_boundary = 1;
-    repeated uint32 ring_indices = 2;
-    repeated RingSectorHashes ring_sector_hashes = 3;
-  }
 
   bytes session_id = 1;
 
-  AcceptResponseMessage accept_response = 2;
+  AcceptResponseMessage accept_response = 10;
 
-  SnapshotRingSectorDetailsMessage snapshot = 10;
+  SnapshotRingSectorDetailsMessage snapshot = 20;
+}
+
+// A Kitsune2 gossip ring sector details diff response protocol message.
+//
+// Acceptable responses:
+message K2GossipRingSectorDetailsDiffResponseMessage {
+  bytes session_id = 1;
+
+  repeated bytes maybe_missing_ids = 10;
+
+  SnapshotRingSectorDetailsMessage snapshot = 20;
 }
 
 // A Kitsune2 gossip hashes protocol message.
@@ -237,5 +252,3 @@ message K2GossipAgentsMessage {
   // The agent infos for the agents that were sent back in the missing_agents list of the previous message.
   repeated bytes provided_agents = 10;
 }
-
-// TODO Further gossip protocol messages.

--- a/crates/gossip/proto/gossip.proto
+++ b/crates/gossip/proto/gossip.proto
@@ -201,7 +201,7 @@ message K2GossipDiscSectorDetailsDiffMessage {
 message K2GossipDiscSectorDetailsDiffResponseMessage {
   bytes session_id = 1;
 
-  repeated bytes maybe_missing_ids = 10;
+  repeated bytes missing_ids = 10;
 
   SnapshotDiscSectorDetailsMessage snapshot = 20;
 }
@@ -239,7 +239,7 @@ message K2GossipRingSectorDetailsDiffMessage {
 message K2GossipRingSectorDetailsDiffResponseMessage {
   bytes session_id = 1;
 
-  repeated bytes maybe_missing_ids = 10;
+  repeated bytes missing_ids = 10;
 
   SnapshotRingSectorDetailsMessage snapshot = 20;
 }
@@ -250,7 +250,7 @@ message K2GossipRingSectorDetailsDiffResponseMessage {
 message K2GossipHashesMessage {
   bytes session_id = 1;
 
-  repeated bytes maybe_missing_ids = 10;
+  repeated bytes missing_ids = 10;
 }
 
 // A Kitsune2 gossip agents protocol message.

--- a/crates/gossip/proto/gossip.proto
+++ b/crates/gossip/proto/gossip.proto
@@ -4,8 +4,8 @@ package kitsune2.gossip;
 
 // A Kitsune2 gossip protocol message.
 message K2GossipMessage {
-  /// These enum variants correspond to `K2Gossip*Message` types,
-  /// e.g. `INITIATE` -> `K2GossipInitiateMessage`.
+  // These enum variants correspond to `K2Gossip*Message` types,
+  // e.g. `INITIATE` -> `K2GossipInitiateMessage`.
   enum GossipMessageType {
     UNSPECIFIED = 0;
 

--- a/crates/gossip/proto/gossip.proto
+++ b/crates/gossip/proto/gossip.proto
@@ -19,11 +19,20 @@ message K2GossipMessage {
     // A gossip disc sectors diff protocol message.
     DISC_SECTORS_DIFF = 4;
 
+    // A gossip disc sector details diff protocol message.
+    DISC_SECTOR_DETAILS_DIFF = 5;
+
+    // A gossip disc sector details diff response protocol message.
+    DISC_SECTOR_DETAILS_RESPONSE_DIFF = 6;
+
     // A gossip ring sector details diff protocol message.
-    RING_SECTOR_DETAILS_DIFF = 5;
+    RING_SECTOR_DETAILS_DIFF = 7;
+
+    // A gossip hashes protocol message.
+    HASHES = 8;
 
     // A gossip agents protocol message.
-    AGENTS = 6;
+    AGENTS = 9;
   }
 
   // The type of this message.
@@ -151,25 +160,40 @@ message K2GossipDiscSectorsDiffMessage {
   SnapshotDiscSectorsMessage snapshot = 10;
 }
 
+message DiscSliceHashes {
+  repeated uint64 slice_indices = 1;
+  repeated bytes hashes = 2;
+}
+
+// Message representation of kitsune2_dht::DhtSnapshot::DiscSectorDetails
+message SnapshotDiscSectorDetailsMessage {
+  int64 disc_boundary = 1;
+  repeated uint32 sector_indices = 2;
+  repeated DiscSliceHashes disc_slice_hashes = 3;
+}
+
 // A Kitsune2 gossip disc sector details diff protocol message.
 //
 // Acceptable responses:
 message K2GossipDiscSectorDetailsDiffMessage {
-  message DiscSliceHashes {
-    repeated uint32 slice_indices = 1;
-    repeated bytes hash = 2;
-  }
-
-  // Message representation of kitsune2_dht::DhtSnapshot::DiscSectorDetails
-  message SnapshotDiscSectorDetailsMessage {
-    int64 disc_boundary = 1;
-    repeated uint32 sector_indices = 2;
-    repeated DiscSliceHashes disc_slice_hashes = 3;
-  }
 
   bytes session_id = 1;
 
-  SnapshotDiscSectorDetailsMessage snapshot = 10;
+  // The agent infos for the agents that were sent back in the missing_agents list of the previous message.
+  repeated bytes provided_agents = 10;
+
+  SnapshotDiscSectorDetailsMessage snapshot = 20;
+}
+
+// A Kitsune2 gossip disc sector details diff protocol message.
+//
+// Acceptable responses:
+message K2GossipDiscSectorDetailsDiffResponseMessage {
+  bytes session_id = 1;
+
+  repeated bytes maybe_missing_ids = 10;
+
+  SnapshotDiscSectorDetailsMessage snapshot = 20;
 }
 
 // A Kitsune2 gossip ring sector details diff protocol message.
@@ -188,12 +212,20 @@ message K2GossipRingSectorDetailsDiffMessage {
     repeated RingSectorHashes ring_sector_hashes = 3;
   }
 
-
   bytes session_id = 1;
 
   AcceptResponseMessage accept_response = 2;
 
   SnapshotRingSectorDetailsMessage snapshot = 10;
+}
+
+// A Kitsune2 gossip hashes protocol message.
+//
+// This message is a final message when used in a gossip round.
+message K2GossipHashesMessage {
+  bytes session_id = 1;
+
+  repeated bytes maybe_missing_ids = 10;
 }
 
 // A Kitsune2 gossip agents protocol message.

--- a/crates/gossip/proto/gossip.proto
+++ b/crates/gossip/proto/gossip.proto
@@ -62,7 +62,7 @@ message AcceptResponseMessage {
   // The agent infos for the agents that were sent back in the missing_agents list in the acceptor's response.
   repeated bytes provided_agents = 2;
 
-  // Ops that we have stored since the timestamp provided by the acceptors in `new_since`.
+  // Ops that we have stored since the timestamp provided by the acceptor in `new_since`.
   repeated bytes new_ops = 3;
 
   // Provide a new bookmark for the initiator. Any new ops will have been returned in `new_ops`

--- a/crates/gossip/proto/gossip.proto
+++ b/crates/gossip/proto/gossip.proto
@@ -39,44 +39,6 @@ message ArcSetMessage {
   repeated uint32 value = 1;
 }
 
-// Message representation of kitsune2_dht::DhtSnapshot::Minimal
-message SnapshotMinimalMessage {
-  int64 disc_boundary = 1;
-  bytes disc_top_hash = 2;
-  repeated bytes ring_top_hashes = 3;
-}
-
-// Message representation of kitsune2_dht::DhtSnapshot::DiscSectors
-message SnapshotDiscSectorsMessage {
-  int64 disc_boundary = 1;
-  repeated uint32 disc_sectors = 2;
-  repeated bytes disc_sector_hashes = 3;
-}
-
-message DiscSliceHashes {
-  repeated uint32 slice_indices = 1;
-  repeated bytes hash = 2;
-}
-
-// Message representation of kitsune2_dht::DhtSnapshot::DiscSectorDetails
-message SnapshotDiscSectorDetailsMessage {
-  int64 disc_boundary = 1;
-  repeated uint32 sector_indices = 2;
-  repeated DiscSliceHashes disc_slice_hashes = 3;
-}
-
-message RingSectorHashes {
-  repeated uint32 sector_indices = 1;
-  repeated bytes hashes = 2;
-}
-
-// Message representation of kitsune2_dht::DhtSnapshot::RingSectorDetails
-message SnapshotRingSectorDetailsMessage {
-  int64 disc_boundary = 1;
-  repeated uint32 ring_indices = 2;
-  repeated RingSectorHashes ring_sector_hashes = 3;
-}
-
 // Common fields to be sent in response to an accept message
 message AcceptResponseMessage {
   // Agent ids of agents that were mentioned in the acceptor's participating_agents list
@@ -119,6 +81,13 @@ message K2GossipInitiateMessage {
 // Acceptable responses:
 // - `K2GossipNoDiffMessage`
 message K2GossipAcceptMessage {
+  // Message representation of kitsune2_dht::DhtSnapshot::Minimal
+  message SnapshotMinimalMessage {
+    int64 disc_boundary = 1;
+    bytes disc_top_hash = 2;
+    repeated bytes ring_top_hashes = 3;
+  }
+
   bytes session_id = 1;
 
   // The agent ids of the agents from the acceptor who are in the peer store for the space where gossip is running.
@@ -168,6 +137,13 @@ message K2GossipNoDiffMessage {
 //
 // Acceptable responses:
 message K2GossipDiscSectorsDiffMessage {
+  // Message representation of kitsune2_dht::DhtSnapshot::DiscSectors
+  message SnapshotDiscSectorsMessage {
+    int64 disc_boundary = 1;
+    repeated uint32 disc_sectors = 2;
+    repeated bytes disc_sector_hashes = 3;
+  }
+
   bytes session_id = 1;
 
   AcceptResponseMessage accept_response = 2;
@@ -175,10 +151,44 @@ message K2GossipDiscSectorsDiffMessage {
   SnapshotDiscSectorsMessage snapshot = 10;
 }
 
+// A Kitsune2 gossip disc sector details diff protocol message.
+//
+// Acceptable responses:
+message K2GossipDiscSectorDetailsDiffMessage {
+  message DiscSliceHashes {
+    repeated uint32 slice_indices = 1;
+    repeated bytes hash = 2;
+  }
+
+  // Message representation of kitsune2_dht::DhtSnapshot::DiscSectorDetails
+  message SnapshotDiscSectorDetailsMessage {
+    int64 disc_boundary = 1;
+    repeated uint32 sector_indices = 2;
+    repeated DiscSliceHashes disc_slice_hashes = 3;
+  }
+
+  bytes session_id = 1;
+
+  SnapshotDiscSectorDetailsMessage snapshot = 10;
+}
+
 // A Kitsune2 gossip ring sector details diff protocol message.
 //
 // Acceptable responses:
 message K2GossipRingSectorDetailsDiffMessage {
+  message RingSectorHashes {
+    repeated uint32 sector_indices = 1;
+    repeated bytes hashes = 2;
+  }
+
+  // Message representation of kitsune2_dht::DhtSnapshot::RingSectorDetails
+  message SnapshotRingSectorDetailsMessage {
+    int64 disc_boundary = 1;
+    repeated uint32 ring_indices = 2;
+    repeated RingSectorHashes ring_sector_hashes = 3;
+  }
+
+
   bytes session_id = 1;
 
   AcceptResponseMessage accept_response = 2;

--- a/crates/gossip/src/gossip.rs
+++ b/crates/gossip/src/gossip.rs
@@ -1,6 +1,6 @@
 use crate::initiate::spawn_initiate_task;
 use crate::peer_meta_store::K2PeerMetaStore;
-use crate::protocol::{deserialize_gossip_message, encode_agent_ids, encode_agent_infos, encode_op_ids, serialize_gossip_message, AcceptResponseMessage, ArcSetMessage, GossipMessage, K2GossipAcceptMessage, K2GossipAgentsMessage, K2GossipDiscSectorsDiffMessage, K2GossipInitiateMessage, K2GossipNoDiffMessage, K2GossipRingSectorDetailsDiffMessage, SnapshotMinimalMessage};
+use crate::protocol::{deserialize_gossip_message, encode_agent_ids, encode_agent_infos, encode_op_ids, serialize_gossip_message, AcceptResponseMessage, ArcSetMessage, GossipMessage, K2GossipAcceptMessage, K2GossipAgentsMessage, K2GossipDiscSectorsDiffMessage, K2GossipInitiateMessage, K2GossipNoDiffMessage, K2GossipRingSectorDetailsDiffMessage};
 use crate::state::{GossipRoundState, RoundStage};
 use crate::timeout::spawn_timeout_task;
 use crate::{K2GossipConfig, K2GossipModConfig, MOD_NAME};
@@ -22,6 +22,7 @@ use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::Mutex;
 use tokio::time::Instant;
+use crate::protocol::k2_gossip_accept_message::SnapshotMinimalMessage;
 
 /// A factory for creating K2Gossip instances.
 #[derive(Debug)]

--- a/crates/gossip/src/gossip.rs
+++ b/crates/gossip/src/gossip.rs
@@ -759,7 +759,7 @@ impl K2Gossip {
                         Ok(Some(GossipMessage::DiscSectorDetailsDiffResponse(
                             K2GossipDiscSectorDetailsDiffResponseMessage {
                                 session_id: disc_sector_details_diff.session_id,
-                                maybe_missing_ids: encode_op_ids(ops),
+                                missing_ids: encode_op_ids(ops),
                                 snapshot: Some(snapshot.try_into()?),
                             },
                         )))
@@ -782,7 +782,7 @@ impl K2Gossip {
                 self.fetch
                     .request_ops(
                         decode_ids(
-                            disc_sector_details_response_diff.maybe_missing_ids,
+                            disc_sector_details_response_diff.missing_ids,
                         ),
                         from_peer.clone(),
                     )
@@ -826,7 +826,7 @@ impl K2Gossip {
                         Ok(Some(GossipMessage::Hashes(K2GossipHashesMessage {
                             session_id: disc_sector_details_response_diff
                                 .session_id,
-                            maybe_missing_ids: encode_op_ids(op_ids),
+                            missing_ids: encode_op_ids(op_ids),
                         })))
                     }
                     _ => {
@@ -909,7 +909,7 @@ impl K2Gossip {
                         Ok(Some(GossipMessage::RingSectorDetailsDiffResponse(
                             K2GossipRingSectorDetailsDiffResponseMessage {
                                 session_id: ring_sector_details_diff.session_id,
-                                maybe_missing_ids: encode_op_ids(op_ids),
+                                missing_ids: encode_op_ids(op_ids),
                                 snapshot: Some(snapshot.try_into()?),
                             },
                         )))
@@ -932,7 +932,7 @@ impl K2Gossip {
                 self.fetch
                     .request_ops(
                         decode_ids(
-                            ring_sector_details_diff_response.maybe_missing_ids,
+                            ring_sector_details_diff_response.missing_ids,
                         ),
                         from_peer.clone(),
                     )
@@ -972,7 +972,7 @@ impl K2Gossip {
                         Ok(Some(GossipMessage::Hashes(K2GossipHashesMessage {
                             session_id: ring_sector_details_diff_response
                                 .session_id,
-                            maybe_missing_ids: encode_op_ids(op_ids),
+                            missing_ids: encode_op_ids(op_ids),
                         })))
                     }
                     _ => {
@@ -996,9 +996,7 @@ impl K2Gossip {
 
                             self.fetch
                                 .request_ops(
-                                    decode_ids(
-                                        hashes.maybe_missing_ids.clone(),
-                                    ),
+                                    decode_ids(hashes.missing_ids.clone()),
                                     from_peer.clone(),
                                 )
                                 .await?;
@@ -1031,7 +1029,7 @@ impl K2Gossip {
 
                             self.fetch
                                 .request_ops(
-                                    decode_ids(hashes.maybe_missing_ids),
+                                    decode_ids(hashes.missing_ids),
                                     from_peer.clone(),
                                 )
                                 .await?;

--- a/crates/gossip/src/gossip.rs
+++ b/crates/gossip/src/gossip.rs
@@ -1299,7 +1299,7 @@ mod test {
             target_arc: DhtArc,
         ) -> Arc<AgentInfoSigned> {
             let local_agent = Arc::new(Ed25519LocalAgent::default());
-            local_agent.set_tgt_storage_arc_hint(target_arc.clone());
+            local_agent.set_tgt_storage_arc_hint(target_arc);
 
             self.space
                 .local_agent_join(local_agent.clone())

--- a/crates/gossip/src/gossip.rs
+++ b/crates/gossip/src/gossip.rs
@@ -1704,13 +1704,7 @@ mod test {
         let space = test_space();
         let factory = TestGossipFactory::create(space.clone()).await;
         let harness_1 = factory.new_instance().await;
-        let agent_1 = harness_1.join_local_agent(DhtArc::FULL).await;
-        let agent_info_1 = harness_1
-            .peer_store
-            .get(agent_1.agent.clone())
-            .await
-            .unwrap()
-            .unwrap();
+        let agent_info_1 = harness_1.join_local_agent(DhtArc::FULL).await;
 
         let harness_2 = factory.new_instance().await;
         harness_2.join_local_agent(DhtArc::FULL).await;
@@ -1759,19 +1753,13 @@ mod test {
         let space = test_space();
         let factory = TestGossipFactory::create(space.clone()).await;
         let harness_1 = factory.new_instance().await;
-        let agent_1 = harness_1.join_local_agent(DhtArc::FULL).await;
+        let agent_info_1 = harness_1.join_local_agent(DhtArc::FULL).await;
         let op_1 = MemoryOp::new(Timestamp::now(), vec![1; 128]);
         let op_id_1 = op_1.compute_op_id();
         harness_1
             .op_store
             .process_incoming_ops(vec![op_1.clone().into()])
             .await
-            .unwrap();
-        let agent_info_1 = harness_1
-            .peer_store
-            .get(agent_1.agent().clone())
-            .await
-            .unwrap()
             .unwrap();
 
         let harness_2 = factory.new_instance().await;
@@ -1786,7 +1774,7 @@ mod test {
 
         harness_2
             .gossip
-            .initiate_gossip(agent_info_1.url.clone())
+            .initiate_gossip(agent_info_1.url.clone().unwrap())
             .await
             .unwrap();
 
@@ -1806,7 +1794,7 @@ mod test {
         let space = test_space();
         let factory = TestGossipFactory::create(space.clone()).await;
         let harness_1 = factory.new_instance().await;
-        let agent_1 = harness_1.join_local_agent(DhtArc::FULL).await;
+        let agent_info_1 = harness_1.join_local_agent(DhtArc::FULL).await;
         let op_1 = MemoryOp::new(Timestamp::from_micros(100), vec![1; 128]);
         let op_id_1 = op_1.compute_op_id();
         harness_1
@@ -1825,7 +1813,7 @@ mod test {
             .unwrap();
 
         let harness_2 = factory.new_instance().await;
-        let agent_2 = harness_2.join_local_agent(DhtArc::FULL).await;
+        let agent_info_2 = harness_2.join_local_agent(DhtArc::FULL).await;
         let op_2 = MemoryOp::new(Timestamp::from_micros(500), vec![2; 128]);
         let op_id_2 = op_2.compute_op_id();
         harness_2
@@ -1849,7 +1837,7 @@ mod test {
             .gossip
             .peer_meta_store
             .set_new_ops_bookmark(
-                agent_2.url.clone().unwrap(),
+                agent_info_2.url.clone().unwrap(),
                 Timestamp::now(),
             )
             .await
@@ -1858,7 +1846,7 @@ mod test {
             .gossip
             .peer_meta_store
             .set_new_ops_bookmark(
-                agent_1.url.clone().unwrap(),
+                agent_info_1.url.clone().unwrap(),
                 Timestamp::now(),
             )
             .await
@@ -1866,7 +1854,7 @@ mod test {
 
         harness_2
             .gossip
-            .initiate_gossip(agent_1.agent.clone())
+            .initiate_gossip(agent_info_1.url.clone().unwrap())
             .await
             .unwrap();
 
@@ -1886,7 +1874,7 @@ mod test {
         let space = test_space();
         let factory = TestGossipFactory::create(space.clone()).await;
         let harness_1 = factory.new_instance().await;
-        let agent_1 = harness_1.join_local_agent(DhtArc::FULL).await;
+        let agent_info_1 = harness_1.join_local_agent(DhtArc::FULL).await;
         let op_1 = MemoryOp::new(
             (Timestamp::now() - 2 * UNIT_TIME).unwrap(),
             vec![1; 128],
@@ -1944,7 +1932,7 @@ mod test {
             .gossip
             .peer_meta_store
             .set_new_ops_bookmark(
-                agent_1.url.clone().unwrap(),
+                agent_info_1.url.clone().unwrap(),
                 Timestamp::now(),
             )
             .await
@@ -1952,7 +1940,7 @@ mod test {
 
         harness_2
             .gossip
-            .initiate_gossip(agent_1.agent.clone())
+            .initiate_gossip(agent_info_1.url.clone().unwrap())
             .await
             .unwrap();
 

--- a/crates/gossip/src/initiate.rs
+++ b/crates/gossip/src/initiate.rs
@@ -36,9 +36,16 @@ pub fn spawn_initiate_task(
             .await
             {
                 Ok(Some(url)) => {
-                    tracing::info!("Initiating gossip with {}", url);
-                    if let Err(e) = gossip.initiate_gossip(url).await {
-                        tracing::error!("Error initiating gossip: {:?}", e);
+                    match gossip.initiate_gossip(url.clone()).await {
+                        Ok(true) => {
+                            tracing::info!("Initiated gossip with {}", url);
+                        }
+                        Ok(false) => {
+                            // Don't log here, will already have logged the reason
+                        }
+                        Err(e) => {
+                            tracing::error!("Error initiating gossip: {:?}", e);
+                        }
                     }
                 }
                 Ok(None) => {

--- a/crates/gossip/src/protocol.rs
+++ b/crates/gossip/src/protocol.rs
@@ -8,6 +8,9 @@ use kitsune2_dht::snapshot::DhtSnapshot;
 use prost::{bytes, Message};
 use std::collections::HashMap;
 use std::sync::Arc;
+use crate::protocol::k2_gossip_accept_message::SnapshotMinimalMessage;
+use crate::protocol::k2_gossip_disc_sectors_diff_message::SnapshotDiscSectorsMessage;
+use crate::protocol::k2_gossip_ring_sector_details_diff_message::{RingSectorHashes, SnapshotRingSectorDetailsMessage};
 
 include!("../proto/gen/kitsune2.gossip.rs");
 

--- a/crates/gossip/src/protocol.rs
+++ b/crates/gossip/src/protocol.rs
@@ -1,5 +1,10 @@
 //! Protocol definitions for the gossip module.
 
+use crate::protocol::k2_gossip_accept_message::SnapshotMinimalMessage;
+use crate::protocol::k2_gossip_disc_sectors_diff_message::SnapshotDiscSectorsMessage;
+use crate::protocol::k2_gossip_ring_sector_details_diff_message::{
+    RingSectorHashes, SnapshotRingSectorDetailsMessage,
+};
 use bytes::{Bytes, BytesMut};
 use kitsune2_api::agent::AgentInfoSigned;
 use kitsune2_api::id::encode_ids;
@@ -8,9 +13,6 @@ use kitsune2_dht::snapshot::DhtSnapshot;
 use prost::{bytes, Message};
 use std::collections::HashMap;
 use std::sync::Arc;
-use crate::protocol::k2_gossip_accept_message::SnapshotMinimalMessage;
-use crate::protocol::k2_gossip_disc_sectors_diff_message::SnapshotDiscSectorsMessage;
-use crate::protocol::k2_gossip_ring_sector_details_diff_message::{RingSectorHashes, SnapshotRingSectorDetailsMessage};
 
 include!("../proto/gen/kitsune2.gossip.rs");
 
@@ -20,7 +22,10 @@ pub enum GossipMessage {
     Accept(K2GossipAcceptMessage),
     NoDiff(K2GossipNoDiffMessage),
     DiscSectorsDiff(K2GossipDiscSectorsDiffMessage),
+    DiscSectorDetailsDiff(K2GossipDiscSectorDetailsDiffMessage),
+    DiscSectorDetailsResponseDiff(K2GossipDiscSectorDetailsDiffResponseMessage),
     RingSectorDetailsDiff(K2GossipRingSectorDetailsDiffMessage),
+    Hashes(K2GossipHashesMessage),
     Agents(K2GossipAgentsMessage),
 }
 
@@ -49,11 +54,29 @@ pub fn deserialize_gossip_message(value: Bytes) -> K2Result<GossipMessage> {
                 .map_err(K2Error::other)?;
             Ok(GossipMessage::DiscSectorsDiff(inner))
         }
+        k2_gossip_message::GossipMessageType::DiscSectorDetailsDiff => {
+            let inner =
+                K2GossipDiscSectorDetailsDiffMessage::decode(outer.data)
+                    .map_err(K2Error::other)?;
+            Ok(GossipMessage::DiscSectorDetailsDiff(inner))
+        }
+        k2_gossip_message::GossipMessageType::DiscSectorDetailsResponseDiff => {
+            let inner = K2GossipDiscSectorDetailsDiffResponseMessage::decode(
+                outer.data,
+            )
+            .map_err(K2Error::other)?;
+            Ok(GossipMessage::DiscSectorDetailsResponseDiff(inner))
+        }
         k2_gossip_message::GossipMessageType::RingSectorDetailsDiff => {
             let inner =
                 K2GossipRingSectorDetailsDiffMessage::decode(outer.data)
                     .map_err(K2Error::other)?;
             Ok(GossipMessage::RingSectorDetailsDiff(inner))
+        }
+        k2_gossip_message::GossipMessageType::Hashes => {
+            let inner = K2GossipHashesMessage::decode(outer.data)
+                .map_err(K2Error::other)?;
+            Ok(GossipMessage::Hashes(inner))
         }
         k2_gossip_message::GossipMessageType::Agents => {
             let inner = K2GossipAgentsMessage::decode(outer.data)
@@ -85,75 +108,56 @@ pub fn serialize_gossip_message(value: GossipMessage) -> K2Result<Bytes> {
 fn serialize_inner_gossip_message(
     value: GossipMessage,
 ) -> K2Result<(k2_gossip_message::GossipMessageType, Bytes)> {
-    let mut out = BytesMut::new();
+    let out = BytesMut::new();
+
+    fn encode<T: prost::Message>(msg: T, mut out: BytesMut) -> K2Result<Bytes> {
+        msg.encode(&mut out).map_err(|e| {
+            K2Error::other(format!(
+                "Failed to serialize gossip message: {:?}",
+                e
+            ))
+        })?;
+
+        Ok(out.freeze())
+    }
 
     match value {
-        GossipMessage::Initiate(inner) => {
-            inner.encode(&mut out).map_err(|e| {
-                K2Error::other(format!(
-                    "Failed to serialize gossip message: {:?}",
-                    e
-                ))
-            })?;
-
-            Ok((k2_gossip_message::GossipMessageType::Initiate, out.freeze()))
-        }
-        GossipMessage::Accept(inner) => {
-            inner.encode(&mut out).map_err(|e| {
-                K2Error::other(format!(
-                    "Failed to serialize gossip message: {:?}",
-                    e
-                ))
-            })?;
-
-            Ok((k2_gossip_message::GossipMessageType::Accept, out.freeze()))
-        }
-        GossipMessage::NoDiff(inner) => {
-            inner.encode(&mut out).map_err(|e| {
-                K2Error::other(format!(
-                    "Failed to serialize gossip message: {:?}",
-                    e
-                ))
-            })?;
-
-            Ok((k2_gossip_message::GossipMessageType::NoDiff, out.freeze()))
-        }
-        GossipMessage::DiscSectorsDiff(inner) => {
-            inner.encode(&mut out).map_err(|e| {
-                K2Error::other(format!(
-                    "Failed to serialize gossip message: {:?}",
-                    e
-                ))
-            })?;
-
-            Ok((
-                k2_gossip_message::GossipMessageType::DiscSectorsDiff,
-                out.freeze(),
-            ))
-        }
-        GossipMessage::RingSectorDetailsDiff(inner) => {
-            inner.encode(&mut out).map_err(|e| {
-                K2Error::other(format!(
-                    "Failed to serialize gossip message: {:?}",
-                    e
-                ))
-            })?;
-
-            Ok((
-                k2_gossip_message::GossipMessageType::RingSectorDetailsDiff,
-                out.freeze(),
-            ))
-        }
-        GossipMessage::Agents(inner) => {
-            inner.encode(&mut out).map_err(|e| {
-                K2Error::other(format!(
-                    "Failed to serialize gossip message: {:?}",
-                    e
-                ))
-            })?;
-
-            Ok((k2_gossip_message::GossipMessageType::Agents, out.freeze()))
-        }
+        GossipMessage::Initiate(inner) => Ok((
+            k2_gossip_message::GossipMessageType::Initiate,
+            encode(inner, out)?,
+        )),
+        GossipMessage::Accept(inner) => Ok((
+            k2_gossip_message::GossipMessageType::Accept,
+            encode(inner, out)?,
+        )),
+        GossipMessage::NoDiff(inner) => Ok((
+            k2_gossip_message::GossipMessageType::NoDiff,
+            encode(inner, out)?,
+        )),
+        GossipMessage::DiscSectorsDiff(inner) => Ok((
+            k2_gossip_message::GossipMessageType::DiscSectorsDiff,
+            encode(inner, out)?,
+        )),
+        GossipMessage::DiscSectorDetailsDiff(inner) => Ok((
+            k2_gossip_message::GossipMessageType::DiscSectorDetailsDiff,
+            encode(inner, out)?,
+        )),
+        GossipMessage::DiscSectorDetailsResponseDiff(inner) => Ok((
+            k2_gossip_message::GossipMessageType::DiscSectorDetailsResponseDiff,
+            encode(inner, out)?,
+        )),
+        GossipMessage::RingSectorDetailsDiff(inner) => Ok((
+            k2_gossip_message::GossipMessageType::RingSectorDetailsDiff,
+            encode(inner, out)?,
+        )),
+        GossipMessage::Hashes(inner) => Ok((
+            k2_gossip_message::GossipMessageType::Hashes,
+            encode(inner, out)?,
+        )),
+        GossipMessage::Agents(inner) => Ok((
+            k2_gossip_message::GossipMessageType::Agents,
+            encode(inner, out)?,
+        )),
     }
 }
 
@@ -193,8 +197,8 @@ impl TryFrom<DhtSnapshot> for SnapshotMinimalMessage {
             } => {
                 Ok(SnapshotMinimalMessage {
                     disc_boundary: disc_boundary.as_micros(),
-                    disc_top_hash: disc_top_hash.into(),
-                    ring_top_hashes: ring_top_hashes.into_iter().map(|h| h.into()).collect(),
+                    disc_top_hash,
+                    ring_top_hashes: ring_top_hashes.into_iter().collect(),
                 })
             }
             _ => {
@@ -255,6 +259,66 @@ impl TryFrom<SnapshotDiscSectorsMessage> for DhtSnapshot {
                 .into_iter()
                 .zip(value.disc_sector_hashes)
                 .collect(),
+        })
+    }
+}
+
+impl TryFrom<DhtSnapshot> for SnapshotDiscSectorDetailsMessage {
+    type Error = K2Error;
+
+    fn try_from(value: DhtSnapshot) -> K2Result<Self> {
+        match value {
+            DhtSnapshot::DiscSectorDetails {
+                disc_boundary,
+                disc_sector_hashes,
+            } => {
+                Ok(SnapshotDiscSectorDetailsMessage {
+                    disc_boundary: disc_boundary.as_micros(),
+                    sector_indices: disc_sector_hashes.keys().cloned().collect(),
+                    disc_slice_hashes: disc_sector_hashes.values().map(|m| {
+                        DiscSliceHashes {
+                            slice_indices: m.keys().cloned().collect(),
+                            hashes: m.values().cloned().collect(),
+                        }
+                    }).collect()
+                })
+            }
+            _ => {
+                Err(K2Error::other("Only DhtSnapshot::DiscSectorDetails can be converted to a SnapshotDiscSectorDetailsMessage".to_string()))
+            }
+        }
+    }
+}
+
+impl TryFrom<SnapshotDiscSectorDetailsMessage> for DhtSnapshot {
+    type Error = K2Error;
+
+    fn try_from(value: SnapshotDiscSectorDetailsMessage) -> K2Result<Self> {
+        if value.sector_indices.len() != value.disc_slice_hashes.len() {
+            return Err(K2Error::other(
+                "Mismatched sector and hash lengths".to_string(),
+            ));
+        }
+
+        Ok(DhtSnapshot::DiscSectorDetails {
+            disc_boundary: Timestamp::from_micros(value.disc_boundary),
+            disc_sector_hashes: value
+                .sector_indices
+                .into_iter()
+                .zip(value.disc_slice_hashes.into_iter().map(|r| {
+                    if r.slice_indices.len() != r.hashes.len() {
+                        return Err(K2Error::other(
+                            "Mismatched slice and hash lengths".to_string(),
+                        ));
+                    }
+
+                    Ok(r.slice_indices.into_iter().zip(r.hashes).collect())
+                }))
+                .map(|(a, b)| match b {
+                    Ok(b) => Ok((a, b)),
+                    Err(e) => Err(e),
+                })
+                .collect::<K2Result<HashMap<_, _>>>()?,
         })
     }
 }

--- a/crates/gossip/src/protocol.rs
+++ b/crates/gossip/src/protocol.rs
@@ -2,9 +2,6 @@
 
 use crate::protocol::k2_gossip_accept_message::SnapshotMinimalMessage;
 use crate::protocol::k2_gossip_disc_sectors_diff_message::SnapshotDiscSectorsMessage;
-use crate::protocol::k2_gossip_ring_sector_details_diff_message::{
-    RingSectorHashes, SnapshotRingSectorDetailsMessage,
-};
 use bytes::{Bytes, BytesMut};
 use kitsune2_api::agent::AgentInfoSigned;
 use kitsune2_api::id::encode_ids;
@@ -23,8 +20,9 @@ pub enum GossipMessage {
     NoDiff(K2GossipNoDiffMessage),
     DiscSectorsDiff(K2GossipDiscSectorsDiffMessage),
     DiscSectorDetailsDiff(K2GossipDiscSectorDetailsDiffMessage),
-    DiscSectorDetailsResponseDiff(K2GossipDiscSectorDetailsDiffResponseMessage),
+    DiscSectorDetailsDiffResponse(K2GossipDiscSectorDetailsDiffResponseMessage),
     RingSectorDetailsDiff(K2GossipRingSectorDetailsDiffMessage),
+    RingSectorDetailsDiffResponse(K2GossipRingSectorDetailsDiffResponseMessage),
     Hashes(K2GossipHashesMessage),
     Agents(K2GossipAgentsMessage),
 }
@@ -60,18 +58,25 @@ pub fn deserialize_gossip_message(value: Bytes) -> K2Result<GossipMessage> {
                     .map_err(K2Error::other)?;
             Ok(GossipMessage::DiscSectorDetailsDiff(inner))
         }
-        k2_gossip_message::GossipMessageType::DiscSectorDetailsResponseDiff => {
+        k2_gossip_message::GossipMessageType::DiscSectorDetailsDiffResponse => {
             let inner = K2GossipDiscSectorDetailsDiffResponseMessage::decode(
                 outer.data,
             )
             .map_err(K2Error::other)?;
-            Ok(GossipMessage::DiscSectorDetailsResponseDiff(inner))
+            Ok(GossipMessage::DiscSectorDetailsDiffResponse(inner))
         }
         k2_gossip_message::GossipMessageType::RingSectorDetailsDiff => {
             let inner =
                 K2GossipRingSectorDetailsDiffMessage::decode(outer.data)
                     .map_err(K2Error::other)?;
             Ok(GossipMessage::RingSectorDetailsDiff(inner))
+        }
+        k2_gossip_message::GossipMessageType::RingSectorDetailsDiffResponse => {
+            let inner = K2GossipRingSectorDetailsDiffResponseMessage::decode(
+                outer.data,
+            )
+            .map_err(K2Error::other)?;
+            Ok(GossipMessage::RingSectorDetailsDiffResponse(inner))
         }
         k2_gossip_message::GossipMessageType::Hashes => {
             let inner = K2GossipHashesMessage::decode(outer.data)
@@ -142,12 +147,16 @@ fn serialize_inner_gossip_message(
             k2_gossip_message::GossipMessageType::DiscSectorDetailsDiff,
             encode(inner, out)?,
         )),
-        GossipMessage::DiscSectorDetailsResponseDiff(inner) => Ok((
-            k2_gossip_message::GossipMessageType::DiscSectorDetailsResponseDiff,
+        GossipMessage::DiscSectorDetailsDiffResponse(inner) => Ok((
+            k2_gossip_message::GossipMessageType::DiscSectorDetailsDiffResponse,
             encode(inner, out)?,
         )),
         GossipMessage::RingSectorDetailsDiff(inner) => Ok((
             k2_gossip_message::GossipMessageType::RingSectorDetailsDiff,
+            encode(inner, out)?,
+        )),
+        GossipMessage::RingSectorDetailsDiffResponse(inner) => Ok((
+            k2_gossip_message::GossipMessageType::RingSectorDetailsDiffResponse,
             encode(inner, out)?,
         )),
         GossipMessage::Hashes(inner) => Ok((

--- a/crates/gossip/src/protocol.rs
+++ b/crates/gossip/src/protocol.rs
@@ -3,8 +3,10 @@
 use bytes::{Bytes, BytesMut};
 use kitsune2_api::agent::AgentInfoSigned;
 use kitsune2_api::id::encode_ids;
-use kitsune2_api::{AgentId, K2Error, K2Result, OpId};
+use kitsune2_api::{AgentId, K2Error, K2Result, OpId, Timestamp};
+use kitsune2_dht::snapshot::DhtSnapshot;
 use prost::{bytes, Message};
+use std::collections::HashMap;
 use std::sync::Arc;
 
 include!("../proto/gen/kitsune2.gossip.rs");
@@ -14,6 +16,8 @@ pub enum GossipMessage {
     Initiate(K2GossipInitiateMessage),
     Accept(K2GossipAcceptMessage),
     NoDiff(K2GossipNoDiffMessage),
+    DiscSectorsDiff(K2GossipDiscSectorsDiffMessage),
+    RingSectorDetailsDiff(K2GossipRingSectorDetailsDiffMessage),
     Agents(K2GossipAgentsMessage),
 }
 
@@ -36,6 +40,17 @@ pub fn deserialize_gossip_message(value: Bytes) -> K2Result<GossipMessage> {
             let inner = K2GossipNoDiffMessage::decode(outer.data)
                 .map_err(K2Error::other)?;
             Ok(GossipMessage::NoDiff(inner))
+        }
+        k2_gossip_message::GossipMessageType::DiscSectorsDiff => {
+            let inner = K2GossipDiscSectorsDiffMessage::decode(outer.data)
+                .map_err(K2Error::other)?;
+            Ok(GossipMessage::DiscSectorsDiff(inner))
+        }
+        k2_gossip_message::GossipMessageType::RingSectorDetailsDiff => {
+            let inner =
+                K2GossipRingSectorDetailsDiffMessage::decode(outer.data)
+                    .map_err(K2Error::other)?;
+            Ok(GossipMessage::RingSectorDetailsDiff(inner))
         }
         k2_gossip_message::GossipMessageType::Agents => {
             let inner = K2GossipAgentsMessage::decode(outer.data)
@@ -100,6 +115,32 @@ fn serialize_inner_gossip_message(
 
             Ok((k2_gossip_message::GossipMessageType::NoDiff, out.freeze()))
         }
+        GossipMessage::DiscSectorsDiff(inner) => {
+            inner.encode(&mut out).map_err(|e| {
+                K2Error::other(format!(
+                    "Failed to serialize gossip message: {:?}",
+                    e
+                ))
+            })?;
+
+            Ok((
+                k2_gossip_message::GossipMessageType::DiscSectorsDiff,
+                out.freeze(),
+            ))
+        }
+        GossipMessage::RingSectorDetailsDiff(inner) => {
+            inner.encode(&mut out).map_err(|e| {
+                K2Error::other(format!(
+                    "Failed to serialize gossip message: {:?}",
+                    e
+                ))
+            })?;
+
+            Ok((
+                k2_gossip_message::GossipMessageType::RingSectorDetailsDiff,
+                out.freeze(),
+            ))
+        }
         GossipMessage::Agents(inner) => {
             inner.encode(&mut out).map_err(|e| {
                 K2Error::other(format!(
@@ -135,4 +176,142 @@ pub(crate) fn encode_op_ids(
     op_ids: impl IntoIterator<Item = OpId>,
 ) -> Vec<Bytes> {
     encode_ids(op_ids)
+}
+
+impl TryFrom<DhtSnapshot> for SnapshotMinimalMessage {
+    type Error = K2Error;
+
+    fn try_from(value: DhtSnapshot) -> K2Result<Self> {
+        match value {
+            DhtSnapshot::Minimal {
+                disc_boundary,
+                disc_top_hash,
+                ring_top_hashes
+            } => {
+                Ok(SnapshotMinimalMessage {
+                    disc_boundary: disc_boundary.as_micros(),
+                    disc_top_hash: disc_top_hash.into(),
+                    ring_top_hashes: ring_top_hashes.into_iter().map(|h| h.into()).collect(),
+                })
+            }
+            _ => {
+                Err(K2Error::other("Only DhtSnapshot::Minimal can be converted to a SnapshotMinimalMessage".to_string()))
+            }
+        }
+    }
+}
+
+impl From<SnapshotMinimalMessage> for DhtSnapshot {
+    fn from(value: SnapshotMinimalMessage) -> Self {
+        DhtSnapshot::Minimal {
+            disc_boundary: Timestamp::from_micros(value.disc_boundary),
+            disc_top_hash: value.disc_top_hash,
+            ring_top_hashes: value.ring_top_hashes,
+        }
+    }
+}
+
+impl TryFrom<DhtSnapshot> for SnapshotDiscSectorsMessage {
+    type Error = K2Error;
+
+    fn try_from(value: DhtSnapshot) -> K2Result<Self> {
+        match value {
+            DhtSnapshot::DiscSectors {
+                disc_boundary,
+                disc_sector_top_hashes,
+            } => {
+                Ok(SnapshotDiscSectorsMessage {
+                    disc_boundary: disc_boundary.as_micros(),
+                    disc_sectors: disc_sector_top_hashes.keys().cloned().collect(),
+                    disc_sector_hashes: disc_sector_top_hashes.values().cloned().collect(),
+                })
+            }
+            _ => {
+                Err(K2Error::other("Only DhtSnapshot::DiscSectors can be converted to a SnapshotDiscSectorsMessage".to_string()))
+            }
+        }
+    }
+}
+
+impl TryFrom<SnapshotDiscSectorsMessage> for DhtSnapshot {
+    type Error = K2Error;
+
+    fn try_from(
+        value: SnapshotDiscSectorsMessage,
+    ) -> Result<Self, Self::Error> {
+        if value.disc_sectors.len() != value.disc_sector_hashes.len() {
+            return Err(K2Error::other(
+                "Mismatched disc sector and hash lengths".to_string(),
+            ));
+        }
+
+        Ok(DhtSnapshot::DiscSectors {
+            disc_boundary: Timestamp::from_micros(value.disc_boundary),
+            disc_sector_top_hashes: value
+                .disc_sectors
+                .into_iter()
+                .zip(value.disc_sector_hashes)
+                .collect(),
+        })
+    }
+}
+
+impl TryFrom<DhtSnapshot> for SnapshotRingSectorDetailsMessage {
+    type Error = K2Error;
+
+    fn try_from(value: DhtSnapshot) -> K2Result<Self> {
+        match value {
+            DhtSnapshot::RingSectorDetails {
+                disc_boundary,
+                ring_sector_hashes,
+            } => {
+                Ok(SnapshotRingSectorDetailsMessage {
+                    disc_boundary: disc_boundary.as_micros(),
+                    ring_indices: ring_sector_hashes.keys().cloned().collect(),
+                    ring_sector_hashes: ring_sector_hashes.values().map(|m| {
+                        RingSectorHashes {
+                            sector_indices: m.keys().cloned().collect(),
+                            hashes: m.values().cloned().collect(),
+                        }
+                    }).collect(),
+                })
+            }
+            _ => {
+                Err(K2Error::other("Only DhtSnapshot::RingSectorDetails can be converted to a SnapshotRingSectorDetailsMessage".to_string()))
+            }
+        }
+    }
+}
+
+impl TryFrom<SnapshotRingSectorDetailsMessage> for DhtSnapshot {
+    type Error = K2Error;
+
+    fn try_from(value: SnapshotRingSectorDetailsMessage) -> K2Result<Self> {
+        if value.ring_indices.len() != value.ring_sector_hashes.len() {
+            return Err(K2Error::other(
+                "Mismatched ring sector and hash lengths".to_string(),
+            ));
+        }
+
+        Ok(DhtSnapshot::RingSectorDetails {
+            disc_boundary: Timestamp::from_micros(value.disc_boundary),
+            ring_sector_hashes: value
+                .ring_indices
+                .into_iter()
+                .zip(value.ring_sector_hashes.into_iter().map(|r| {
+                    if r.sector_indices.len() != r.hashes.len() {
+                        return Err(K2Error::other(
+                            "Mismatched sector and hash lengths".to_string(),
+                        ));
+                    }
+
+                    Ok(r.sector_indices.into_iter().zip(r.hashes).collect())
+                }))
+                .map(|(a, b)| match b {
+                    Ok(b) => Ok((a, b)),
+                    Err(e) => Err(e),
+                })
+                .collect::<K2Result<HashMap<_, _>>>()?,
+        })
+    }
 }

--- a/crates/gossip/src/state.rs
+++ b/crates/gossip/src/state.rs
@@ -366,7 +366,7 @@ pub(crate) enum RoundStage {
     NoDiff,
     DiscSectorsDiff(RoundStageDiscSectorsDiff),
     DiscSectorDetailsDiff(RoundStageDiscSectorDetailsDiff),
-    RingSectorDetailsDiff,
+    RingSectorDetailsDiff(RoundStageRingSectorDetailsDiff),
 }
 
 /// The state of a gossip round that has been initiated.
@@ -383,6 +383,12 @@ pub(crate) struct RoundStageDiscSectorsDiff {
 
 #[derive(Debug)]
 pub(crate) struct RoundStageDiscSectorDetailsDiff {
+    pub common_arc_set: ArcSet,
+    pub snapshot: DhtSnapshot,
+}
+
+#[derive(Debug)]
+pub(crate) struct RoundStageRingSectorDetailsDiff {
     pub common_arc_set: ArcSet,
     pub snapshot: DhtSnapshot,
 }

--- a/crates/gossip/src/state.rs
+++ b/crates/gossip/src/state.rs
@@ -360,7 +360,6 @@ impl GossipRoundState {
 pub(crate) enum RoundStage {
     Initiated(RoundStageInitiated),
     Accepted {
-        #[allow(dead_code)]
         our_agents: Vec<AgentId>,
         common_arc_set: ArcSet,
     },

--- a/crates/gossip/src/timeout.rs
+++ b/crates/gossip/src/timeout.rs
@@ -2,10 +2,10 @@ use crate::gossip::K2Gossip;
 use crate::state::GossipRoundState;
 use crate::K2GossipConfig;
 use kitsune2_api::Url;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, RwLock};
 use tokio::task::AbortHandle;
 
 /// Spawns a task that checks for timed-out gossip rounds and drops their state.
@@ -35,7 +35,9 @@ pub(crate) fn spawn_timeout_task(
 async fn remove_timed_out_rounds(
     round_timeout: Duration,
     initiated_round_state: Arc<Mutex<Option<GossipRoundState>>>,
-    accepted_round_states: Arc<Mutex<HashMap<Url, GossipRoundState>>>,
+    accepted_round_states: Arc<
+        RwLock<HashMap<Url, Arc<Mutex<GossipRoundState>>>>,
+    >,
 ) {
     {
         let mut initiated_state = initiated_round_state.lock().await;
@@ -47,31 +49,36 @@ async fn remove_timed_out_rounds(
             _ => (),
         }
     }
-
-    accepted_round_states.lock().await.retain(|_, state| {
-        if state.started_at.elapsed() > round_timeout {
-            tracing::warn!("Accepted round timed out: {:?}", state);
-            false
-        } else {
-            true
+    let mut accepted_round_states = accepted_round_states.write().await;
+    let mut remove = HashSet::new();
+    {
+        for (url, state) in accepted_round_states.iter() {
+            if state.lock().await.started_at.elapsed() > round_timeout {
+                tracing::warn!("Accepted round timed out: {:?}", state);
+                remove.insert(url.clone());
+            }
         }
-    });
+    }
+    accepted_round_states.retain(|k, _| !remove.contains(k));
 }
 
 #[cfg(test)]
 mod tests {
     use crate::state::GossipRoundState;
     use crate::timeout::remove_timed_out_rounds;
+    use kitsune2_api::DhtArc;
     use kitsune2_api::Url;
+    use kitsune2_dht::ArcSet;
     use std::collections::HashMap;
     use std::sync::Arc;
-    use tokio::sync::Mutex;
+    use tokio::sync::{Mutex, RwLock};
 
     #[tokio::test(start_paused = true)]
     async fn expire_initiated_round() {
         let initiated = Arc::new(Mutex::new(Some(GossipRoundState::new(
             Url::from_str("ws://test:80/1").unwrap(),
             vec![],
+            ArcSet::new(vec![DhtArc::FULL]).unwrap(),
         ))));
         remove_timed_out_rounds(
             std::time::Duration::from_secs(60),
@@ -87,7 +94,7 @@ mod tests {
         remove_timed_out_rounds(
             std::time::Duration::from_secs(60),
             initiated.clone(),
-            Arc::new(Mutex::new(Default::default())),
+            Default::default(),
         )
         .await;
 
@@ -96,22 +103,27 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn expire_accepted_rounds() {
-        let accepted = Arc::new(Mutex::new(HashMap::new()));
+        let accepted = Arc::new(RwLock::new(HashMap::new()));
 
-        accepted.lock().await.insert(
+        accepted.write().await.insert(
             Url::from_str("ws://test:80/1").unwrap(),
-            GossipRoundState::new(
+            Arc::new(Mutex::new(GossipRoundState::new(
                 Url::from_str("ws://test:80/1").unwrap(),
                 vec![],
-            ),
+                ArcSet::new(vec![DhtArc::FULL]).unwrap(),
+            ))),
         );
 
         tokio::time::advance(std::time::Duration::from_secs(30)).await;
 
         let expected_url = Url::from_str("ws://test:80/2").unwrap();
-        accepted.lock().await.insert(
+        accepted.write().await.insert(
             expected_url.clone(),
-            GossipRoundState::new(expected_url.clone(), vec![]),
+            Arc::new(Mutex::new(GossipRoundState::new(
+                expected_url.clone(),
+                vec![],
+                ArcSet::new(vec![DhtArc::FULL]).unwrap(),
+            ))),
         );
 
         remove_timed_out_rounds(
@@ -121,7 +133,7 @@ mod tests {
         )
         .await;
 
-        assert_eq!(2, accepted.lock().await.len());
+        assert_eq!(2, accepted.read().await.len());
 
         tokio::time::advance(std::time::Duration::from_secs(31)).await;
 
@@ -132,10 +144,10 @@ mod tests {
         )
         .await;
 
-        assert_eq!(1, accepted.lock().await.len());
+        assert_eq!(1, accepted.read().await.len());
         assert_eq!(
             expected_url,
-            accepted.lock().await.keys().next().unwrap().clone()
+            accepted.read().await.keys().next().unwrap().clone()
         );
 
         tokio::time::advance(std::time::Duration::from_secs(31)).await;
@@ -147,6 +159,6 @@ mod tests {
         )
         .await;
 
-        assert_eq!(0, accepted.lock().await.len());
+        assert_eq!(0, accepted.read().await.len());
     }
 }


### PR DESCRIPTION
Integrates the DHT model into gossip to the extent that a tests can be written for disc sync and ring sync.

Most of the required messages are in place now. We might want a "busy" message depending how we deal with limiting the number of rounds or updating the DHT model. We might also want a "Terminate" message to deal with errors so we make an effort to avoid forcing the other side to time out when something goes wrong that wasn't their fault.

There are a lot of paths here that can't be tested in an integration test because they require DHT model mismatches (updated at different timestamps) that happen during the sync process. I need to add unit tests to cover these cases but the PR is big enough I think.

I've not dealt with updating the state of the DHT model. We can either do that in a task and let the open rounds maybe fail or we can drain the current rounds and do the DHT update when there are no active gossip rounds.

Then the obvious is needed, to split up the `gossip.rs`. I have an idea how I'd like to do that but again, this PR is huge and I didn't want to start a refactor on it.. Not sure yet whether that was the right decision :)