### PR TITLE
feat(kitsune2): add top-level crate kitsune2

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,9 +1,7 @@
 name: Test
 
 on:
-  pull_request:
-    branches:
-      - main
+  pull_request: {}
 
 jobs:
   static:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,9 +386,9 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "cmake"
-version = "0.1.52"
+version = "0.1.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c682c223677e0e5b6b7f63a64b9351844c3f1b1678a68b7ee617e30fb082620e"
+checksum = "e24a03c8b52922d68a1589ad61032f2c1aa5a8158d2aa0d93c6e9534944bbad6"
 dependencies = [
  "cc",
 ]
@@ -1250,6 +1250,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "kitsune2"
+version = "0.0.1-alpha"
+dependencies = [
+ "bytes",
+ "futures",
+ "kitsune2_api",
+ "kitsune2_core",
+ "kitsune2_gossip",
+ "kitsune2_test_utils",
+ "kitsune2_transport_tx5",
+ "sbd-server",
+ "tokio",
+]
+
+[[package]]
 name = "kitsune2_api"
 version = "0.0.1-alpha"
 dependencies = [
@@ -1294,7 +1309,6 @@ dependencies = [
 name = "kitsune2_core"
 version = "0.0.1-alpha"
 dependencies = [
- "axum",
  "backon",
  "bytes",
  "ed25519-dalek",
@@ -1346,10 +1360,12 @@ dependencies = [
 name = "kitsune2_test_utils"
 version = "0.1.0-nopublish"
 dependencies = [
+ "axum",
  "bytes",
  "futures",
  "kitsune2_api",
  "rand",
+ "tokio",
  "tracing",
  "tracing-subscriber",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "crates/core",
   "crates/dht",
   "crates/gossip",
+  "crates/kitsune2",
   "crates/test_utils",
   "crates/tool_proto_build",
   "crates/transport_tx5",
@@ -18,6 +19,7 @@ resolver = "2"
 kitsune2_api = { version = "0.0.1-alpha", path = "crates/api" }
 kitsune2_dht = { version = "0.0.1-alpha", path = "crates/dht" }
 kitsune2_gossip = { version = "0.0.1-alpha", path = "crates/gossip" }
+kitsune2_transport_tx5 = { version = "0.0.1-alpha", path = "crates/transport_tx5" }
 
 # used by bootstrap_srv for mpmc worker queue pattern.
 async-channel = "2.3.1"

--- a/crates/api/src/builder.rs
+++ b/crates/api/src/builder.rs
@@ -50,6 +50,7 @@ pub struct Builder {
     /// The [gossip::GossipFactory] to be used for creating
     /// [gossip::Gossip] instances.
     pub gossip: gossip::DynGossipFactory,
+
     /// The [local_agent_store::LocalAgentStoreFactory] to be used for creating
     /// [local_agent_store::LocalAgentStore] instances.
     pub local_agent_store: Arc<dyn LocalAgentStoreFactory>,

--- a/crates/api/src/gossip.rs
+++ b/crates/api/src/gossip.rs
@@ -5,12 +5,19 @@ use crate::peer_store::DynPeerStore;
 use crate::transport::DynTransport;
 use crate::{
     builder, config, BoxFut, DynLocalAgentStore, DynOpStore, DynPeerMetaStore,
-    K2Result, SpaceId,
+    K2Result, SpaceId, StoredOp,
 };
 use std::sync::Arc;
 
 /// Represents the ability to sync DHT data with other agents through background communication.
-pub trait Gossip: 'static + Send + Sync + std::fmt::Debug {}
+pub trait Gossip: 'static + Send + Sync + std::fmt::Debug {
+    /// Inform the gossip module that a set of ops have been stored.
+    ///
+    /// This is not expected to be called directly. It is intended to be used by the
+    /// space that owns this gossip module. See [crate::space::Space::inform_ops_stored].
+    fn inform_ops_stored(&self, ops: Vec<StoredOp>)
+        -> BoxFut<'_, K2Result<()>>;
+}
 
 /// Trait-object [Gossip].
 pub type DynGossip = Arc<dyn Gossip>;

--- a/crates/api/src/space.rs
+++ b/crates/api/src/space.rs
@@ -1,6 +1,7 @@
 //! Kitsune2 space related types.
 
 use crate::agent::DynLocalAgent;
+use crate::fetch::DynFetch;
 use crate::*;
 use std::sync::Arc;
 
@@ -47,6 +48,19 @@ pub trait Space: 'static + Send + Sync + std::fmt::Debug {
     /// Get a reference to the local agent store being used by this space.
     fn local_agent_store(&self) -> &DynLocalAgentStore;
 
+    /// Get a reference to the op store of this space. Ops can be injected and
+    /// retrieved from the op store.
+    fn op_store(&self) -> &DynOpStore;
+
+    /// Get a reference to the fetch module of this space.
+    fn fetch(&self) -> &DynFetch;
+
+    /// Get a reference to the gossip module of this space.
+    fn gossip(&self) -> &DynGossip;
+
+    /// Get a reference to the peer meta store being used by this space.
+    fn peer_meta_store(&self) -> &DynPeerMetaStore;
+
     /// Indicate that an agent is now online, and should begin receiving
     /// messages and exchanging dht information.
     fn local_agent_join(
@@ -80,6 +94,19 @@ pub trait Space: 'static + Send + Sync + std::fmt::Debug {
         from_agent: AgentId,
         data: bytes::Bytes,
     ) -> BoxFut<'_, K2Result<()>>;
+
+    /// Inform the space that a set of ops have been stored.
+    ///
+    /// This should be called once the ops have been:
+    /// - Checked to be correctly structured according to the Kitsune2 host implementation.
+    /// - Persisted to the op store.
+    ///
+    /// Until this is called, gossip will not include these ops in its DHT model, and they will
+    /// therefore not be synced with other peers. They may be synced with other peers through the
+    /// "new ops" mechanism, depending on the op store implementation, but that only makes them
+    /// available briefly.
+    fn inform_ops_stored(&self, ops: Vec<StoredOp>)
+        -> BoxFut<'_, K2Result<()>>;
 }
 
 /// Trait-object [Space].

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -27,10 +27,6 @@ ureq = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
-axum = { workspace = true, default-features = false, features = [
-  "http1",
-  "tokio",
-] }
 ed25519-dalek = { workspace = true, features = ["rand_core"] }
 kitsune2_api = { workspace = true, features = ["mockall"] }
 kitsune2_test_utils = { workspace = true }

--- a/crates/core/src/factories/core_fetch/message_handler.rs
+++ b/crates/core/src/factories/core_fetch/message_handler.rs
@@ -24,7 +24,7 @@ impl TxModuleHandler for FetchMessageHandler {
         _module: String,
         data: bytes::Bytes,
     ) -> K2Result<()> {
-        tracing::debug!("receiving module message from {peer}");
+        tracing::trace!("receiving module message from {peer}");
         let fetch = K2FetchMessage::decode(data).map_err(|err| {
             K2Error::other_src(
                 format!("could not decode module message from {peer}"),

--- a/crates/core/src/factories/core_gossip.rs
+++ b/crates/core/src/factories/core_gossip.rs
@@ -5,7 +5,7 @@ use kitsune2_api::peer_store::DynPeerStore;
 use kitsune2_api::transport::{DynTransport, TxBaseHandler, TxModuleHandler};
 use kitsune2_api::{
     BoxFut, DynGossip, DynGossipFactory, DynLocalAgentStore, DynOpStore,
-    DynPeerMetaStore, Gossip, GossipFactory, K2Result, SpaceId,
+    DynPeerMetaStore, Gossip, GossipFactory, K2Result, SpaceId, StoredOp,
 };
 use std::sync::Arc;
 
@@ -60,7 +60,17 @@ impl GossipFactory for CoreGossipStubFactory {
 #[derive(Debug, Clone)]
 pub struct CoreGossipStub;
 
-impl Gossip for CoreGossipStub {}
+impl Gossip for CoreGossipStub {
+    fn inform_ops_stored(
+        &self,
+        ops: Vec<StoredOp>,
+    ) -> BoxFut<'_, K2Result<()>> {
+        Box::pin(async move {
+            drop(ops);
+            Ok(())
+        })
+    }
+}
 
 impl TxBaseHandler for CoreGossipStub {}
 impl TxModuleHandler for CoreGossipStub {}

--- a/crates/core/src/factories/core_kitsune.rs
+++ b/crates/core/src/factories/core_kitsune.rs
@@ -140,6 +140,8 @@ impl Kitsune for CoreKitsune {
 
 #[cfg(test)]
 mod test {
+    use kitsune2_test_utils::space::TEST_SPACE_ID;
+
     #[tokio::test(flavor = "multi_thread")]
     async fn happy_space_construct() {
         use kitsune2_api::{kitsune::*, space::*, *};
@@ -186,8 +188,6 @@ mod test {
             .await
             .unwrap();
 
-        k.space(bytes::Bytes::from_static(b"space1").into())
-            .await
-            .unwrap();
+        k.space(TEST_SPACE_ID).await.unwrap();
     }
 }

--- a/crates/core/src/factories/core_local_agent_store.rs
+++ b/crates/core/src/factories/core_local_agent_store.rs
@@ -51,7 +51,8 @@ impl LocalAgentStore for CoreLocalAgentStore {
 pub struct CoreLocalAgentStoreFactory;
 
 impl CoreLocalAgentStoreFactory {
-    pub(crate) fn create() -> Arc<dyn LocalAgentStoreFactory> {
+    /// Construct a new CoreLocalAgentStoreFactory.
+    pub fn create() -> Arc<dyn LocalAgentStoreFactory> {
         Arc::new(CoreLocalAgentStoreFactory)
     }
 }

--- a/crates/core/src/factories/core_space/test.rs
+++ b/crates/core/src/factories/core_space/test.rs
@@ -38,7 +38,7 @@ async fn space_local_agent_join_leave() {
     let bob = Arc::new(TestLocalAgent::default()) as agent::DynLocalAgent;
     let ned = Arc::new(TestLocalAgent::default()) as agent::DynLocalAgent;
 
-    let s1 = k1.space(TEST_SPACE_ID.clone()).await.unwrap();
+    let s1 = k1.space(TEST_SPACE_ID).await.unwrap();
 
     s1.local_agent_join(bob.clone()).await.unwrap();
     s1.local_agent_join(ned.clone()).await.unwrap();

--- a/crates/gossip/src/gossip.rs
+++ b/crates/gossip/src/gossip.rs
@@ -14,9 +14,9 @@ use kitsune2_api::fetch::DynFetch;
 use kitsune2_api::peer_store::DynPeerStore;
 use kitsune2_api::transport::{DynTransport, TxBaseHandler, TxModuleHandler};
 use kitsune2_api::{
-    DynGossip, DynGossipFactory, DynLocalAgentStore, DynOpStore,
+    BoxFut, DynGossip, DynGossipFactory, DynLocalAgentStore, DynOpStore,
     DynPeerMetaStore, Gossip, GossipFactory, K2Error, K2Result, SpaceId,
-    Timestamp, Url, UNIX_TIMESTAMP,
+    StoredOp, Timestamp, Url, UNIX_TIMESTAMP,
 };
 use kitsune2_dht::{Dht, DhtApi};
 use std::collections::HashMap;
@@ -63,11 +63,12 @@ impl GossipFactory for K2GossipFactory {
         fetch: DynFetch,
     ) -> kitsune2_api::BoxFut<'static, K2Result<DynGossip>> {
         Box::pin(async move {
-            let config: K2GossipConfig = builder.config.get_module_config()?;
+            let config =
+                builder.config.get_module_config::<K2GossipModConfig>()?;
 
             let gossip: DynGossip = Arc::new(
                 K2Gossip::create(
-                    config,
+                    config.k2_gossip,
                     space_id,
                     peer_store,
                     local_agent_store,
@@ -273,7 +274,7 @@ impl K2Gossip {
             max_new_bytes: self.config.max_gossip_op_bytes,
         };
 
-        // Right before we send the initiate message, check whether the target has already
+        // Before we send the initiate message, check whether the target has already
         // initiated with us. If they have, we can just skip initiating.
         if self
             .accepted_round_states
@@ -323,7 +324,16 @@ impl K2Gossip {
     }
 }
 
-impl Gossip for K2Gossip {}
+impl Gossip for K2Gossip {
+    fn inform_ops_stored(
+        &self,
+        ops: Vec<StoredOp>,
+    ) -> BoxFut<'_, K2Result<()>> {
+        Box::pin(
+            async move { self.dht.write().await.inform_ops_stored(ops).await },
+        )
+    }
+}
 
 impl TxBaseHandler for K2Gossip {}
 impl TxModuleHandler for K2Gossip {
@@ -382,14 +392,17 @@ mod test {
     use kitsune2_core::{default_test_builder, Ed25519LocalAgent};
     use kitsune2_dht::UNIT_TIME;
     use kitsune2_test_utils::enable_tracing;
+    use kitsune2_test_utils::noop_bootstrap::NoopBootstrapFactory;
+    use kitsune2_test_utils::space::TEST_SPACE_ID;
     use std::time::Duration;
 
     #[derive(Debug, Clone)]
     struct GossipTestHarness {
-        gossip: K2Gossip,
+        _gossip: DynGossip,
         peer_store: DynPeerStore,
         op_store: DynOpStore,
         space: DynSpace,
+        peer_meta_store: Arc<K2PeerMetaStore>,
     }
 
     impl GossipTestHarness {
@@ -500,11 +513,30 @@ mod test {
     }
 
     impl TestGossipFactory {
-        pub async fn create(space: SpaceId) -> TestGossipFactory {
-            let mut builder = default_test_builder();
+        pub async fn create(
+            space: SpaceId,
+            bootstrap: bool,
+        ) -> TestGossipFactory {
+            let mut builder =
+                default_test_builder().with_default_config().unwrap();
             // Replace the core builder with a real gossip factory
             builder.gossip = K2GossipFactory::create();
-            let builder = Arc::new(builder.with_default_config().unwrap());
+
+            if !bootstrap {
+                builder.bootstrap = Arc::new(NoopBootstrapFactory);
+            }
+
+            builder
+                .config
+                .set_module_config(&K2GossipModConfig {
+                    k2_gossip: K2GossipConfig {
+                        initiate_interval_ms: 10,
+                        min_initiate_interval_ms: 10,
+                        ..Default::default()
+                    },
+                })
+                .unwrap();
+            let builder = Arc::new(builder);
 
             TestGossipFactory {
                 space_id: space,
@@ -539,97 +571,54 @@ mod test {
                 .await
                 .unwrap();
 
-            let op_store = self
-                .builder
-                .op_store
-                .create(self.builder.clone(), self.space_id.clone())
-                .await
-                .unwrap();
-
-            let gossip = K2Gossip::create(
-                K2GossipConfig::default(),
+            let peer_meta_store = K2PeerMetaStore::new(
+                space.peer_meta_store().clone(),
                 self.space_id.clone(),
-                space.peer_store().clone(),
-                space.local_agent_store().clone(),
-                self.builder
-                    .peer_meta_store
-                    .create(self.builder.clone())
-                    .await
-                    .unwrap(),
-                op_store.clone(),
-                transport.clone(),
-                self.builder
-                    .fetch
-                    .create(
-                        self.builder.clone(),
-                        self.space_id.clone(),
-                        op_store.clone(),
-                        transport.clone(),
-                    )
-                    .await
-                    .unwrap(),
-                self.builder.verifier.clone(),
-            )
-            .await
-            .unwrap();
+            );
 
             GossipTestHarness {
-                gossip,
+                _gossip: space.gossip().clone(),
                 peer_store: space.peer_store().clone(),
-                op_store,
+                op_store: space.op_store().clone(),
                 space,
+                peer_meta_store: Arc::new(peer_meta_store),
             }
         }
-    }
-
-    fn test_space() -> SpaceId {
-        SpaceId::from(Bytes::from_static(b"test-space"))
-    }
-
-    #[tokio::test]
-    async fn create_gossip_instance() {
-        let factory = TestGossipFactory::create(test_space()).await;
-        factory.new_instance().await;
     }
 
     #[tokio::test]
     async fn two_way_agent_sync() {
         enable_tracing();
 
-        let space = test_space();
-        let factory = TestGossipFactory::create(space.clone()).await;
+        let space = TEST_SPACE_ID;
+        let factory = TestGossipFactory::create(space.clone(), false).await;
         let harness_1 = factory.new_instance().await;
         let agent_info_1 = harness_1.join_local_agent(DhtArc::FULL).await;
 
         let harness_2 = factory.new_instance().await;
         harness_2.join_local_agent(DhtArc::FULL).await;
-        harness_2
-            .peer_store
-            .insert(vec![agent_info_1.clone()])
-            .await
-            .unwrap();
 
         // Join extra agents for each peer. These will take a few seconds to be
         // found by bootstrap. Try to sync them with gossip.
         let secret_agent_1 = harness_1.join_local_agent(DhtArc::FULL).await;
-        let secret_agent_2 = harness_2.join_local_agent(DhtArc::FULL).await;
-
-        assert!(harness_1
-            .peer_store
-            .get(secret_agent_2.agent.clone())
-            .await
-            .unwrap()
-            .is_none());
         assert!(harness_2
             .peer_store
             .get(secret_agent_1.agent.clone())
             .await
             .unwrap()
             .is_none());
+        let secret_agent_2 = harness_2.join_local_agent(DhtArc::FULL).await;
+        assert!(harness_1
+            .peer_store
+            .get(secret_agent_2.agent.clone())
+            .await
+            .unwrap()
+            .is_none());
 
+        // Simulate peer discovery so that gossip can sync agents
         harness_2
-            .gossip
-            .initiate_gossip(agent_info_1.url.clone().unwrap())
+            .peer_store
+            .insert(vec![agent_info_1.clone()])
             .await
             .unwrap();
 
@@ -645,10 +634,10 @@ mod test {
     async fn two_way_op_sync() {
         enable_tracing();
 
-        let space = test_space();
-        let factory = TestGossipFactory::create(space.clone()).await;
+        let space = TEST_SPACE_ID;
+        let factory = TestGossipFactory::create(space.clone(), true).await;
         let harness_1 = factory.new_instance().await;
-        let agent_info_1 = harness_1.join_local_agent(DhtArc::FULL).await;
+        harness_1.join_local_agent(DhtArc::FULL).await;
         let op_1 = MemoryOp::new(Timestamp::now(), vec![1; 128]);
         let op_id_1 = op_1.compute_op_id();
         harness_1
@@ -667,12 +656,6 @@ mod test {
             .await
             .unwrap();
 
-        harness_2
-            .gossip
-            .initiate_gossip(agent_info_1.url.clone().unwrap())
-            .await
-            .unwrap();
-
         let received_ops = harness_1.wait_for_ops(vec![op_id_2]).await;
         assert_eq!(1, received_ops.len());
         assert_eq!(op_2, received_ops[0]);
@@ -686,8 +669,9 @@ mod test {
     async fn disc_sync() {
         enable_tracing();
 
-        let space = test_space();
-        let factory = TestGossipFactory::create(space.clone()).await;
+        let space = TEST_SPACE_ID;
+        let factory = TestGossipFactory::create(space.clone(), false).await;
+
         let harness_1 = factory.new_instance().await;
         let agent_info_1 = harness_1.join_local_agent(DhtArc::FULL).await;
         let op_1 = MemoryOp::new(Timestamp::from_micros(100), vec![1; 128]);
@@ -697,12 +681,8 @@ mod test {
             .process_incoming_ops(vec![op_1.clone().into()])
             .await
             .unwrap();
-
         harness_1
-            .gossip
-            .dht
-            .write()
-            .await
+            .space
             .inform_ops_stored(vec![op_1.clone().into()])
             .await
             .unwrap();
@@ -716,12 +696,8 @@ mod test {
             .process_incoming_ops(vec![op_2.clone().into()])
             .await
             .unwrap();
-
         harness_2
-            .gossip
-            .dht
-            .write()
-            .await
+            .space
             .inform_ops_stored(vec![op_2.clone().into()])
             .await
             .unwrap();
@@ -729,7 +705,6 @@ mod test {
         // Inform the harnesses that we've already synced up to now. This will force the
         // ops we just created to be treated as historical disc ops.
         harness_1
-            .gossip
             .peer_meta_store
             .set_new_ops_bookmark(
                 agent_info_2.url.clone().unwrap(),
@@ -738,7 +713,6 @@ mod test {
             .await
             .unwrap();
         harness_2
-            .gossip
             .peer_meta_store
             .set_new_ops_bookmark(
                 agent_info_1.url.clone().unwrap(),
@@ -747,9 +721,10 @@ mod test {
             .await
             .unwrap();
 
-        harness_2
-            .gossip
-            .initiate_gossip(agent_info_1.url.clone().unwrap())
+        // Simulate peer discovery so that gossip can perform a disc sync
+        harness_1
+            .peer_store
+            .insert(vec![agent_info_2.clone()])
             .await
             .unwrap();
 
@@ -766,8 +741,8 @@ mod test {
     async fn ring_sync() {
         enable_tracing();
 
-        let space = test_space();
-        let factory = TestGossipFactory::create(space.clone()).await;
+        let space = TEST_SPACE_ID;
+        let factory = TestGossipFactory::create(space.clone(), false).await;
         let harness_1 = factory.new_instance().await;
         let agent_info_1 = harness_1.join_local_agent(DhtArc::FULL).await;
         let op_1 = MemoryOp::new(
@@ -780,18 +755,14 @@ mod test {
             .process_incoming_ops(vec![op_1.clone().into()])
             .await
             .unwrap();
-
         harness_1
-            .gossip
-            .dht
-            .write()
-            .await
+            .space
             .inform_ops_stored(vec![op_1.clone().into()])
             .await
             .unwrap();
 
         let harness_2 = factory.new_instance().await;
-        let agent_2 = harness_2.join_local_agent(DhtArc::FULL).await;
+        let agent_info_2 = harness_2.join_local_agent(DhtArc::FULL).await;
         let op_2 = MemoryOp::new(
             (Timestamp::now() - 2 * UNIT_TIME).unwrap(),
             vec![2; 128],
@@ -802,29 +773,23 @@ mod test {
             .process_incoming_ops(vec![op_2.clone().into()])
             .await
             .unwrap();
-
         harness_2
-            .gossip
-            .dht
-            .write()
-            .await
+            .space
             .inform_ops_stored(vec![op_2.clone().into()])
             .await
             .unwrap();
 
         // Inform the harnesses that we've already synced up to now. This will force the
-        // ops we just created to be treated as historical disc ops.
+        // ops we just created to be treated as historical ring ops.
         harness_1
-            .gossip
             .peer_meta_store
             .set_new_ops_bookmark(
-                agent_2.url.clone().unwrap(),
+                agent_info_2.url.clone().unwrap(),
                 Timestamp::now(),
             )
             .await
             .unwrap();
         harness_2
-            .gossip
             .peer_meta_store
             .set_new_ops_bookmark(
                 agent_info_1.url.clone().unwrap(),
@@ -833,9 +798,10 @@ mod test {
             .await
             .unwrap();
 
-        harness_2
-            .gossip
-            .initiate_gossip(agent_info_1.url.clone().unwrap())
+        // Simulate peer discovery so that gossip can perform a ring sync
+        harness_1
+            .peer_store
+            .insert(vec![agent_info_2.clone()])
             .await
             .unwrap();
 

--- a/crates/kitsune2/Cargo.toml
+++ b/crates/kitsune2/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "kitsune2"
+version = "0.0.1-alpha"
+description = "p2p / dht communication framework api"
+license = "Apache-2.0"
+homepage = "https://github.com/holochain/kitsune2"
+documentation = "https://docs.rs/kitsune2"
+authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
+keywords = ["holochain", "p2p", "dht", "networking"]
+categories = ["network-programming"]
+edition = "2021"
+
+[dependencies]
+bytes = { workspace = true }
+kitsune2_api = { workspace = true }
+kitsune2_core = { workspace = true }
+kitsune2_gossip = { workspace = true }
+kitsune2_transport_tx5 = { workspace = true }
+
+[dev-dependencies]
+futures = { workspace = true }
+kitsune2_gossip = { workspace = true }
+kitsune2_test_utils = { workspace = true }
+sbd-server = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }

--- a/crates/kitsune2/src/lib.rs
+++ b/crates/kitsune2/src/lib.rs
@@ -1,0 +1,39 @@
+use kitsune2_api::{builder::Builder, config::Config};
+use kitsune2_core::{
+    factories::{self, MemOpStoreFactory},
+    Ed25519Verifier,
+};
+use kitsune2_gossip::K2GossipFactory;
+use kitsune2_transport_tx5::Tx5TransportFactory;
+
+/// Construct a default production builder for Kitsune2.
+///
+/// - `verifier` - The default verifier is [Ed25519Verifier].
+/// - `kitsune` - The default top-level kitsune module is [factories::CoreKitsuneFactory].
+/// - `space` - The default space module is [factories::CoreSpaceFactory].
+/// - `peer_store` - The default peer store is [factories::MemPeerStoreFactory].
+/// - `bootstrap` - The default bootstrap is [factories::CoreBootstrapFactory].
+/// - `fetch` - The default fetch module is [factories::CoreFetchFactory].
+/// - `transport` - The default transport is [Tx5TransportFactory].
+/// - `op_store` - The default op store is [MemOpStoreFactory].
+///                Note: you will likely want to implement your own op store.
+/// - `peer_meta_store` - The default peer meta store is [factories::MemPeerMetaStoreFactory].
+///                       Note: you will likely want to implement your own peer meta store.
+/// - `gossip` - The default gossip module is [K2GossipFactory].
+/// - `local_agent_store` - The default local agent store is [factories::CoreLocalAgentStoreFactory].
+pub fn default_builder() -> Builder {
+    Builder {
+        config: Config::default(),
+        verifier: std::sync::Arc::new(Ed25519Verifier),
+        kitsune: factories::CoreKitsuneFactory::create(),
+        space: factories::CoreSpaceFactory::create(),
+        peer_store: factories::MemPeerStoreFactory::create(),
+        bootstrap: factories::CoreBootstrapFactory::create(),
+        fetch: factories::CoreFetchFactory::create(),
+        transport: Tx5TransportFactory::create(),
+        op_store: MemOpStoreFactory::create(),
+        peer_meta_store: factories::MemPeerMetaStoreFactory::create(),
+        gossip: K2GossipFactory::create(),
+        local_agent_store: factories::CoreLocalAgentStoreFactory::create(),
+    }
+}

--- a/crates/test_utils/Cargo.toml
+++ b/crates/test_utils/Cargo.toml
@@ -5,9 +5,14 @@ version = "0.1.0-nopublish"
 edition = "2021"
 
 [dependencies]
+axum = { workspace = true, default-features = false, features = [
+  "http1",
+  "tokio",
+] }
 bytes = { workspace = true }
 futures = { workspace = true }
 kitsune2_api = { workspace = true }
 rand = { workspace = true }
+tokio = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/crates/test_utils/src/bootstrap.rs
+++ b/crates/test_utils/src/bootstrap.rs
@@ -1,0 +1,112 @@
+//! Test utilities associated with bootstrapping.
+
+use axum::*;
+use std::sync::atomic::*;
+use std::sync::{Arc, Mutex};
+
+/// A test bootstrap server.
+pub struct TestBootstrapSrv {
+    kill: Option<tokio::sync::oneshot::Sender<()>>,
+    task: tokio::task::JoinHandle<std::io::Result<()>>,
+    halt: Arc<std::sync::atomic::AtomicBool>,
+    addr: String,
+}
+
+impl Drop for TestBootstrapSrv {
+    fn drop(&mut self) {
+        if let Some(kill) = self.kill.take() {
+            let _ = kill.send(());
+        }
+        self.task.abort();
+    }
+}
+
+impl TestBootstrapSrv {
+    /// Construct a test bootstrap server.
+    pub async fn new(initial_halt: bool) -> Self {
+        let (kill, kill_r) = tokio::sync::oneshot::channel();
+        let kill = Some(kill);
+        let kill_r = async move {
+            let _ = kill_r.await;
+        };
+
+        let l = tokio::net::TcpListener::bind(std::net::SocketAddr::from((
+            [127, 0, 0, 1],
+            0,
+        )))
+        .await
+        .unwrap();
+        let addr = format!("http://{:?}", l.local_addr().unwrap());
+
+        let halt = Arc::new(std::sync::atomic::AtomicBool::new(initial_halt));
+
+        #[derive(Clone)]
+        struct State {
+            halt: Arc<AtomicBool>,
+            data: Arc<Mutex<Vec<String>>>,
+        }
+
+        let get_state = State {
+            halt: halt.clone(),
+            data: Arc::new(Mutex::new(Vec::new())),
+        };
+        let put_state = get_state.clone();
+
+        let app: Router = Router::new()
+            .route(
+                "/bootstrap/:space",
+                routing::get(move || async move {
+                    if get_state.halt.load(Ordering::SeqCst) {
+                        return Err(
+                            http::status::StatusCode::INTERNAL_SERVER_ERROR,
+                        );
+                    }
+                    let mut out = "[".to_string();
+                    let mut is_first = true;
+                    for d in get_state.data.lock().unwrap().iter() {
+                        if is_first {
+                            is_first = false;
+                        } else {
+                            out.push(',');
+                        }
+                        out.push_str(d);
+                    }
+                    out.push(']');
+                    Ok(out)
+                }),
+            )
+            .route(
+                "/bootstrap/:space/:agent",
+                routing::put(move |body: String| async move {
+                    if put_state.halt.load(Ordering::SeqCst) {
+                        return Err(
+                            http::status::StatusCode::INTERNAL_SERVER_ERROR,
+                        );
+                    }
+                    put_state.data.lock().unwrap().push(body);
+                    Ok("{}".to_string())
+                }),
+            );
+
+        let task = tokio::task::spawn(std::future::IntoFuture::into_future(
+            serve(l, app).with_graceful_shutdown(kill_r),
+        ));
+
+        Self {
+            kill,
+            task,
+            halt,
+            addr,
+        }
+    }
+
+    /// Set whether server should return an error.
+    pub fn set_halt(&self, halt: bool) {
+        self.halt.store(halt, std::sync::atomic::Ordering::SeqCst);
+    }
+
+    /// Return server address.
+    pub fn addr(&self) -> &str {
+        &self.addr
+    }
+}

--- a/crates/test_utils/src/lib.rs
+++ b/crates/test_utils/src/lib.rs
@@ -4,7 +4,9 @@
 use rand::RngCore;
 
 pub mod agent;
+pub mod bootstrap;
 pub mod id;
+pub mod noop_bootstrap;
 pub mod space;
 
 /// Enable tracing with the RUST_LOG environment variable.
@@ -33,19 +35,25 @@ pub fn random_bytes(length: u16) -> Vec<u8> {
 /// The default timeout is 100 ms.
 #[macro_export]
 macro_rules! iter_check {
-    ($millis:literal, $code:block) => {
+    ($timeout_ms:literal, $sleep_ms:literal, $code:block) => {
         tokio::time::timeout(
-            std::time::Duration::from_millis($millis),
+            std::time::Duration::from_millis($timeout_ms),
             async {
                 loop {
-                    tokio::time::sleep(std::time::Duration::from_millis(1))
-                        .await;
+                    tokio::time::sleep(std::time::Duration::from_millis(
+                        $sleep_ms,
+                    ))
+                    .await;
                     $code
                 }
             },
         )
         .await
         .unwrap();
+    };
+
+    ($timeout_ms:literal, $code:block) => {
+        iter_check!($timeout_ms, 1, $code)
     };
 
     ($code:block) => {

--- a/crates/test_utils/src/noop_bootstrap.rs
+++ b/crates/test_utils/src/noop_bootstrap.rs
@@ -1,0 +1,47 @@
+//! A no-op bootstrap implementation.
+//!
+//! This is useful for testing or for cases where you don't want bootstrap to discover peers.
+
+use kitsune2_api::agent::AgentInfoSigned;
+use kitsune2_api::bootstrap::{Bootstrap, BootstrapFactory, DynBootstrap};
+use kitsune2_api::builder::Builder;
+use kitsune2_api::config::Config;
+use kitsune2_api::peer_store::DynPeerStore;
+use kitsune2_api::{BoxFut, K2Result, SpaceId};
+use std::sync::Arc;
+
+/// A factory for constructing [NoopBootstrap] instances.
+#[derive(Debug)]
+pub struct NoopBootstrapFactory;
+
+impl BootstrapFactory for NoopBootstrapFactory {
+    fn default_config(&self, _config: &mut Config) -> K2Result<()> {
+        Ok(())
+    }
+
+    fn validate_config(&self, _config: &Config) -> K2Result<()> {
+        Ok(())
+    }
+
+    fn create(
+        &self,
+        _builder: Arc<Builder>,
+        _peer_store: DynPeerStore,
+        _space: SpaceId,
+    ) -> BoxFut<'static, K2Result<DynBootstrap>> {
+        Box::pin(async move {
+            let bootstrap: DynBootstrap = Arc::new(NoopBootstrap {});
+            Ok(bootstrap)
+        })
+    }
+}
+
+/// A bootstrap implementation that does nothing.
+#[derive(Debug)]
+pub struct NoopBootstrap;
+
+impl Bootstrap for NoopBootstrap {
+    fn put(&self, _info: Arc<AgentInfoSigned>) {
+        // no-op
+    }
+}

--- a/crates/transport_tx5/Cargo.toml
+++ b/crates/transport_tx5/Cargo.toml
@@ -16,7 +16,7 @@ kitsune2_api = { workspace = true }
 serde = { workspace = true }
 tokio = { workspace = true, features = ["rt", "sync", "time"] }
 tracing = { workspace = true }
-tx5 = { version = "0.2.0-beta", default-features = false, features = [
+tx5 = { workspace = true, default-features = false, features = [
   "backend-libdatachannel",
 ] }
 


### PR DESCRIPTION
Adds a top-level crate called "kitsune2" with a production default builder. There's a full integration test using the builder.

The test is flaky with higher number of ops. ~~and I'm asking here first before going about the debugging myself. When the number of ops to be exchanged during gossip is increased to about 100 each, the following error happens almost always:~~

Fixing the error will be part of another branch.

```sh
2025-01-28T18:37:32.101834Z DEBUG NETAUDIT: pub_key=0HDL-1H_0bmwwx7XZUWY6k39pRM9OSHLWwIs_P2c6xE byte_count=195 err=Kind(BrokenPipe) m="tx5-connection" a="send_framed_error"
2025-01-28T18:37:32.101862Z  WARN kitsune2_core::factories::core_fetch: could not send ops to requesting peer: tx5 send error (src: broken pipe) op_ids=[qLkchkQ6c3wdv8e8z2edk6OAjSQFbHIEwMr7vXYiEfM] peer=ws://127.0.0.1:38851/0HDL-1H_0bmwwx7XZUWY6k39pRM9OSHLWwIs_P2c6xE
```

Famous error that we spotted in Holochain too, I believe.

resolved #79 