### PR TITLE
New ops respect common arc set

### DIFF
--- a/crates/api/src/op_store.rs
+++ b/crates/api/src/op_store.rs
@@ -92,7 +92,8 @@ pub trait OpStore: 'static + Send + Sync + std::fmt::Debug {
         op_ids: Vec<OpId>,
     ) -> BoxFuture<'_, K2Result<Vec<MetaOp>>>;
 
-    /// Retrieve a size-bounded list of op ids that have been stored since `start`.
+    /// Retrieve a size-bounded list of op ids that have been stored within the given `arc` since
+    /// `start`.
     ///
     /// The `start` timestamp is used to retrieve ops by their `stored_at` timestamp rather than
     /// their creation timestamp. This means that the `start` value can be used to page an op
@@ -109,13 +110,15 @@ pub trait OpStore: 'static + Send + Sync + std::fmt::Debug {
     ///
     /// # Returns
     ///
-    /// As many op ids as can be returned within the `limit_bytes` limit.
-    // TODO Must respect an arc set because it is used within gossip!
+    /// - As many op ids as can be returned within the `limit_bytes` limit.
+    /// - The total size of the op data that is pointed to by the returned op ids.
+    /// - A new timestamp to be used for the next query..
     fn retrieve_op_ids_bounded(
         &self,
+        arc: DhtArc,
         start: Timestamp,
         limit_bytes: usize,
-    ) -> BoxFuture<'_, K2Result<(Vec<OpId>, Timestamp)>>;
+    ) -> BoxFuture<'_, K2Result<(Vec<OpId>, usize, Timestamp)>>;
 
     /// Store the combined hash of a time slice.
     fn store_slice_hash(

--- a/crates/core/src/factories/mem_op_store/test.rs
+++ b/crates/core/src/factories/mem_op_store/test.rs
@@ -4,7 +4,7 @@ use kitsune2_api::{DhtArc, DynOpStore, SpaceId, Timestamp};
 use std::sync::Arc;
 
 fn op_at_location(loc: u32) -> MemoryOp {
-    let mut out = vec![];
+    let mut out = Vec::with_capacity(32);
     out.extend_from_slice(&loc.to_le_bytes());
     out.resize(32, 0);
 

--- a/crates/core/src/factories/mem_op_store/test.rs
+++ b/crates/core/src/factories/mem_op_store/test.rs
@@ -1,6 +1,6 @@
 use crate::factories::mem_op_store::Kitsune2MemoryOpStore;
 use crate::factories::MemoryOp;
-use kitsune2_api::{DhtArc, DynOpStore, SpaceId, Timestamp};
+use kitsune2_api::{DhtArc, DynOpStore, Timestamp};
 use kitsune2_test_utils::space::TEST_SPACE_ID;
 use std::sync::Arc;
 
@@ -55,9 +55,8 @@ async fn retrieve_op_ids_bounded_empty_arc() {
 
 #[tokio::test]
 async fn retrieve_op_ids_bounded_limit_applied() {
-    let op_store: DynOpStore = Arc::new(Kitsune2MemoryOpStore::new(
-        SpaceId::from(bytes::Bytes::from_static(b"test")),
-    ));
+    let op_store: DynOpStore =
+        Arc::new(Kitsune2MemoryOpStore::new(TEST_SPACE_ID));
 
     op_store
         .process_incoming_ops(vec![
@@ -86,9 +85,8 @@ async fn retrieve_op_ids_bounded_limit_applied() {
 
 #[tokio::test]
 async fn retrieve_op_ids_bounded_across_multiple_arcs() {
-    let op_store: DynOpStore = Arc::new(Kitsune2MemoryOpStore::new(
-        SpaceId::from(bytes::Bytes::from_static(b"test")),
-    ));
+    let op_store: DynOpStore =
+        Arc::new(Kitsune2MemoryOpStore::new(TEST_SPACE_ID));
 
     op_store
         .process_incoming_ops(vec![

--- a/crates/core/src/factories/mem_op_store/test.rs
+++ b/crates/core/src/factories/mem_op_store/test.rs
@@ -1,7 +1,15 @@
 use crate::factories::mem_op_store::Kitsune2MemoryOpStore;
 use crate::factories::MemoryOp;
-use kitsune2_api::{DynOpStore, SpaceId, Timestamp};
+use kitsune2_api::{DhtArc, DynOpStore, SpaceId, Timestamp};
 use std::sync::Arc;
+
+fn op_at_location(loc: u32) -> MemoryOp {
+    let mut out = vec![];
+    out.extend_from_slice(&loc.to_le_bytes());
+    out.resize(32, 0);
+
+    MemoryOp::new(Timestamp::now(), out)
+}
 
 #[tokio::test]
 async fn process_and_retrieve_op() {
@@ -22,4 +30,121 @@ async fn process_and_retrieve_op() {
 
     let out: MemoryOp = serde_json::from_slice(&retrieved[0].op_data).unwrap();
     assert_eq!(op, out);
+}
+
+#[tokio::test]
+async fn retrieve_op_ids_bounded_empty_arc() {
+    let op_store: DynOpStore = Arc::new(Kitsune2MemoryOpStore::new(
+        SpaceId::from(bytes::Bytes::from_static(b"test")),
+    ));
+
+    op_store
+        .process_incoming_ops(vec![op_at_location(1).clone().into()])
+        .await
+        .unwrap();
+
+    let ops_in_empty_arc = op_store
+        .retrieve_op_ids_bounded(DhtArc::Empty, Timestamp::from_micros(0), 100)
+        .await
+        .unwrap();
+    assert!(ops_in_empty_arc.0.is_empty());
+    assert_eq!(0, ops_in_empty_arc.1);
+    // Notice that the bookmark moves even though we didn't retrieve any ops. This means that
+    // changing the arc invalidates the bookmark.
+    assert!(ops_in_empty_arc.2.as_micros() > 0);
+}
+
+#[tokio::test]
+async fn retrieve_op_ids_bounded_limit_applied() {
+    let op_store: DynOpStore = Arc::new(Kitsune2MemoryOpStore::new(
+        SpaceId::from(bytes::Bytes::from_static(b"test")),
+    ));
+
+    op_store
+        .process_incoming_ops(vec![
+            op_at_location(1).clone().into(),
+            op_at_location(2).clone().into(),
+            op_at_location(3).clone().into(),
+        ])
+        .await
+        .unwrap();
+
+    let before_query = Timestamp::now();
+    let ops_in_arc = op_store
+        .retrieve_op_ids_bounded(
+            DhtArc::Arc(0, 32),
+            Timestamp::from_micros(0),
+            68,
+        )
+        .await
+        .unwrap();
+    assert_eq!(2, ops_in_arc.0.len());
+    assert_eq!(64, ops_in_arc.1);
+    // Should give us back the stored timestamp since we hit the limit.
+    // Otherwise, we'd get a timestamp from the query time, which would be after `before_query`.
+    assert!(ops_in_arc.2.as_micros() < before_query.as_micros());
+}
+
+#[tokio::test]
+async fn retrieve_op_ids_bounded_across_multiple_arcs() {
+    let op_store: DynOpStore = Arc::new(Kitsune2MemoryOpStore::new(
+        SpaceId::from(bytes::Bytes::from_static(b"test")),
+    ));
+
+    op_store
+        .process_incoming_ops(vec![
+            op_at_location(1).clone().into(),
+            op_at_location(2).clone().into(),
+            op_at_location(3).clone().into(),
+            op_at_location(50).clone().into(),
+            op_at_location(51).clone().into(),
+            op_at_location(52).clone().into(),
+        ])
+        .await
+        .unwrap();
+
+    let bookmark = Timestamp::from_micros(0);
+    let mut limit_bytes = 164;
+
+    let ops_in_arc_1 = op_store
+        .retrieve_op_ids_bounded(DhtArc::Arc(0, 32), bookmark, limit_bytes)
+        .await
+        .unwrap();
+
+    assert_eq!(3, ops_in_arc_1.0.len());
+    assert_eq!(96, ops_in_arc_1.1);
+    let new_bookmark_1 = ops_in_arc_1.2;
+
+    limit_bytes -= ops_in_arc_1.1;
+    let op_in_arc_2 = op_store
+        .retrieve_op_ids_bounded(DhtArc::Arc(32, 64), bookmark, limit_bytes)
+        .await
+        .unwrap();
+
+    assert_eq!(2, op_in_arc_2.0.len());
+    assert_eq!(64, op_in_arc_2.1);
+    let new_bookmark_2 = op_in_arc_2.2;
+
+    // Select the minimum bookmark. This will still advance but we want to avoid missing ops
+    // as much as possible.
+    let new_bookmark =
+        &[new_bookmark_1, new_bookmark_2].into_iter().min().unwrap();
+
+    assert!(*new_bookmark > bookmark);
+
+    let ops_in_arc_1 = op_store
+        .retrieve_op_ids_bounded(DhtArc::Arc(0, 32), *new_bookmark, 1_000)
+        .await
+        .unwrap();
+
+    // Nothing more to fetch in this arc.
+    assert!(ops_in_arc_1.0.is_empty());
+
+    let ops_in_arc_2 = op_store
+        .retrieve_op_ids_bounded(DhtArc::Arc(32, 64), *new_bookmark, 1_000)
+        .await
+        .unwrap();
+
+    // Gets the remaining op in the second arc.
+    assert_eq!(1, ops_in_arc_2.0.len());
 }

--- a/crates/core/src/factories/mem_op_store/test.rs
+++ b/crates/core/src/factories/mem_op_store/test.rs
@@ -1,6 +1,7 @@
 use crate::factories::mem_op_store::Kitsune2MemoryOpStore;
 use crate::factories::MemoryOp;
 use kitsune2_api::{DhtArc, DynOpStore, SpaceId, Timestamp};
+use kitsune2_test_utils::space::TEST_SPACE_ID;
 use std::sync::Arc;
 
 fn op_at_location(loc: u32) -> MemoryOp {
@@ -13,9 +14,8 @@ fn op_at_location(loc: u32) -> MemoryOp {
 
 #[tokio::test]
 async fn process_and_retrieve_op() {
-    let op_store: DynOpStore = Arc::new(Kitsune2MemoryOpStore::new(
-        SpaceId::from(bytes::Bytes::from_static(b"test")),
-    ));
+    let op_store: DynOpStore =
+        Arc::new(Kitsune2MemoryOpStore::new(TEST_SPACE_ID));
 
     let op = MemoryOp::new(Timestamp::now(), vec![1, 2, 3]);
     let op_id = op.compute_op_id();
@@ -34,9 +34,8 @@ async fn process_and_retrieve_op() {
 
 #[tokio::test]
 async fn retrieve_op_ids_bounded_empty_arc() {
-    let op_store: DynOpStore = Arc::new(Kitsune2MemoryOpStore::new(
-        SpaceId::from(bytes::Bytes::from_static(b"test")),
-    ));
+    let op_store: DynOpStore =
+        Arc::new(Kitsune2MemoryOpStore::new(TEST_SPACE_ID));
 
     op_store
         .process_incoming_ops(vec![op_at_location(1).clone().into()])

--- a/crates/dht/src/arc_set.rs
+++ b/crates/dht/src/arc_set.rs
@@ -153,6 +153,51 @@ impl ArcSet {
     pub fn includes_sector_index(&self, value: u32) -> bool {
         self.inner.contains(&value)
     }
+
+    /// Convert an arc set to a list of arcs.
+    ///
+    /// Note that an [ArcSet] is created from a `Vec<DhtArc>`, so if you have just created an
+    /// [ArcSet] then this should return an equivalent list of arcs to what you provided, though
+    /// not necessarily the same list. E.g. `ArcSet::new(vec![DhtArc::FULL, DhtArc::FULL])` will
+    /// return `vec![DhtArc::FULL]`.
+    ///
+    /// This method is intended to be used after taking an intersection with [ArcSet::intersection].
+    /// In that case, the list of arcs is not known and converting to a list of arcs is useful.
+    pub fn as_arcs(&self) -> Vec<DhtArc> {
+        if self.inner.is_empty() {
+            return vec![];
+        } else if self.inner.len() == 512 {
+            return vec![DhtArc::FULL];
+        }
+
+        let mut arcs = vec![];
+
+        let mut sectors = self.inner.iter().copied().collect::<Vec<_>>();
+        sectors.sort();
+
+        let mut start = 0;
+        while start < sectors.len() {
+            let mut end = start;
+            while end + 1 < sectors.len()
+                && sectors[end] + 1 == sectors[end + 1]
+            {
+                end += 1;
+            }
+
+            let start_sector = sectors[start];
+            let end_sector = sectors[end];
+
+            let top = (end_sector + 1).saturating_mul(SECTOR_SIZE);
+            arcs.push(DhtArc::Arc(
+                start_sector * SECTOR_SIZE,
+                if top == u32::MAX { u32::MAX } else { top - 1 },
+            ));
+
+            start = end + 1;
+        }
+
+        arcs
+    }
 }
 
 #[cfg(test)]
@@ -350,5 +395,64 @@ mod test {
         let decoded = ArcSet::decode(&encoded).unwrap();
 
         assert_eq!(set, decoded);
+    }
+
+    #[test]
+    fn as_arcs_empty() {
+        let set = ArcSet::new(vec![DhtArc::Empty]).unwrap();
+        assert_eq!(set.as_arcs(), vec![]);
+    }
+
+    #[test]
+    fn as_arcs_full() {
+        let set = ArcSet::new(vec![DhtArc::FULL]).unwrap();
+        assert_eq!(set.as_arcs(), vec![DhtArc::FULL]);
+    }
+
+    #[test]
+    fn as_arcs_full_from_overlap() {
+        let set = ArcSet::new(vec![
+            DhtArc::Arc(0, 2 * SECTOR_SIZE - 1),
+            DhtArc::Arc(SECTOR_SIZE, u32::MAX),
+        ])
+        .unwrap();
+        assert_eq!(set.as_arcs(), vec![DhtArc::FULL]);
+    }
+
+    #[test]
+    fn as_arcs_multiple_disjoint() {
+        let arc_1 = DhtArc::Arc(0, 2 * SECTOR_SIZE - 1);
+        let arc_2 = DhtArc::Arc(10 * SECTOR_SIZE, 40 * SECTOR_SIZE - 1);
+        let set = ArcSet::new(vec![arc_1, arc_2]).unwrap();
+
+        assert_eq!(set.as_arcs(), vec![arc_1, arc_2]);
+    }
+
+    #[test]
+    fn as_arcs_full_on_wrap() {
+        let set = ArcSet::new(vec![
+            DhtArc::Arc(SECTOR_SIZE, 2 * SECTOR_SIZE - 1),
+            DhtArc::Arc(2 * SECTOR_SIZE, SECTOR_SIZE - 1),
+        ])
+        .unwrap();
+
+        assert_eq!(set.as_arcs(), vec![DhtArc::FULL]);
+    }
+
+    #[test]
+    fn as_arcs_split_on_wrap() {
+        let set = ArcSet::new(vec![DhtArc::Arc(
+            510 * SECTOR_SIZE,
+            2 * SECTOR_SIZE - 1,
+        )])
+        .unwrap();
+
+        assert_eq!(
+            set.as_arcs(),
+            vec![
+                DhtArc::Arc(0, 2 * SECTOR_SIZE - 1),
+                DhtArc::Arc(510 * SECTOR_SIZE, u32::MAX)
+            ]
+        );
     }
 }

--- a/crates/dht/src/arc_set.rs
+++ b/crates/dht/src/arc_set.rs
@@ -177,6 +177,7 @@ impl ArcSet {
 
         let mut start = 0;
         while start < sectors.len() {
+            // Determine consecutive sectors.
             let mut end = start;
             while end + 1 < sectors.len()
                 && sectors[end] + 1 == sectors[end + 1]

--- a/crates/gossip/src/respond/initiate.rs
+++ b/crates/gossip/src/respond/initiate.rs
@@ -64,7 +64,7 @@ impl K2Gossip {
                     .dht
                     .read()
                     .await
-                    .snapshot_minimal(common_arc_set)
+                    .snapshot_minimal(common_arc_set.clone())
                     .await?;
                 Some(snapshot.try_into()?)
             } else {
@@ -87,11 +87,9 @@ impl K2Gossip {
             .await?
             .unwrap_or(UNIX_TIMESTAMP);
 
-        // TODO Use common arc set here to restrict the ops we look up.
-        //      Which also means that changing arc will invalidate the bookmark?
         let (new_ops, new_bookmark) = self
-            .op_store
-            .retrieve_op_ids_bounded(
+            .retrieve_new_op_ids(
+                &common_arc_set,
                 Timestamp::from_micros(initiate.new_since),
                 initiate.max_new_bytes as usize,
             )


### PR DESCRIPTION
This is another hopefully straight forward change. Requesting "what's new" should respect the common arc set during gossip in the same way that the DHT diff does. We wouldn't notice this right now with full arc but I think it's best to have this in place.