### PR TITLE
Limit data sent after dht differences

### DIFF
--- a/crates/api/src/op_store.rs
+++ b/crates/api/src/op_store.rs
@@ -77,12 +77,19 @@ pub trait OpStore: 'static + Send + Sync + std::fmt::Debug {
     ///
     /// This must be the timestamp of the op, not the time that we saw the op or chose to store it.
     /// The returned ops must be ordered by timestamp, ascending.
+    ///
+    /// # Returns
+    ///
+    /// - As many op ids as can be returned within the `limit_bytes` limit, within the arc and time
+    ///   bounds.
+    /// - The total size of the op data that is pointed to by the returned op ids.
     fn retrieve_op_hashes_in_time_slice(
         &self,
         arc: DhtArc,
         start: Timestamp,
         end: Timestamp,
-    ) -> BoxFuture<'_, K2Result<Vec<OpId>>>;
+        limit_bytes: Option<u32>,
+    ) -> BoxFuture<'_, K2Result<(Vec<OpId>, u32)>>;
 
     /// Retrieve a list of ops by their op ids.
     ///
@@ -112,13 +119,13 @@ pub trait OpStore: 'static + Send + Sync + std::fmt::Debug {
     ///
     /// - As many op ids as can be returned within the `limit_bytes` limit.
     /// - The total size of the op data that is pointed to by the returned op ids.
-    /// - A new timestamp to be used for the next query..
+    /// - A new timestamp to be used for the next query.
     fn retrieve_op_ids_bounded(
         &self,
         arc: DhtArc,
         start: Timestamp,
-        limit_bytes: usize,
-    ) -> BoxFuture<'_, K2Result<(Vec<OpId>, usize, Timestamp)>>;
+        limit_bytes: u32,
+    ) -> BoxFuture<'_, K2Result<(Vec<OpId>, u32, Timestamp)>>;
 
     /// Store the combined hash of a time slice.
     fn store_slice_hash(

--- a/crates/dht/src/dht/tests.rs
+++ b/crates/dht/src/dht/tests.rs
@@ -80,6 +80,7 @@ async fn cannot_handle_snapshot_with_empty_arc_set() {
             snapshot,
             None,
             ArcSet::new(vec![DhtArc::Empty]).unwrap(),
+            1_000,
         )
         .await
         .unwrap_err();

--- a/crates/dht/src/dht/tests/harness.rs
+++ b/crates/dht/src/dht/tests/harness.rs
@@ -111,8 +111,9 @@ impl DhtSyncHarness {
             self.dht.snapshot_minimal(arc_set.clone()).await?;
         match other
             .dht
-            .handle_snapshot(initial_snapshot, None, arc_set.clone())
+            .handle_snapshot(initial_snapshot, None, arc_set.clone(), 1_000)
             .await?
+            .0
         {
             DhtSnapshotNextAction::Identical => Ok(true),
             _ => Ok(false),
@@ -134,8 +135,9 @@ impl DhtSyncHarness {
         // Send it to the other agent and have them diff against it
         let outcome = other
             .dht
-            .handle_snapshot(initial_snapshot, None, arc_set.clone())
-            .await?;
+            .handle_snapshot(initial_snapshot, None, arc_set.clone(), 1_000)
+            .await?
+            .0;
 
         match outcome {
             DhtSnapshotNextAction::Identical => {
@@ -192,8 +194,9 @@ impl DhtSyncHarness {
         // coming back to us
         let outcome = self
             .dht
-            .handle_snapshot(snapshot, None, arc_set.clone())
-            .await?;
+            .handle_snapshot(snapshot, None, arc_set.clone(), 1_000)
+            .await?
+            .0;
 
         let our_details_snapshot = match outcome {
             DhtSnapshotNextAction::NewSnapshot(new_snapshot) => new_snapshot,
@@ -225,8 +228,10 @@ impl DhtSyncHarness {
                 our_details_snapshot.clone(),
                 None,
                 arc_set.clone(),
+                1_000,
             )
-            .await?;
+            .await?
+            .0;
 
         let (snapshot, hash_list_from_other) = match outcome {
             DhtSnapshotNextAction::NewSnapshotAndHashList(
@@ -260,8 +265,10 @@ impl DhtSyncHarness {
                 snapshot,
                 Some(our_details_snapshot),
                 arc_set.clone(),
+                1000,
             )
-            .await?;
+            .await?
+            .0;
 
         let hash_list_from_self = match outcome {
             DhtSnapshotNextAction::HashList(hash_list) => hash_list,
@@ -316,8 +323,10 @@ impl DhtSyncHarness {
                 other_details_snapshot.clone(),
                 None,
                 arc_set.clone(),
+                1_000,
             )
-            .await?;
+            .await?
+            .0;
 
         let (snapshot, hash_list_from_self) = match outcome {
             DhtSnapshotNextAction::Identical => {
@@ -349,8 +358,10 @@ impl DhtSyncHarness {
                 snapshot,
                 Some(other_details_snapshot),
                 arc_set.clone(),
+                1_000,
             )
-            .await?;
+            .await?
+            .0;
 
         let hash_list_from_other = match outcome {
             DhtSnapshotNextAction::Identical => {

--- a/crates/dht/src/time.rs
+++ b/crates/dht/src/time.rs
@@ -520,8 +520,10 @@ impl TimePartition {
                     self.sector_constraint,
                     full_slices_end_timestamp,
                     full_slices_end_timestamp + self.full_slice_duration,
+                    None,
                 )
-                .await?;
+                .await?
+                .0;
 
             let hash = combine::combine_op_hashes(op_hashes);
 
@@ -625,8 +627,10 @@ impl TimePartition {
                                 self.sector_constraint,
                                 start,
                                 end,
+                                None,
                             )
-                            .await?,
+                            .await?
+                            .0,
                     )
                 }
             };

--- a/crates/gossip/proto/gen/kitsune2.gossip.rs
+++ b/crates/gossip/proto/gen/kitsune2.gossip.rs
@@ -142,9 +142,11 @@ pub struct K2GossipInitiateMessage {
     /// Request ops that are new since the given timestamp.
     #[prost(int64, tag = "20")]
     pub new_since: i64,
-    /// The maximum number of bytes of new ops to respond with.
+    /// Gossip exchanges just op ids. This value is a hint to the other party about how many bytes of op data
+    /// those op ids should point to. The other party can't check this until they have fetched and checked the
+    /// op data, so you cannot rely on this being respected during gossip.
     #[prost(uint32, tag = "21")]
-    pub max_new_bytes: u32,
+    pub max_op_data_bytes: u32,
 }
 /// A Kitsune2 gossip acceptance protocol message.
 ///
@@ -169,9 +171,11 @@ pub struct K2GossipAcceptMessage {
     /// Request ops that are new since the given timestamp.
     #[prost(int64, tag = "20")]
     pub new_since: i64,
-    /// The maximum number of bytes of new ops to respond with.
+    /// Gossip exchanges just op ids. This value is a hint to the other party about how many bytes of op data
+    /// those op ids should point to. The other party can't check this until they have fetched and checked the
+    /// op data, so you cannot rely on this being respected during gossip.
     #[prost(uint32, tag = "21")]
-    pub max_new_bytes: u32,
+    pub max_op_data_bytes: u32,
     /// Ops that we have stored since the timestamp provided by the initiator in `new_since`.
     #[prost(bytes = "bytes", repeated, tag = "22")]
     pub new_ops: ::prost::alloc::vec::Vec<::prost::bytes::Bytes>,

--- a/crates/gossip/proto/gossip.proto
+++ b/crates/gossip/proto/gossip.proto
@@ -90,8 +90,10 @@ message K2GossipInitiateMessage {
   // Request ops that are new since the given timestamp.
   int64 new_since = 20;
 
-  // The maximum number of bytes of new ops to respond with.
-  uint32 max_new_bytes = 21;
+  // Gossip exchanges just op ids. This value is a hint to the other party about how many bytes of op data
+  // those op ids should point to. The other party can't check this until they have fetched and checked the
+  // op data, so you cannot rely on this being respected during gossip.
+  uint32 max_op_data_bytes = 21;
 }
 
 // A Kitsune2 gossip acceptance protocol message.
@@ -123,8 +125,10 @@ message K2GossipAcceptMessage {
   // Request ops that are new since the given timestamp.
   int64 new_since = 20;
 
-  // The maximum number of bytes of new ops to respond with.
-  uint32 max_new_bytes = 21;
+  // Gossip exchanges just op ids. This value is a hint to the other party about how many bytes of op data
+  // those op ids should point to. The other party can't check this until they have fetched and checked the
+  // op data, so you cannot rely on this being respected during gossip.
+  uint32 max_op_data_bytes = 21;
 
   // Ops that we have stored since the timestamp provided by the initiator in `new_since`.
   repeated bytes new_ops = 22;

--- a/crates/gossip/src/gossip.rs
+++ b/crates/gossip/src/gossip.rs
@@ -270,7 +270,7 @@ impl K2Gossip {
                 value: our_arc_set.encode(),
             }),
             new_since: new_since.as_micros(),
-            max_new_bytes: self.config.max_gossip_op_bytes,
+            max_op_data_bytes: self.config.max_gossip_op_bytes,
         };
 
         // Right before we send the initiate message, check whether the target has already

--- a/crates/gossip/src/initiate.rs
+++ b/crates/gossip/src/initiate.rs
@@ -576,7 +576,7 @@ mod tests {
             .await;
 
         let mut seen = HashSet::new();
-        for _ in 0..10 {
+        for _ in 0..100 {
             let url = select_next_target(
                 Duration::from_secs(60),
                 harness.peer_store.clone(),

--- a/crates/gossip/src/respond/disc_sectors_diff.rs
+++ b/crates/gossip/src/respond/disc_sectors_diff.rs
@@ -45,8 +45,11 @@ impl K2Gossip {
                 their_snapshot,
                 None,
                 accepted.common_arc_set.clone(),
+                // Zero because this cannot return op ids
+                0,
             )
-            .await?;
+            .await?
+            .0;
 
         match next_action {
             DhtSnapshotNextAction::CannotCompare

--- a/crates/gossip/src/respond/ring_sector_details_diff.rs
+++ b/crates/gossip/src/respond/ring_sector_details_diff.rs
@@ -40,7 +40,7 @@ impl K2Gossip {
             )
             .try_into()?;
 
-        let next_action = self
+        let (next_action, used_bytes) = self
             .dht
             .read()
             .await
@@ -48,8 +48,11 @@ impl K2Gossip {
                 their_snapshot,
                 None,
                 accepted.common_arc_set.clone(),
+                state.peer_max_op_data_bytes,
             )
             .await?;
+
+        state.peer_max_op_data_bytes -= used_bytes;
 
         match next_action {
             DhtSnapshotNextAction::CannotCompare

--- a/crates/gossip/src/respond/ring_sector_details_diff_response.rs
+++ b/crates/gossip/src/respond/ring_sector_details_diff_response.rs
@@ -32,7 +32,12 @@ impl K2Gossip {
         let their_snapshot: DhtSnapshot =
             response.snapshot.unwrap().try_into()?;
 
-        let next_action = self
+        let peer_max_op_data_bytes = state
+            .as_ref()
+            .map(|s| s.peer_max_op_data_bytes)
+            .unwrap_or(0);
+
+        let (next_action, used_bytes) = self
             .dht
             .read()
             .await
@@ -40,8 +45,13 @@ impl K2Gossip {
                 their_snapshot,
                 Some(ring_sector_details.snapshot.clone()),
                 ring_sector_details.common_arc_set,
+                peer_max_op_data_bytes,
             )
             .await?;
+
+        if let Some(state) = state.as_mut() {
+            state.peer_max_op_data_bytes -= used_bytes;
+        }
 
         match next_action {
             DhtSnapshotNextAction::CannotCompare

--- a/crates/gossip/src/state.rs
+++ b/crates/gossip/src/state.rs
@@ -20,6 +20,12 @@ pub(crate) struct GossipRoundState {
     /// Must be randomly chosen and unique for each initiated round.
     pub session_id: Bytes,
 
+    /// The maximum number of bytes of [kitsune2_api::Op]s the peer is willing to accept.
+    ///
+    /// Note that it's actually [kitsune2_api::OpId]s that are exchanged. So this is a hint in
+    /// terms of op data about how many op ids we should send back to the other peer.
+    pub peer_max_op_data_bytes: u32,
+
     /// The current stage of the round.
     ///
     /// Store the current stage, so that the next stage can be validated.
@@ -40,6 +46,8 @@ impl GossipRoundState {
             session_with_peer,
             started_at: tokio::time::Instant::now(),
             session_id: session_id.freeze(),
+            // Initial value, to be updated when the round is accepted.
+            peer_max_op_data_bytes: 0,
             stage: RoundStage::Initiated(RoundStageInitiated {
                 our_agents,
                 our_arc_set,
@@ -50,6 +58,7 @@ impl GossipRoundState {
     pub(crate) fn new_accepted(
         session_with_peer: Url,
         session_id: Bytes,
+        peer_max_op_data_bytes: u32,
         our_agents: Vec<AgentId>,
         common_arc_set: ArcSet,
     ) -> Self {
@@ -57,6 +66,7 @@ impl GossipRoundState {
             session_with_peer,
             started_at: tokio::time::Instant::now(),
             session_id,
+            peer_max_op_data_bytes,
             stage: RoundStage::Accepted(RoundStageAccepted {
                 our_agents,
                 common_arc_set,


### PR DESCRIPTION
Applies the same logic that we have for "new ops" to the op ids returned by the DHT diff process. I believe this is necessary regardless of whether it's a complete solution to the "new agent joining an existing network" problem.

By leaving this unlimited, we'd just return the entire data set in one batch during the first gossip round with new peers. That's too much load on the peer you happen to hit. As I'm writing, I'm wondering if we should enforce a maximum value for this that peers can request...

By limiting how much data we get in one go, we aren't doing anything too complicated like trying to decide which sectors we want data from or which time slices, when both are sparse and we'd get unpredictable results that way. Like this, we do our best to sync. Then we have to hope that between one gossip round and the next, the other peer will fetch enough to reduce the number of sectors/slices that produce a diff on the next round. If it's not that quick, then over time that is the effect.

As soon as we stop having a diff for a time slice or a sector, we'll be able to progress to new areas of the DHT in a natural way. There will be some duplicate requests of op ids but that's a reasonable thing to have happen I think. it's part of learning about the network.

This change really needs tests that exercise the 3 different paths
- Limit on "new ops"
- Limit on "disc diff" when part of the limit was consumed by "new ops"
- Limit on "ring diff" when part of the limit was consumed by "new ops"

But adding those tests requires modifying the testing in the same ways as #85