### PR TITLE
Op data limit tests

### DIFF
--- a/crates/dht/src/dht/tests.rs
+++ b/crates/dht/src/dht/tests.rs
@@ -316,7 +316,7 @@ async fn ring_sync_with_matching_disc() {
     // Put recent data in the first ring of both DHTs
     dht1.inject_ops(vec![MemoryOp::new(
         dht1.dht.partition.full_slice_end_timestamp(),
-        vec![7; 4],
+        vec![17; 4],
     )])
     .await
     .unwrap();

--- a/crates/gossip/src/respond/accept.rs
+++ b/crates/gossip/src/respond/accept.rs
@@ -72,6 +72,13 @@ impl K2Gossip {
         // Update the peer's max op data bytes to reflect the amount of data we're sending ids for.
         // The remaining limit will be used for the DHT diff as required.
         if let Some(state) = lock.as_mut() {
+            tracing::debug!(
+                "Used {}/{} op budget to send {} op ids",
+                used_bytes,
+                accept.max_op_data_bytes,
+                send_new_ops.len()
+            );
+
             // Note that this value will have been initialised to 0 here when we created the
             // initial state. So we need to initialise and subtract here.
             state.peer_max_op_data_bytes = std::cmp::min(

--- a/crates/gossip/src/respond/disc_sector_details_diff.rs
+++ b/crates/gossip/src/respond/disc_sector_details_diff.rs
@@ -50,6 +50,11 @@ impl K2Gossip {
             .await?;
 
         if let Some(state) = state.as_mut() {
+            tracing::debug!(
+                "Used {}/{} op budget to send disc ops",
+                used_bytes,
+                state.peer_max_op_data_bytes,
+            );
             state.peer_max_op_data_bytes -= used_bytes;
         }
 

--- a/crates/gossip/src/respond/disc_sector_details_diff_response.rs
+++ b/crates/gossip/src/respond/disc_sector_details_diff_response.rs
@@ -47,6 +47,11 @@ impl K2Gossip {
             )
             .await?;
 
+        tracing::debug!(
+            "Used {}/{} op budget to send disc ops",
+            used_bytes,
+            state.peer_max_op_data_bytes,
+        );
         state.peer_max_op_data_bytes -= used_bytes;
 
         match next_action {

--- a/crates/gossip/src/respond/initiate.rs
+++ b/crates/gossip/src/respond/initiate.rs
@@ -99,6 +99,12 @@ impl K2Gossip {
 
         // Update the peer's max op data bytes to reflect the amount of data we're sending ids for.
         // The remaining limit will be used for the DHT diff as required.
+        tracing::debug!(
+            "Used {}/{} op budget to send {} op ids",
+            used_bytes,
+            initiate.max_op_data_bytes,
+            new_ops.len()
+        );
         state.peer_max_op_data_bytes -= used_bytes;
 
         Ok(Some(GossipMessage::Accept(K2GossipAcceptMessage {


### PR DESCRIPTION
Tests the previous PR -> https://github.com/holochain/kitsune2/pull/94

Some minor improvements needed in the mem peer store to support this change, I'll comment on those separately.

I think this raises an important problem though. I still want these tests in but I think I should change how I've applied limits. It shouldn't apply in the middle of a time slice because if a time slice grows larger than the limit, we'll never be able to sync it. So I think I should roll back the code that applies limits in the op store and does a soft application of the limit in the DHT code that calls the op store. That way we might return more op ids than the other side wanted but we won't get stuck on a time slice. It's an edge case really, for when there's more data around, but I think it's easier to fix now.