### PR TITLE
test(kitsune2_gossip): Limit the value we'll accept as a max op bytes…

### DIFF
--- a/crates/gossip/src/config.rs
+++ b/crates/gossip/src/config.rs
@@ -26,7 +26,7 @@ pub struct K2GossipConfig {
     /// fast they'll be able to discover ops from us because it'll require multiple rounds to
     /// discover all the op ids they'd need to request from us.
     ///
-    /// Default: 250MB
+    /// Default: 100MB
     pub max_request_gossip_op_bytes: u32,
 
     /// The interval in seconds between initiating gossip rounds.
@@ -82,7 +82,7 @@ impl Default for K2GossipConfig {
     fn default() -> Self {
         Self {
             max_gossip_op_bytes: 100 * 1024 * 1024,
-            max_request_gossip_op_bytes: 250 * 1024 * 1024,
+            max_request_gossip_op_bytes: 100 * 1024 * 1024,
             initiate_interval_ms: 120_000,
             min_initiate_interval_ms: 300_000,
             round_timeout_ms: 60_000,

--- a/crates/gossip/src/config.rs
+++ b/crates/gossip/src/config.rs
@@ -18,6 +18,17 @@ pub struct K2GossipConfig {
     /// Default: 100MB
     pub max_gossip_op_bytes: u32,
 
+    /// The maximum value that this instance will accept for the `max_gossip_op_bytes` parameter
+    /// from a remote peer.
+    ///
+    /// This prevents the remote peer from setting a high value for `max_gossip_op_bytes` and
+    /// requesting all their op data from us in one batch. With this value set, we can limit how
+    /// fast they'll be able to discover ops from us because it'll require multiple rounds to
+    /// discover all the op ids they'd need to request from us.
+    ///
+    /// Default: 250MB
+    pub max_request_gossip_op_bytes: u32,
+
     /// The interval in seconds between initiating gossip rounds.
     ///
     /// This controls how often Kitsune will attempt to find a peer to gossip with.
@@ -71,6 +82,7 @@ impl Default for K2GossipConfig {
     fn default() -> Self {
         Self {
             max_gossip_op_bytes: 100 * 1024 * 1024,
+            max_request_gossip_op_bytes: 250 * 1024 * 1024,
             initiate_interval_ms: 120_000,
             min_initiate_interval_ms: 300_000,
             round_timeout_ms: 60_000,

--- a/crates/gossip/src/respond.rs
+++ b/crates/gossip/src/respond.rs
@@ -3,6 +3,7 @@ use crate::protocol::{
     AcceptResponseMessage, GossipMessage, K2GossipInitiateMessage,
 };
 use crate::state::GossipRoundState;
+use crate::K2GossipConfig;
 use bytes::Bytes;
 use kitsune2_api::agent::AgentInfoSigned;
 use kitsune2_api::id::decode_ids;
@@ -102,6 +103,7 @@ impl K2Gossip {
 
     pub(crate) async fn create_accept_state(
         &self,
+        config: Arc<K2GossipConfig>,
         from_peer: &Url,
         initiate: &K2GossipInitiateMessage,
         our_agents: Vec<AgentId>,
@@ -121,7 +123,10 @@ impl K2Gossip {
                     Arc::new(Mutex::new(GossipRoundState::new_accepted(
                         from_peer.clone(),
                         initiate.session_id.clone(),
-                        initiate.max_op_data_bytes,
+                        std::cmp::min(
+                            config.max_request_gossip_op_bytes,
+                            initiate.max_op_data_bytes,
+                        ),
                         our_agents,
                         common_arc_set,
                     )));

--- a/crates/gossip/src/respond/accept.rs
+++ b/crates/gossip/src/respond/accept.rs
@@ -74,8 +74,10 @@ impl K2Gossip {
         if let Some(state) = lock.as_mut() {
             // Note that this value will have been initialised to 0 here when we created the
             // initial state. So we need to initialise and subtract here.
-            state.peer_max_op_data_bytes =
-                accept.max_op_data_bytes - used_bytes;
+            state.peer_max_op_data_bytes = std::cmp::min(
+                self.config.max_request_gossip_op_bytes,
+                accept.max_op_data_bytes,
+            ) - used_bytes;
         }
 
         // The common part

--- a/crates/gossip/src/respond/initiate.rs
+++ b/crates/gossip/src/respond/initiate.rs
@@ -50,6 +50,7 @@ impl K2Gossip {
         // have initiated and that we plan to accept.
         let mut state = self
             .create_accept_state(
+                self.config.clone(),
                 &from_peer,
                 &initiate,
                 our_agents.clone(),


### PR DESCRIPTION
We're just trusting the value the remote sends us at the moment and trying to send them as many op ids as their op data limit permits. To avoid peers setting this value high and using us to get all their op data at once, set a limit for this value and apply the lower of the two values.

For example, we could set a 10MB limit on a low-powered node even though people will be requesting 100Mb.