### PR TITLE
Update storage arcs

### DIFF
--- a/crates/api/src/arc.rs
+++ b/crates/api/src/arc.rs
@@ -152,6 +152,25 @@ impl DhtArc {
             }
         }
     }
+
+    /// Get the length of the arc.
+    pub fn len(&self) -> u32 {
+        match self {
+            DhtArc::Empty => 0,
+            DhtArc::Arc(start, end) => {
+                if start > end {
+                    u32::MAX - start + end + 1
+                } else {
+                    end - start + 1
+                }
+            }
+        }
+    }
+
+    /// Determine if the arc is empty.
+    pub fn is_empty(&self) -> bool {
+        matches!(self, DhtArc::Empty)
+    }
 }
 
 #[cfg(test)]

--- a/crates/api/src/arc.rs
+++ b/crates/api/src/arc.rs
@@ -159,9 +159,9 @@ impl DhtArc {
             DhtArc::Empty => 0,
             DhtArc::Arc(start, end) => {
                 if start > end {
-                    u32::MAX - start + end + 1
+                    u32::MAX - start + end
                 } else {
-                    end - start + 1
+                    end - start
                 }
             }
         }

--- a/crates/dht/src/arc_set.rs
+++ b/crates/dht/src/arc_set.rs
@@ -201,6 +201,23 @@ impl ArcSet {
     }
 }
 
+impl IntoIterator for ArcSet {
+    type Item = u32;
+    type IntoIter = std::collections::hash_set::IntoIter<u32>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.inner.into_iter()
+    }
+}
+
+impl FromIterator<u32> for ArcSet {
+    fn from_iter<T: IntoIterator<Item = u32>>(iter: T) -> Self {
+        ArcSet {
+            inner: iter.into_iter().collect(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/crates/dht/src/arc_set.rs
+++ b/crates/dht/src/arc_set.rs
@@ -154,6 +154,22 @@ impl ArcSet {
         self.inner.contains(&value)
     }
 
+    /// Remove the given sector indices from this arc set.
+    ///
+    /// Note that this is a mutable operation, which is normally not needed for arc sets. This
+    /// function therefore consumes the provided arc set to make it harder to accidentally modify
+    /// an arc set that wasn't intended to be updated.
+    pub fn without_sector_indices(
+        mut self,
+        remove: impl IntoIterator<Item = u32>,
+    ) -> Self {
+        for sector in remove {
+            self.inner.remove(&sector);
+        }
+
+        self
+    }
+
     /// Convert an arc set to a list of arcs.
     ///
     /// Note that an [ArcSet] is created from a `Vec<DhtArc>`, so if you have just created an
@@ -198,23 +214,6 @@ impl ArcSet {
         }
 
         arcs
-    }
-}
-
-impl IntoIterator for ArcSet {
-    type Item = u32;
-    type IntoIter = std::collections::hash_set::IntoIter<u32>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.inner.into_iter()
-    }
-}
-
-impl FromIterator<u32> for ArcSet {
-    fn from_iter<T: IntoIterator<Item = u32>>(iter: T) -> Self {
-        ArcSet {
-            inner: iter.into_iter().collect(),
-        }
     }
 }
 

--- a/crates/dht/src/dht/snapshot.rs
+++ b/crates/dht/src/dht/snapshot.rs
@@ -57,6 +57,8 @@ pub enum DhtSnapshot {
     /// hashes.
     RingSectorDetails {
         /// Similar to the `ring_top_hashes` except the sector hashes are not combined.
+        ///
+        /// Organized by ring index in the first HashMap, then sector index in the second HashMap.
         ring_sector_hashes: HashMap<u32, HashMap<u32, bytes::Bytes>>,
         /// The end timestamp of the most recent full time slice.
         disc_boundary: Timestamp,

--- a/crates/gossip/Cargo.toml
+++ b/crates/gossip/Cargo.toml
@@ -30,3 +30,6 @@ kitsune2_dht = { workspace = true, features = ["mockall"] }
 kitsune2_test_utils = { workspace = true }
 
 tokio = { workspace = true, features = ["test-util"] }
+
+[features]
+sharding = []

--- a/crates/gossip/src/gossip.rs
+++ b/crates/gossip/src/gossip.rs
@@ -5,6 +5,7 @@ use crate::protocol::{
     ArcSetMessage, GossipMessage, K2GossipInitiateMessage,
 };
 use crate::state::GossipRoundState;
+use crate::storage_arc::update_storage_arcs;
 use crate::timeout::spawn_timeout_task;
 use crate::update::spawn_dht_update_task;
 use crate::{K2GossipConfig, K2GossipModConfig, MOD_NAME};
@@ -286,6 +287,29 @@ impl K2Gossip {
         *initiated_lock = Some(round_state);
 
         Ok(true)
+    }
+
+    pub(crate) async fn update_storage_arcs(
+        &self,
+        next_action: &kitsune2_dht::DhtSnapshotNextAction,
+        their_snapshot: &kitsune2_dht::snapshot::DhtSnapshot,
+        common_arc_set: kitsune2_dht::ArcSet,
+    ) -> K2Result<()> {
+        if !matches!(
+            next_action,
+            kitsune2_dht::DhtSnapshotNextAction::CannotCompare
+        ) {
+            // As long as the comparison was successful, use this diff to update storage arcs.
+            if let Err(e) = update_storage_arcs(
+                their_snapshot,
+                self.local_agent_store.get_all().await?,
+                common_arc_set.clone(),
+            ) {
+                tracing::error!("Error updating storage arcs: {:?}", e);
+            }
+        }
+
+        Ok(())
     }
 
     /// Handle an incoming gossip message.

--- a/crates/gossip/src/gossip.rs
+++ b/crates/gossip/src/gossip.rs
@@ -292,7 +292,7 @@ impl K2Gossip {
     pub(crate) async fn update_storage_arcs(
         &self,
         next_action: &kitsune2_dht::DhtSnapshotNextAction,
-        their_snapshot: &kitsune2_dht::snapshot::DhtSnapshot,
+        their_snapshot: &kitsune2_dht::DhtSnapshot,
         common_arc_set: kitsune2_dht::ArcSet,
     ) -> K2Result<()> {
         if !matches!(

--- a/crates/gossip/src/lib.rs
+++ b/crates/gossip/src/lib.rs
@@ -11,11 +11,11 @@ pub use constant::*;
 mod gossip;
 pub use gossip::*;
 
-mod peer_meta_store;
-
 mod initiate;
+mod peer_meta_store;
 mod protocol;
 mod respond;
 mod state;
+mod storage_arc;
 mod timeout;
 mod update;

--- a/crates/gossip/src/respond/accept.rs
+++ b/crates/gossip/src/respond/accept.rs
@@ -96,12 +96,13 @@ impl K2Gossip {
 
         match accept.snapshot {
             Some(their_snapshot) => {
+                let their_snapshot: DhtSnapshot = their_snapshot.into();
                 let (next_action, _) = self
                     .dht
                     .read()
                     .await
                     .handle_snapshot(
-                        their_snapshot.into(),
+                        their_snapshot.clone(),
                         None,
                         common_arc_set.clone(),
                         // Zero because this cannot return op ids
@@ -115,6 +116,13 @@ impl K2Gossip {
                         if let Some(state) = lock.as_mut() {
                             state.stage = RoundStage::NoDiff;
                         }
+
+                        self.update_storage_arcs(
+                            &next_action,
+                            &their_snapshot,
+                            common_arc_set.clone(),
+                        )
+                        .await?;
 
                         Ok(Some(GossipMessage::NoDiff(K2GossipNoDiffMessage {
                             session_id: accept.session_id,

--- a/crates/gossip/src/respond/ring_sector_details_diff.rs
+++ b/crates/gossip/src/respond/ring_sector_details_diff.rs
@@ -9,7 +9,7 @@ use crate::state::{
     RoundStageRingSectorDetailsDiff,
 };
 use kitsune2_api::{AgentId, K2Error, K2Result, Url};
-use kitsune2_dht::snapshot::DhtSnapshot;
+use kitsune2_dht::DhtSnapshot;
 use kitsune2_dht::DhtSnapshotNextAction;
 use tokio::sync::OwnedMutexGuard;
 

--- a/crates/gossip/src/respond/ring_sector_details_diff.rs
+++ b/crates/gossip/src/respond/ring_sector_details_diff.rs
@@ -9,6 +9,7 @@ use crate::state::{
     RoundStageRingSectorDetailsDiff,
 };
 use kitsune2_api::{AgentId, K2Error, K2Result, Url};
+use kitsune2_dht::snapshot::DhtSnapshot;
 use kitsune2_dht::DhtSnapshotNextAction;
 use tokio::sync::OwnedMutexGuard;
 
@@ -33,7 +34,7 @@ impl K2Gossip {
         )
         .await?;
 
-        let their_snapshot = ring_sector_details_diff
+        let their_snapshot: DhtSnapshot = ring_sector_details_diff
             .snapshot
             .expect(
                 "Snapshot present checked by validate_ring_sector_details_diff",
@@ -45,7 +46,7 @@ impl K2Gossip {
             .read()
             .await
             .handle_snapshot(
-                their_snapshot,
+                their_snapshot.clone(),
                 None,
                 accepted.common_arc_set.clone(),
                 state.peer_max_op_data_bytes,
@@ -53,6 +54,13 @@ impl K2Gossip {
             .await?;
 
         state.peer_max_op_data_bytes -= used_bytes as i32;
+
+        self.update_storage_arcs(
+            &next_action,
+            &their_snapshot,
+            accepted.common_arc_set.clone(),
+        )
+        .await?;
 
         match next_action {
             DhtSnapshotNextAction::CannotCompare

--- a/crates/gossip/src/respond/ring_sector_details_diff_response.rs
+++ b/crates/gossip/src/respond/ring_sector_details_diff_response.rs
@@ -42,9 +42,9 @@ impl K2Gossip {
             .read()
             .await
             .handle_snapshot(
-                their_snapshot,
+                their_snapshot.clone(),
                 Some(ring_sector_details.snapshot.clone()),
-                ring_sector_details.common_arc_set,
+                ring_sector_details.common_arc_set.clone(),
                 peer_max_op_data_bytes,
             )
             .await?;
@@ -52,6 +52,13 @@ impl K2Gossip {
         if let Some(state) = state.as_mut() {
             state.peer_max_op_data_bytes -= used_bytes as i32;
         }
+
+        self.update_storage_arcs(
+            &next_action,
+            &their_snapshot,
+            ring_sector_details.common_arc_set,
+        )
+        .await?;
 
         match next_action {
             DhtSnapshotNextAction::CannotCompare

--- a/crates/gossip/src/storage_arc.rs
+++ b/crates/gossip/src/storage_arc.rs
@@ -1,7 +1,7 @@
-use kitsune2_api::agent::{DynLocalAgent, LocalAgent};
 use kitsune2_api::{DhtArc, K2Result};
-use kitsune2_dht::snapshot::DhtSnapshot;
+use kitsune2_api::{DynLocalAgent, LocalAgent};
 use kitsune2_dht::ArcSet;
+use kitsune2_dht::DhtSnapshot;
 use std::collections::HashSet;
 
 /// Update the storage arcs of local agents based on a DhtSnapshot.

--- a/crates/gossip/src/storage_arc.rs
+++ b/crates/gossip/src/storage_arc.rs
@@ -1,0 +1,285 @@
+use kitsune2_api::agent::{DynLocalAgent, LocalAgent};
+use kitsune2_api::{DhtArc, K2Result};
+use kitsune2_dht::snapshot::DhtSnapshot;
+use kitsune2_dht::ArcSet;
+use std::collections::HashSet;
+
+/// Update the storage arcs of local agents based on a DhtSnapshot.
+///
+/// Note that the DHT model prioritises syncing the disc. So if we've reached a ring diff then we
+/// can assume that the disc was synced at the point this diff was produced. This function requires
+/// the input [DhtSnapshot] to be a [DhtSnapshot::RingSectorDetails] variant.
+///
+/// The function looks for sectors within the common arc set that did not show up as a mismatch
+/// in the snapshot. Such sectors are considered synced. If any synced sectors can be added to the
+/// start or end of the current storage arc for a local agent, it will do so. Any synced sectors
+/// that cannot be added to the storage arc to produce a larger continuous arc are ignored.
+pub(crate) fn update_storage_arcs(
+    ring_details: &DhtSnapshot,
+    local_agents: Vec<DynLocalAgent>,
+    common_arc_set: ArcSet,
+) -> K2Result<()> {
+    let DhtSnapshot::RingSectorDetails {
+        ring_sector_hashes, ..
+    } = ring_details
+    else {
+        tracing::info!("Unable to update storage arc with a non-ring sector details snapshot");
+        return Ok(());
+    };
+
+    // These sectors didn't match, so we can't include them in our storage arc.
+    let mismatched_sectors = ring_sector_hashes
+        .values()
+        .flat_map(|v| v.keys())
+        .copied()
+        .collect::<HashSet<_>>();
+    let common_sectors = common_arc_set.into_iter().collect::<HashSet<_>>();
+
+    // The difference between the common arc set used to construct the DhtSnapshot and the
+    // mismatched sectors is the set of sectors that we can use to update our storage arc.
+    let synced_arcs = common_sectors
+        .difference(&mismatched_sectors)
+        .copied()
+        .collect::<ArcSet>()
+        .as_arcs();
+
+    for local_agent in local_agents {
+        let target_storage_arc = local_agent.get_tgt_storage_arc();
+        let current_storage_arc = local_agent.get_cur_storage_arc();
+
+        if target_storage_arc == current_storage_arc {
+            // No adjustment needed, already at the target.
+            continue;
+        }
+
+        let target_set = ArcSet::new(vec![target_storage_arc])?;
+
+        // Add our current storage arc to the set of sectors covered by synced arcs.
+        let mut synced_arc_set = synced_arcs.clone();
+        synced_arc_set.push(current_storage_arc);
+
+        // Then intersect the result with our target arc. This prevents the storage arc from
+        // growing outside the target arc. That might happen when we have multiple local agents
+        // with different target arcs.
+        let new_arcs = ArcSet::new(synced_arc_set)?
+            .intersection(&target_set)
+            .as_arcs();
+
+        if current_storage_arc == DhtArc::Empty {
+            // When our current storage arc is empty, we're free to pick a new one that is
+            // contained within the target arc. Pick the largest one.
+            if let Some(new_arc) =
+                new_arcs.into_iter().max_by_key(|arc| arc.len())
+            {
+                local_agent.set_cur_storage_arc(new_arc);
+            }
+        } else {
+            // At this point, we have added any synced sectors to our current storage arc and ignored
+            // and synced sectors that aren't in our target arc. We can find the largest overlapping
+            // arc and that will contain our old storage arc with any new sectors added.
+            if let Some(new_arc) = new_arcs.into_iter().find(|arc| {
+                arc.len() > current_storage_arc.len()
+                    && arc.overlaps(&current_storage_arc)
+            }) {
+                local_agent.set_cur_storage_arc(new_arc);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use kitsune2_api::{DhtArc, UNIX_TIMESTAMP};
+    use kitsune2_core::Ed25519LocalAgent;
+    use kitsune2_dht::SECTOR_SIZE;
+    use std::sync::Arc;
+
+    fn test_snapshot_with_mismatched_sectors(
+        mismatched: &[u32],
+    ) -> DhtSnapshot {
+        DhtSnapshot::RingSectorDetails {
+            ring_sector_hashes: [(
+                0,
+                mismatched
+                    .iter()
+                    .map(|s| (*s, bytes::Bytes::new()))
+                    .collect(),
+            )]
+            .into_iter()
+            .collect(),
+            disc_boundary: UNIX_TIMESTAMP,
+        }
+    }
+
+    #[test]
+    fn storage_arc_at_target() {
+        let local_agent = Arc::new(Ed25519LocalAgent::default());
+        let arc = DhtArc::Arc(0, 5 * SECTOR_SIZE - 1);
+        local_agent.set_cur_storage_arc(arc);
+        local_agent.set_tgt_storage_arc_hint(arc);
+
+        update_storage_arcs(
+            &test_snapshot_with_mismatched_sectors(&[0, 1, 2]),
+            vec![local_agent.clone()],
+            ArcSet::new(vec![DhtArc::FULL]).unwrap(),
+        )
+        .unwrap();
+
+        // Storage arc doesn't change
+        assert_eq!(arc, local_agent.get_cur_storage_arc());
+    }
+
+    #[test]
+    fn no_mismatched_sectors_from_empty() {
+        let local_agent = Arc::new(Ed25519LocalAgent::default());
+
+        // Start with an empty storage arc
+        local_agent.set_cur_storage_arc(DhtArc::Empty);
+
+        // and a target arc that is larger than the current storage arc
+        let arc = DhtArc::Arc(0, 5 * SECTOR_SIZE - 1);
+        local_agent.set_tgt_storage_arc_hint(arc);
+
+        update_storage_arcs(
+            // No mismatched sectors
+            &test_snapshot_with_mismatched_sectors(&[]),
+            vec![local_agent.clone()],
+            ArcSet::new(vec![DhtArc::FULL]).unwrap(),
+        )
+        .unwrap();
+
+        // Storage arc is updated to the target
+        assert_eq!(arc, local_agent.get_cur_storage_arc());
+        assert_eq!(
+            local_agent.get_tgt_storage_arc(),
+            local_agent.get_cur_storage_arc()
+        );
+    }
+
+    #[test]
+    fn some_mismatched_sectors_from_empty() {
+        let local_agent = Arc::new(Ed25519LocalAgent::default());
+
+        // Start with an empty storage arc
+        local_agent.set_cur_storage_arc(DhtArc::Empty);
+
+        // and a target arc that is larger than the current storage arc
+        local_agent
+            .set_tgt_storage_arc_hint(DhtArc::Arc(0, 5 * SECTOR_SIZE - 1));
+
+        update_storage_arcs(
+            // one mismatched sector, in the middle of the target arc
+            &test_snapshot_with_mismatched_sectors(&[3]),
+            vec![local_agent.clone()],
+            ArcSet::new(vec![DhtArc::FULL]).unwrap(),
+        )
+        .unwrap();
+
+        // Storage arc is updated to the largest of the possible arcs around the mismatched sector
+        assert_eq!(
+            DhtArc::Arc(0, 3 * SECTOR_SIZE - 1),
+            local_agent.get_cur_storage_arc()
+        );
+    }
+
+    #[test]
+    fn discover_sectors_that_do_not_expand_arc() {
+        let local_agent = Arc::new(Ed25519LocalAgent::default());
+
+        // Start with an arc that is smaller than the target arc
+        let arc = DhtArc::Arc(0, 2 * SECTOR_SIZE - 1);
+        local_agent.set_cur_storage_arc(arc);
+
+        // and some larger target arc
+        local_agent
+            .set_tgt_storage_arc_hint(DhtArc::Arc(0, 5 * SECTOR_SIZE - 1));
+
+        update_storage_arcs(
+            // mismatch at the end of our arc, but that means there are two sectors that have
+            // matched. We can't expand our arc until `2` matches.
+            &test_snapshot_with_mismatched_sectors(&[2]),
+            vec![local_agent.clone()],
+            ArcSet::new(vec![DhtArc::FULL]).unwrap(),
+        )
+        .unwrap();
+
+        // Storage arc cannot be updated
+        assert_eq!(arc, local_agent.get_cur_storage_arc());
+    }
+
+    #[test]
+    fn expand_towards_target_arc() {
+        let local_agent = Arc::new(Ed25519LocalAgent::default());
+
+        // Start with an arc that is smaller than the target arc
+        let arc = DhtArc::Arc(2 * SECTOR_SIZE, 5 * SECTOR_SIZE - 1);
+        local_agent.set_cur_storage_arc(arc);
+
+        // and some larger target arc
+        local_agent
+            .set_tgt_storage_arc_hint(DhtArc::Arc(0, 10 * SECTOR_SIZE - 1));
+
+        update_storage_arcs(
+            // mismatch on either side of our storage arc, but with room to grow
+            &test_snapshot_with_mismatched_sectors(&[0, 8]),
+            vec![local_agent.clone()],
+            ArcSet::new(vec![DhtArc::FULL]).unwrap(),
+        )
+        .unwrap();
+
+        // Storage arc grows as much as it can
+        assert_eq!(
+            DhtArc::Arc(SECTOR_SIZE, 8 * SECTOR_SIZE - 1),
+            local_agent.get_cur_storage_arc()
+        );
+    }
+
+    #[test]
+    fn update_multiple_agents() {
+        let local_agent_1 = Arc::new(Ed25519LocalAgent::default());
+        let local_agent_2 = Arc::new(Ed25519LocalAgent::default());
+        let local_agent_3 = Arc::new(Ed25519LocalAgent::default());
+
+        // Set up an arc outside the common arc set, should not change
+        local_agent_1.set_tgt_storage_arc_hint(DhtArc::FULL);
+        let arc_1 = DhtArc::Arc(10 * SECTOR_SIZE, 15 * SECTOR_SIZE - 1);
+        local_agent_1.set_cur_storage_arc(arc_1);
+
+        // Set up an arc that can grow
+        local_agent_2.set_tgt_storage_arc_hint(DhtArc::FULL);
+        let arc_2 = DhtArc::Arc(0, 5 * SECTOR_SIZE - 1);
+        local_agent_2.set_cur_storage_arc(arc_2);
+
+        // Set up an arc that can grow but won't be able to because of mismatched sectors
+        local_agent_3.set_tgt_storage_arc_hint(DhtArc::FULL);
+        let arc_3 = DhtArc::Arc(4 * SECTOR_SIZE, 9 * SECTOR_SIZE - 1);
+        local_agent_3.set_cur_storage_arc(arc_3);
+
+        update_storage_arcs(
+            // Some sector mismatches
+            &test_snapshot_with_mismatched_sectors(&[3, 4]),
+            vec![
+                local_agent_1.clone(),
+                local_agent_2.clone(),
+                local_agent_3.clone(),
+            ],
+            ArcSet::new(vec![DhtArc::Arc(0, 7 * SECTOR_SIZE - 1)]).unwrap(),
+        )
+        .unwrap();
+
+        // Storage arc 1 restricted by common arc set
+        assert_eq!(arc_1, local_agent_1.get_cur_storage_arc());
+
+        // Storage arc 2 grows within the common arc set
+        assert_eq!(
+            DhtArc::Arc(0, 7 * SECTOR_SIZE - 1),
+            local_agent_2.get_cur_storage_arc()
+        );
+
+        // Storage arc 3 restricted by mismatched sectors
+        assert_eq!(arc_3, local_agent_3.get_cur_storage_arc());
+    }
+}


### PR DESCRIPTION
The meat of this is the update algorithm. I've done my best to keep it logical and well-commented.

Basically, we're trying to start from the common arc set and skip any mismatched sectors. Then we see if merging the matching sectors into our storage arc yields a longer arc that covers the existing one. Starting from an empty arc is treated as a special case. It took me hours of thinking to put that together so I've done by best to comment and test clearly!

The integration is also interesting. If we get a ring diff then we can update our arc because we know the disc is synced and we can examine the ring diff to see what sectors are matching. That's pretty sound logic I think, but we won't necessarily get a ring diff because the "what's new" operation will keep some agents in sync without a DHT diff. We can also use the receipt of a minimal snapshot that exactly matches ours, as a signal to claim our entire target arc. However, this only happens when we initiated. I don't think it's as reasonable to blindly trust a "NoDiff" message as a signal to claim our entire target arc. I'd rather we always have some information we can work off. So that means that agents who are catching up with the network should claim their storage arc as they go and agents who actively initiate rounds will also discover that they can update their storage arc. Agents that are only passively accepting rounds (perhaps because it's a small network and the timing works out that way) might end up not updating their storage arc for a while until something interrupts the flow, like a new agent joining or somebody going offline.