### PR TITLE
Limit op data at sector granularity

### DIFF
--- a/crates/api/src/op_store.rs
+++ b/crates/api/src/op_store.rs
@@ -88,7 +88,6 @@ pub trait OpStore: 'static + Send + Sync + std::fmt::Debug {
         arc: DhtArc,
         start: Timestamp,
         end: Timestamp,
-        limit_bytes: Option<u32>,
     ) -> BoxFuture<'_, K2Result<(Vec<OpId>, u32)>>;
 
     /// Retrieve a list of ops by their op ids.

--- a/crates/dht/src/time.rs
+++ b/crates/dht/src/time.rs
@@ -520,7 +520,6 @@ impl TimePartition {
                     self.sector_constraint,
                     full_slices_end_timestamp,
                     full_slices_end_timestamp + self.full_slice_duration,
-                    None,
                 )
                 .await?
                 .0;
@@ -627,7 +626,6 @@ impl TimePartition {
                                 self.sector_constraint,
                                 start,
                                 end,
-                                None,
                             )
                             .await?
                             .0,

--- a/crates/gossip/src/gossip.rs
+++ b/crates/gossip/src/gossip.rs
@@ -390,7 +390,7 @@ mod test {
     use kitsune2_api::{AgentId, DhtArc, OpId};
     use kitsune2_core::factories::MemoryOp;
     use kitsune2_core::{default_test_builder, Ed25519LocalAgent};
-    use kitsune2_dht::UNIT_TIME;
+    use kitsune2_dht::{SECTOR_SIZE, UNIT_TIME};
     use kitsune2_test_utils::enable_tracing;
     use kitsune2_test_utils::noop_bootstrap::NoopBootstrapFactory;
     use kitsune2_test_utils::space::TEST_SPACE_ID;
@@ -911,10 +911,11 @@ mod test {
         let mut ops = Vec::new();
 
         for i in 0u8..5 {
-            let op = MemoryOp::new(
-                Timestamp::from_micros(100 + i as i64),
-                vec![i; 128],
-            );
+            let mut op_data = (i as u32 * SECTOR_SIZE).to_le_bytes().to_vec();
+            op_data.resize(128, 0);
+
+            let op =
+                MemoryOp::new(Timestamp::from_micros(100 + i as i64), op_data);
             ops.push(op);
         }
         harness_1
@@ -1004,9 +1005,12 @@ mod test {
         let mut ops = Vec::new();
 
         for i in 0u8..5 {
+            let mut op_data = (i as u32 * SECTOR_SIZE).to_le_bytes().to_vec();
+            op_data.resize(128, 0);
+
             let op = MemoryOp::new(
                 (Timestamp::now() - 2 * UNIT_TIME).unwrap(),
-                vec![i; 128],
+                op_data,
             );
             ops.push(op);
         }

--- a/crates/gossip/src/respond/accept.rs
+++ b/crates/gossip/src/respond/accept.rs
@@ -81,10 +81,10 @@ impl K2Gossip {
 
             // Note that this value will have been initialised to 0 here when we created the
             // initial state. So we need to initialise and subtract here.
-            state.peer_max_op_data_bytes = std::cmp::min(
+            state.peer_max_op_data_bytes = (std::cmp::min(
                 self.config.max_request_gossip_op_bytes,
                 accept.max_op_data_bytes,
-            ) - used_bytes;
+            ) - used_bytes) as i32;
         }
 
         // The common part

--- a/crates/gossip/src/respond/disc_sector_details_diff.rs
+++ b/crates/gossip/src/respond/disc_sector_details_diff.rs
@@ -55,7 +55,7 @@ impl K2Gossip {
                 used_bytes,
                 state.peer_max_op_data_bytes,
             );
-            state.peer_max_op_data_bytes -= used_bytes;
+            state.peer_max_op_data_bytes -= used_bytes as i32;
         }
 
         match next_action {

--- a/crates/gossip/src/respond/disc_sector_details_diff_response.rs
+++ b/crates/gossip/src/respond/disc_sector_details_diff_response.rs
@@ -52,7 +52,7 @@ impl K2Gossip {
             used_bytes,
             state.peer_max_op_data_bytes,
         );
-        state.peer_max_op_data_bytes -= used_bytes;
+        state.peer_max_op_data_bytes -= used_bytes as i32;
 
         match next_action {
             DhtSnapshotNextAction::CannotCompare

--- a/crates/gossip/src/respond/initiate.rs
+++ b/crates/gossip/src/respond/initiate.rs
@@ -105,7 +105,7 @@ impl K2Gossip {
             initiate.max_op_data_bytes,
             new_ops.len()
         );
-        state.peer_max_op_data_bytes -= used_bytes;
+        state.peer_max_op_data_bytes -= used_bytes as i32;
 
         Ok(Some(GossipMessage::Accept(K2GossipAcceptMessage {
             session_id: initiate.session_id,

--- a/crates/gossip/src/respond/ring_sector_details_diff.rs
+++ b/crates/gossip/src/respond/ring_sector_details_diff.rs
@@ -52,7 +52,7 @@ impl K2Gossip {
             )
             .await?;
 
-        state.peer_max_op_data_bytes -= used_bytes;
+        state.peer_max_op_data_bytes -= used_bytes as i32;
 
         match next_action {
             DhtSnapshotNextAction::CannotCompare

--- a/crates/gossip/src/respond/ring_sector_details_diff_response.rs
+++ b/crates/gossip/src/respond/ring_sector_details_diff_response.rs
@@ -50,7 +50,7 @@ impl K2Gossip {
             .await?;
 
         if let Some(state) = state.as_mut() {
-            state.peer_max_op_data_bytes -= used_bytes;
+            state.peer_max_op_data_bytes -= used_bytes as i32;
         }
 
         match next_action {

--- a/crates/gossip/src/state.rs
+++ b/crates/gossip/src/state.rs
@@ -24,7 +24,10 @@ pub(crate) struct GossipRoundState {
     ///
     /// Note that it's actually [kitsune2_api::OpId]s that are exchanged. So this is a hint in
     /// terms of op data about how many op ids we should send back to the other peer.
-    pub peer_max_op_data_bytes: u32,
+    ///
+    /// The value is an `i32` because it's a soft limit and in order to send complete slices,
+    /// gossip may exceed the limit. That is recorded here as a negative number.
+    pub peer_max_op_data_bytes: i32,
 
     /// The current stage of the round.
     ///
@@ -66,7 +69,7 @@ impl GossipRoundState {
             session_with_peer,
             started_at: tokio::time::Instant::now(),
             session_id,
-            peer_max_op_data_bytes,
+            peer_max_op_data_bytes: peer_max_op_data_bytes as i32,
             stage: RoundStage::Accepted(RoundStageAccepted {
                 our_agents,
                 common_arc_set,


### PR DESCRIPTION
This one is slightly subtle. I initially applied the limit rather harshly at an "op boundary". If this falls within a really large sector/slice then it's possible that the limit isn't set high enough to ever retrieve that data. I think it's better to be less strict with the limit to ensure we always make progress when gossiping a diff.

The changes on this PR are all a fallout from that change.