### PR TITLE
chore: Pick serde version that is more widely compatible

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ prost = "0.13.3"
 # used to generate private cryptography keys.
 rand = "0.8.5"
 # kitsune types need to be serializable for network transmission.
-serde = { version = "1.0.215", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
 # kitsune2 agent info is serialized as json to improve debugability of
 # bootstrapping. So, we need a json library.
 serde_json = "1.0.132"


### PR DESCRIPTION
`kitsune2_api` won't build inside Holochain because we pin serde in HSB. We just need to not request a specific version of serde. We only actually depend on the 1.0 API not anything added in recent versions.