### PR TITLE
Peer meta store no space

### DIFF
--- a/crates/api/src/peer_meta_store.rs
+++ b/crates/api/src/peer_meta_store.rs
@@ -1,4 +1,4 @@
-use crate::{builder, config, BoxFut, K2Result, SpaceId, Timestamp, Url};
+use crate::{builder, config, BoxFut, K2Result, Timestamp, Url};
 use futures::future::BoxFuture;
 use std::sync::Arc;
 
@@ -9,7 +9,6 @@ pub trait PeerMetaStore: 'static + Send + Sync + std::fmt::Debug {
     /// Store a key-value pair for a given space and peer.
     fn put(
         &self,
-        space: SpaceId,
         peer: Url,
         key: String,
         value: bytes::Bytes,
@@ -19,18 +18,12 @@ pub trait PeerMetaStore: 'static + Send + Sync + std::fmt::Debug {
     /// Get a value by key for a given space and peer.
     fn get(
         &self,
-        space: SpaceId,
         peer: Url,
         key: String,
     ) -> BoxFuture<'_, K2Result<Option<bytes::Bytes>>>;
 
     /// Delete a key-value pair for a given space and peer.
-    fn delete(
-        &self,
-        space: SpaceId,
-        peer: Url,
-        key: String,
-    ) -> BoxFuture<'_, K2Result<()>>;
+    fn delete(&self, peer: Url, key: String) -> BoxFuture<'_, K2Result<()>>;
 }
 
 /// Trait-object version of kitsune2 [PeerMetaStore].

--- a/crates/gossip/src/gossip.rs
+++ b/crates/gossip/src/gossip.rs
@@ -177,10 +177,7 @@ impl K2Gossip {
             space_id: space_id.clone(),
             peer_store,
             local_agent_store,
-            peer_meta_store: Arc::new(K2PeerMetaStore::new(
-                peer_meta_store,
-                space_id.clone(),
-            )),
+            peer_meta_store: Arc::new(K2PeerMetaStore::new(peer_meta_store)),
             op_store,
             fetch,
             agent_verifier,
@@ -582,10 +579,8 @@ mod test {
                 .await
                 .unwrap();
 
-            let peer_meta_store = K2PeerMetaStore::new(
-                space.peer_meta_store().clone(),
-                self.space_id.clone(),
-            );
+            let peer_meta_store =
+                K2PeerMetaStore::new(space.peer_meta_store().clone());
 
             GossipTestHarness {
                 _gossip: space.gossip().clone(),

--- a/crates/gossip/src/initiate.rs
+++ b/crates/gossip/src/initiate.rs
@@ -214,7 +214,6 @@ mod tests {
     use kitsune2_dht::SECTOR_SIZE;
     use kitsune2_test_utils::agent::{AgentBuilder, TestLocalAgent};
     use kitsune2_test_utils::enable_tracing;
-    use kitsune2_test_utils::space::TEST_SPACE_ID;
     use std::sync::Arc;
 
     struct Harness {
@@ -245,7 +244,6 @@ mod tests {
                         .create(builder.clone())
                         .await
                         .unwrap(),
-                    TEST_SPACE_ID,
                 )),
             }
         }

--- a/crates/gossip/src/respond/harness.rs
+++ b/crates/gossip/src/respond/harness.rs
@@ -72,7 +72,6 @@ impl RespondTestHarness {
                         .create(builder.clone())
                         .await
                         .unwrap(),
-                    TEST_SPACE_ID,
                 )),
                 op_store: op_store.clone(),
                 fetch: builder


### PR DESCRIPTION
This was a mistake I think, it's already in the context of a space and doesn't need to keep data separate by space