### PR TITLE
Add more peer meta for gossip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1494,6 +1494,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
+ "thiserror 2.0.8",
  "tokio",
  "tracing",
 ]

--- a/crates/gossip/Cargo.toml
+++ b/crates/gossip/Cargo.toml
@@ -22,6 +22,7 @@ tracing = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 rand = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 kitsune2_api = { workspace = true, features = ["mockall"] }

--- a/crates/gossip/README.md
+++ b/crates/gossip/README.md
@@ -10,18 +10,30 @@ stateDiagram-v2
     accept --> no_diff: Initiator snapshot matches, send missing agents, new ops, new bookmark
     accept --> disc_sectors_diff: Initiator sends disc diff + missing agents, new ops, new bookmark
     accept --> ring_sector_details_diff: Initiator sends ring diff + missing agents, new ops, new bookmark
+    accept --> terminate: Must stop
     
     no_diff --> agents: Acceptor send agents
     disc_sectors_diff --> agents: Acceptor cannot compare, so sends only agents
     ring_sector_details_diff --> agents: Acceptor cannot compare, so sends only agents 
     
+    disc_sectors_diff --> terminate: Must stop
+    ring_sector_details_diff --> terminate: Must stop
+    
     disc_sectors_diff --> disc_sector_details_diff: Acceptor sends disc diff
     disc_sector_details_diff --> disc_sector_details_diff_response: Initiator sends disc diff + hashes
     disc_sector_details_diff_response --> hashes: Acceptor sends hashes
     
+    disc_sectors_diff --> terminate: Must stop
+    disc_sector_details_diff --> terminate: Must stop
+    disc_sector_details_diff_response --> terminate: Must stop
+    
     ring_sector_details_diff --> ring_sector_details_diff_response: Acceptor sends ring diff + hashes
     ring_sector_details_diff_response --> hashes: Initiator sends hashes
     
+    ring_sector_details_diff --> terminate: Must stop
+    ring_sector_details_diff_response --> terminate: Must stop
+    
     hashes --> [*]
     agents --> [*]
+    terminate --> [*]
 ```

--- a/crates/gossip/proto/gen/kitsune2.gossip.rs
+++ b/crates/gossip/proto/gen/kitsune2.gossip.rs
@@ -49,6 +49,8 @@ pub mod k2_gossip_message {
         Agents = 10,
         /// A gossip busy protocol message.
         Busy = 11,
+        /// A gossip terminate protocol message.
+        Terminate = 12,
     }
     impl GossipMessageType {
         /// String value of the enum field names used in the ProtoBuf definition.
@@ -73,6 +75,7 @@ pub mod k2_gossip_message {
                 Self::Hashes => "HASHES",
                 Self::Agents => "AGENTS",
                 Self::Busy => "BUSY",
+                Self::Terminate => "TERMINATE",
             }
         }
         /// Creates an enum from field names used in the ProtoBuf definition.
@@ -94,6 +97,7 @@ pub mod k2_gossip_message {
                 "HASHES" => Some(Self::Hashes),
                 "AGENTS" => Some(Self::Agents),
                 "BUSY" => Some(Self::Busy),
+                "TERMINATE" => Some(Self::Terminate),
                 _ => None,
             }
         }
@@ -365,4 +369,12 @@ pub struct K2GossipAgentsMessage {
 pub struct K2GossipBusyMessage {
     #[prost(bytes = "bytes", tag = "1")]
     pub session_id: ::prost::bytes::Bytes,
+}
+/// A Kitsune2 gossip terminate protocol message.
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct K2GossipTerminateMessage {
+    #[prost(bytes = "bytes", tag = "1")]
+    pub session_id: ::prost::bytes::Bytes,
+    #[prost(string, tag = "2")]
+    pub reason: ::prost::alloc::string::String,
 }

--- a/crates/gossip/proto/gossip.proto
+++ b/crates/gossip/proto/gossip.proto
@@ -41,6 +41,9 @@ message K2GossipMessage {
 
     // A gossip busy protocol message.
     BUSY = 11;
+
+    // A gossip terminate protocol message.
+    TERMINATE = 12;
   }
 
   // The type of this message.
@@ -277,4 +280,11 @@ message K2GossipAgentsMessage {
 // This allows the initiator to retry the round later, without waiting for a timeout.
 message K2GossipBusyMessage {
   bytes session_id = 1;
+}
+
+// A Kitsune2 gossip terminate protocol message.
+message K2GossipTerminateMessage {
+  bytes session_id = 1;
+
+  string reason = 2;
 }

--- a/crates/gossip/src/error.rs
+++ b/crates/gossip/src/error.rs
@@ -1,0 +1,23 @@
+use kitsune2_api::K2Error;
+use std::sync::Arc;
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum K2GossipError {
+    /// An error caused by peer behavior.
+    #[error("Rejected peer behavior - {ctx}")]
+    PeerBehaviorError {
+        ctx: Arc<str>,
+    },
+
+    /// A Kitsune2 error.
+    #[error("K2Error - {0}")]
+    K2Error(#[from] K2Error),
+}
+
+impl K2GossipError {
+    pub(crate) fn peer_behavior(ctx: impl Into<Arc<str>>) -> Self {
+        Self::PeerBehaviorError { ctx: ctx.into() }
+    }
+}
+
+pub(crate) type K2GossipResult<T> = Result<T, K2GossipError>;

--- a/crates/gossip/src/error.rs
+++ b/crates/gossip/src/error.rs
@@ -5,9 +5,7 @@ use std::sync::Arc;
 pub(crate) enum K2GossipError {
     /// An error caused by peer behavior.
     #[error("Rejected peer behavior - {ctx}")]
-    PeerBehaviorError {
-        ctx: Arc<str>,
-    },
+    PeerBehaviorError { ctx: Arc<str> },
 
     /// A Kitsune2 error.
     #[error("K2Error - {0}")]

--- a/crates/gossip/src/gossip.rs
+++ b/crates/gossip/src/gossip.rs
@@ -1,3 +1,4 @@
+use crate::error::K2GossipError;
 use crate::initiate::spawn_initiate_task;
 use crate::peer_meta_store::K2PeerMetaStore;
 use crate::protocol::{
@@ -17,7 +18,6 @@ use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::{Mutex, RwLock};
 use tokio::time::Instant;
-use crate::error::K2GossipError;
 
 /// A factory for creating K2Gossip instances.
 #[derive(Debug)]
@@ -320,14 +320,33 @@ impl K2Gossip {
 
         let this = self.clone();
         tokio::task::spawn(async move {
-            match this.respond_to_msg(from_peer, msg).await {
-                Ok(_) => {},
+            match this.respond_to_msg(from_peer.clone(), msg).await {
+                Ok(_) => {}
                 Err(e @ K2GossipError::PeerBehaviorError { .. }) => {
-                    // TODO record in peer meta store
                     tracing::error!("Peer behavior error: {:?}", e);
+
+                    if let Err(e) = this
+                        .peer_meta_store
+                        .incr_peer_behavior_errors(from_peer)
+                        .await
+                    {
+                        tracing::warn!(
+                            "Could not record peer behavior error: {:?}",
+                            e
+                        );
+                    }
                 }
                 Err(e) => {
-                    tracing::error!("could not respond to gossip message: {:?}", e);
+                    tracing::error!(
+                        "could not respond to gossip message: {:?}",
+                        e
+                    );
+
+                    if let Err(e) =
+                        this.peer_meta_store.incr_local_errors(from_peer).await
+                    {
+                        tracing::warn!("Could not record local error: {:?}", e);
+                    }
                 }
             }
         });
@@ -608,7 +627,7 @@ mod test {
         let agent_info_1 = harness_1.join_local_agent(DhtArc::FULL).await;
 
         let harness_2 = factory.new_instance().await;
-        harness_2.join_local_agent(DhtArc::FULL).await;
+        let agent_info_2 = harness_2.join_local_agent(DhtArc::FULL).await;
 
         // Join extra agents for each peer. These will take a few seconds to be
         // found by bootstrap. Try to sync them with gossip.
@@ -640,6 +659,21 @@ mod test {
         harness_2
             .wait_for_agent_in_peer_store(secret_agent_1.agent.clone())
             .await;
+
+        let completed_1 = harness_1
+            .peer_meta_store
+            .completed_rounds(agent_info_2.url.clone().unwrap())
+            .await
+            .unwrap()
+            .unwrap_or_default();
+        assert_eq!(1, completed_1);
+        let completed_2 = harness_2
+            .peer_meta_store
+            .completed_rounds(agent_info_1.url.clone().unwrap())
+            .await
+            .unwrap()
+            .unwrap_or_default();
+        assert_eq!(1, completed_2);
     }
 
     #[tokio::test]

--- a/crates/gossip/src/lib.rs
+++ b/crates/gossip/src/lib.rs
@@ -11,6 +11,7 @@ pub use constant::*;
 mod gossip;
 pub use gossip::*;
 
+mod error;
 mod initiate;
 mod peer_meta_store;
 mod protocol;

--- a/crates/gossip/src/protocol.rs
+++ b/crates/gossip/src/protocol.rs
@@ -24,6 +24,7 @@ pub enum GossipMessage {
     Hashes(K2GossipHashesMessage),
     Agents(K2GossipAgentsMessage),
     Busy(K2GossipBusyMessage),
+    Terminate(K2GossipTerminateMessage),
 }
 
 /// Deserialize a gossip message
@@ -91,6 +92,11 @@ pub fn deserialize_gossip_message(value: Bytes) -> K2Result<GossipMessage> {
             let inner = K2GossipBusyMessage::decode(outer.data)
                 .map_err(K2Error::other)?;
             Ok(GossipMessage::Busy(inner))
+        }
+        k2_gossip_message::GossipMessageType::Terminate => {
+            let inner = K2GossipTerminateMessage::decode(outer.data)
+                .map_err(K2Error::other)?;
+            Ok(GossipMessage::Terminate(inner))
         }
         _ => Err(K2Error::other("Unknown gossip message type".to_string())),
     }
@@ -173,6 +179,10 @@ fn serialize_inner_gossip_message(
         )),
         GossipMessage::Busy(inner) => Ok((
             k2_gossip_message::GossipMessageType::Busy,
+            encode(inner, out)?,
+        )),
+        GossipMessage::Terminate(inner) => Ok((
+            k2_gossip_message::GossipMessageType::Terminate,
             encode(inner, out)?,
         )),
     }

--- a/crates/gossip/src/respond.rs
+++ b/crates/gossip/src/respond.rs
@@ -9,6 +9,7 @@ use kitsune2_api::*;
 use kitsune2_dht::{ArcSet, UNIT_TIME};
 use std::sync::Arc;
 use tokio::sync::{Mutex, OwnedMutexGuard};
+use crate::error::K2GossipResult;
 
 mod accept;
 mod agents;
@@ -30,7 +31,7 @@ impl K2Gossip {
         &self,
         from_peer: Url,
         msg: GossipMessage,
-    ) -> K2Result<()> {
+    ) -> K2GossipResult<()> {
         let res = match msg {
             GossipMessage::Initiate(initiate) => {
                 self.respond_to_initiate(from_peer.clone(), initiate).await

--- a/crates/gossip/src/respond.rs
+++ b/crates/gossip/src/respond.rs
@@ -1,3 +1,4 @@
+use crate::error::K2GossipResult;
 use crate::gossip::{send_gossip_message, K2Gossip};
 use crate::protocol::{
     AcceptResponseMessage, GossipMessage, K2GossipInitiateMessage,
@@ -9,7 +10,6 @@ use kitsune2_api::*;
 use kitsune2_dht::{ArcSet, UNIT_TIME};
 use std::sync::Arc;
 use tokio::sync::{Mutex, OwnedMutexGuard};
-use crate::error::K2GossipResult;
 
 mod accept;
 mod agents;
@@ -22,6 +22,7 @@ mod initiate;
 mod no_diff;
 mod ring_sector_details_diff;
 mod ring_sector_details_diff_response;
+mod terminate;
 
 #[cfg(test)]
 mod harness;
@@ -91,10 +92,31 @@ impl K2Gossip {
                 self.respond_to_busy(from_peer.clone(), busy).await?;
                 Ok(None)
             }
+            GossipMessage::Terminate(terminate) => {
+                self.respond_to_terminate(from_peer.clone(), terminate)
+                    .await?;
+                Ok(None)
+            }
         }?;
 
+        // If we're not sending a message back
+        let is_final_message = matches!(
+            &res,
+            None | Some(
+                GossipMessage::Agents(_)
+                    | GossipMessage::Hashes(_)
+                    | GossipMessage::Terminate(_),
+            )
+        );
+
         if let Some(msg) = res {
-            send_gossip_message(&self.response_tx, from_peer, msg)?;
+            send_gossip_message(&self.response_tx, from_peer.clone(), msg)?;
+        }
+
+        if is_final_message {
+            self.peer_meta_store
+                .incr_completed_rounds(from_peer)
+                .await?;
         }
 
         Ok(())

--- a/crates/gossip/src/respond/accept.rs
+++ b/crates/gossip/src/respond/accept.rs
@@ -12,13 +12,14 @@ use kitsune2_api::*;
 use kitsune2_dht::DhtSnapshot;
 use kitsune2_dht::{ArcSet, DhtSnapshotNextAction};
 use tokio::sync::MutexGuard;
+use crate::error::K2GossipResult;
 
 impl K2Gossip {
     pub(super) async fn respond_to_accept(
         &self,
         from_peer: Url,
         accept: K2GossipAcceptMessage,
-    ) -> K2Result<Option<GossipMessage>> {
+    ) -> K2GossipResult<Option<GossipMessage>> {
         // Validate the incoming accept against our own state.
         let (mut lock, initiated) =
             self.check_accept_state(&from_peer, &accept).await?;

--- a/crates/gossip/src/respond/agents.rs
+++ b/crates/gossip/src/respond/agents.rs
@@ -2,13 +2,14 @@ use crate::gossip::K2Gossip;
 use crate::protocol::{GossipMessage, K2GossipAgentsMessage};
 use crate::state::{GossipRoundState, RoundStage};
 use kitsune2_api::{K2Error, K2Result, Url};
+use crate::error::K2GossipResult;
 
 impl K2Gossip {
     pub(super) async fn respond_to_agents(
         &self,
         from_peer: Url,
         agents: K2GossipAgentsMessage,
-    ) -> K2Result<Option<GossipMessage>> {
+    ) -> K2GossipResult<Option<GossipMessage>> {
         // Validate the incoming agents message against our own state.
         let mut initiated_lock = self.initiated_round_state.lock().await;
         match initiated_lock.as_ref() {
@@ -18,7 +19,7 @@ impl K2Gossip {
                 initiated_lock.take();
             }
             None => {
-                return Err(K2Error::other("Unsolicited Agents message"));
+                return Err(K2Error::other("Unsolicited Agents message").into());
             }
         }
 

--- a/crates/gossip/src/respond/agents.rs
+++ b/crates/gossip/src/respond/agents.rs
@@ -1,8 +1,8 @@
+use crate::error::{K2GossipError, K2GossipResult};
 use crate::gossip::K2Gossip;
 use crate::protocol::{GossipMessage, K2GossipAgentsMessage};
 use crate::state::{GossipRoundState, RoundStage};
-use kitsune2_api::{K2Error, K2Result, Url};
-use crate::error::K2GossipResult;
+use kitsune2_api::{K2Error, Url};
 
 impl K2Gossip {
     pub(super) async fn respond_to_agents(
@@ -19,7 +19,9 @@ impl K2Gossip {
                 initiated_lock.take();
             }
             None => {
-                return Err(K2Error::other("Unsolicited Agents message").into());
+                return Err(K2GossipError::peer_behavior(
+                    "Unsolicited Agents message",
+                ));
             }
         }
 
@@ -34,16 +36,17 @@ impl GossipRoundState {
         &self,
         from_peer: Url,
         agents: &K2GossipAgentsMessage,
-    ) -> K2Result<()> {
+    ) -> K2GossipResult<()> {
         if self.session_with_peer != from_peer {
             return Err(K2Error::other(format!(
                 "Agents message from wrong peer: {} != {}",
                 self.session_with_peer, from_peer
-            )));
+            ))
+            .into());
         }
 
         if self.session_id != agents.session_id {
-            return Err(K2Error::other(format!(
+            return Err(K2GossipError::peer_behavior(format!(
                 "Session id mismatch: {:?} != {:?}",
                 self.session_id, agents.session_id
             )));
@@ -54,7 +57,7 @@ impl GossipRoundState {
                 tracing::trace!("NoDiff round state found");
             }
             stage => {
-                return Err(K2Error::other(format!(
+                return Err(K2GossipError::peer_behavior(format!(
                     "Unexpected round state for agents: NoDiff != {:?}",
                     stage
                 )));

--- a/crates/gossip/src/respond/disc_sector_details_diff.rs
+++ b/crates/gossip/src/respond/disc_sector_details_diff.rs
@@ -1,16 +1,16 @@
+use crate::error::{K2GossipError, K2GossipResult};
 use crate::gossip::K2Gossip;
 use crate::protocol::{
     encode_op_ids, GossipMessage, K2GossipDiscSectorDetailsDiffMessage,
-    K2GossipDiscSectorDetailsDiffResponseMessage,
+    K2GossipDiscSectorDetailsDiffResponseMessage, K2GossipTerminateMessage,
 };
 use crate::state::{
     GossipRoundState, RoundStage, RoundStageDiscSectorDetailsDiff,
     RoundStageDiscSectorsDiff,
 };
-use kitsune2_api::{K2Error, K2Result, Url};
+use kitsune2_api::{K2Error, Url};
 use kitsune2_dht::DhtSnapshotNextAction;
 use tokio::sync::MutexGuard;
-use crate::error::K2GossipResult;
 
 impl K2Gossip {
     pub(super) async fn respond_to_disc_sector_details_diff(
@@ -64,12 +64,13 @@ impl K2Gossip {
             | DhtSnapshotNextAction::Identical => {
                 tracing::info!("Received a disc sector details diff but no diff to send back, responding with agents");
 
-                // TODO These cases where we terminate don't notify the remote so they'll
-                //      end up timing out. Should do something differently here.
                 // Terminating the session, so remove the state.
                 state.take();
 
-                Ok(None)
+                Ok(Some(GossipMessage::Terminate(K2GossipTerminateMessage {
+                    session_id: disc_sector_details_diff.session_id,
+                    reason: "Nothing to compare".to_string(),
+                })))
             }
             DhtSnapshotNextAction::NewSnapshotAndHashList(snapshot, ops) => {
                 if let Some(state) = state.as_mut() {
@@ -92,7 +93,15 @@ impl K2Gossip {
                 )))
             }
             _ => {
-                unreachable!("unexpected next action")
+                tracing::error!("Unexpected next action: {:?}", next_action);
+
+                // Remove round state.
+                state.take();
+
+                Ok(Some(GossipMessage::Terminate(K2GossipTerminateMessage {
+                    session_id: disc_sector_details_diff.session_id,
+                    reason: "Unexpected next action".into(),
+                })))
             }
         }
     }
@@ -101,7 +110,7 @@ impl K2Gossip {
         &'a self,
         from_peer: Url,
         disc_sector_details_diff: &K2GossipDiscSectorDetailsDiffMessage,
-    ) -> K2Result<(
+    ) -> K2GossipResult<(
         MutexGuard<'a, Option<GossipRoundState>>,
         RoundStageDiscSectorsDiff,
     )> {
@@ -114,7 +123,7 @@ impl K2Gossip {
                 )?
                 .clone(),
             None => {
-                return Err(K2Error::other(
+                return Err(K2GossipError::peer_behavior(
                     "Unsolicited DiscSectorDetailsDiff message",
                 ));
             }
@@ -129,23 +138,24 @@ impl GossipRoundState {
         &self,
         from_peer: Url,
         disc_sector_details_diff: &K2GossipDiscSectorDetailsDiffMessage,
-    ) -> K2Result<&RoundStageDiscSectorsDiff> {
+    ) -> K2GossipResult<&RoundStageDiscSectorsDiff> {
         if self.session_with_peer != from_peer {
             return Err(K2Error::other(format!(
                 "DiscSectorDetailsDiff message from wrong peer: {} != {}",
                 self.session_with_peer, from_peer
-            )));
+            ))
+            .into());
         }
 
         if self.session_id != disc_sector_details_diff.session_id {
-            return Err(K2Error::other(format!(
+            return Err(K2GossipError::peer_behavior(format!(
                 "Session id mismatch: {:?} != {:?}",
                 self.session_id, disc_sector_details_diff.session_id
             )));
         }
 
         let Some(snapshot) = &disc_sector_details_diff.snapshot else {
-            return Err(K2Error::other(
+            return Err(K2GossipError::peer_behavior(
                 "Received DiscSectorDetailsDiff message without snapshot",
             ));
         };
@@ -154,7 +164,7 @@ impl GossipRoundState {
             RoundStage::DiscSectorsDiff(stage @ RoundStageDiscSectorsDiff { common_arc_set }) => {
                 for sector in &snapshot.sector_indices {
                     if !common_arc_set.includes_sector_index(*sector) {
-                        return Err(K2Error::other(
+                        return Err(K2GossipError::peer_behavior(
                             "DiscSectorDetailsDiff message contains sector that isn't in the common arc set",
                         ));
                     }
@@ -163,7 +173,7 @@ impl GossipRoundState {
                 Ok(stage)
             }
             stage => {
-                Err(K2Error::other(format!(
+                Err(K2GossipError::peer_behavior(format!(
                     "Unexpected round state for disc sector details diff: DiscSectorsDiff != {:?}",
                     stage
                 )))

--- a/crates/gossip/src/respond/disc_sector_details_diff.rs
+++ b/crates/gossip/src/respond/disc_sector_details_diff.rs
@@ -10,13 +10,14 @@ use crate::state::{
 use kitsune2_api::{K2Error, K2Result, Url};
 use kitsune2_dht::DhtSnapshotNextAction;
 use tokio::sync::MutexGuard;
+use crate::error::K2GossipResult;
 
 impl K2Gossip {
     pub(super) async fn respond_to_disc_sector_details_diff(
         &self,
         from_peer: Url,
         disc_sector_details_diff: K2GossipDiscSectorDetailsDiffMessage,
-    ) -> K2Result<Option<GossipMessage>> {
+    ) -> K2GossipResult<Option<GossipMessage>> {
         // Validate the incoming disc sector details diff against our own state.
         let (mut state, disc_sector_details) = self
             .check_disc_sector_details_diff_state(

--- a/crates/gossip/src/respond/disc_sector_details_diff_response.rs
+++ b/crates/gossip/src/respond/disc_sector_details_diff_response.rs
@@ -1,16 +1,16 @@
+use crate::error::{K2GossipError, K2GossipResult};
 use crate::gossip::K2Gossip;
 use crate::protocol::{
     encode_op_ids, GossipMessage, K2GossipDiscSectorDetailsDiffResponseMessage,
-    K2GossipHashesMessage,
+    K2GossipHashesMessage, K2GossipTerminateMessage,
 };
 use crate::state::{
     GossipRoundState, RoundStage, RoundStageDiscSectorDetailsDiff,
 };
 use kitsune2_api::decode_ids;
-use kitsune2_api::{K2Error, K2Result, Url};
+use kitsune2_api::{K2Error, Url};
 use kitsune2_dht::DhtSnapshotNextAction;
 use tokio::sync::OwnedMutexGuard;
-use crate::error::K2GossipResult;
 
 impl K2Gossip {
     pub(super) async fn respond_to_disc_sector_details_diff_response(
@@ -63,7 +63,10 @@ impl K2Gossip {
                 // Terminating the session, so remove the state.
                 self.accepted_round_states.write().await.remove(&from_peer);
 
-                Ok(None)
+                Ok(Some(GossipMessage::Terminate(K2GossipTerminateMessage {
+                    session_id: response.session_id,
+                    reason: "Nothing to compare".to_string(),
+                })))
             }
             DhtSnapshotNextAction::HashList(op_ids) => {
                 // This is the final message we're going to send, remove state
@@ -74,8 +77,16 @@ impl K2Gossip {
                     missing_ids: encode_op_ids(op_ids),
                 })))
             }
-            _ => {
-                unreachable!("unexpected next action")
+            a => {
+                tracing::error!("Unexpected next action: {:?}", a);
+
+                // Terminating the session, so remove the state.
+                self.accepted_round_states.write().await.remove(&from_peer);
+
+                Ok(Some(GossipMessage::Terminate(K2GossipTerminateMessage {
+                    session_id: response.session_id,
+                    reason: "Unexpected next action".to_string(),
+                })))
             }
         }
     }
@@ -84,7 +95,7 @@ impl K2Gossip {
         &self,
         from_peer: Url,
         disc_sector_details_diff_response: &K2GossipDiscSectorDetailsDiffResponseMessage,
-    ) -> K2Result<(
+    ) -> K2GossipResult<(
         OwnedMutexGuard<GossipRoundState>,
         RoundStageDiscSectorDetailsDiff,
     )> {
@@ -98,7 +109,7 @@ impl K2Gossip {
 
                 Ok((state, disc_sector_details))
             }
-            None => Err(K2Error::other(format!(
+            None => Err(K2GossipError::peer_behavior(format!(
                 "Unsolicited DiscSectorDetailsDiffResponse message from peer: {:?}",
                 from_peer
             )))
@@ -111,23 +122,23 @@ impl GossipRoundState {
         &self,
         from_peer: Url,
         disc_sector_details_diff: &K2GossipDiscSectorDetailsDiffResponseMessage,
-    ) -> K2Result<&RoundStageDiscSectorDetailsDiff> {
+    ) -> K2GossipResult<&RoundStageDiscSectorDetailsDiff> {
         if self.session_with_peer != from_peer {
             return Err(K2Error::other(format!(
                 "DiscSectorDetailsDiffResponse message from wrong peer: {} != {}",
                 self.session_with_peer, from_peer
-            )));
+            )).into());
         }
 
         if self.session_id != disc_sector_details_diff.session_id {
-            return Err(K2Error::other(format!(
+            return Err(K2GossipError::peer_behavior(format!(
                 "Session id mismatch: {:?} != {:?}",
                 self.session_id, disc_sector_details_diff.session_id
             )));
         }
 
         let Some(snapshot) = &disc_sector_details_diff.snapshot else {
-            return Err(K2Error::other(
+            return Err(K2GossipError::peer_behavior(
                 "Received DiscSectorDetailsDiffResponse message without snapshot",
             ));
         };
@@ -136,7 +147,7 @@ impl GossipRoundState {
             RoundStage::DiscSectorDetailsDiff(state @ RoundStageDiscSectorDetailsDiff { common_arc_set, .. }) => {
                 for sector in &snapshot.sector_indices {
                     if !common_arc_set.includes_sector_index(*sector) {
-                        return Err(K2Error::other(
+                        return Err(K2GossipError::peer_behavior(
                             "DiscSectorDetailsDiffResponse message contains sector that isn't in the common arc set",
                         ));
                     }
@@ -145,7 +156,7 @@ impl GossipRoundState {
                 Ok(state)
             }
             stage => {
-                Err(K2Error::other(format!(
+                Err(K2GossipError::peer_behavior(format!(
                     "Unexpected round state for disc sector details diff response: DiscSectorDetailsDiff != {:?}",
                     stage
                 )))

--- a/crates/gossip/src/respond/disc_sector_details_diff_response.rs
+++ b/crates/gossip/src/respond/disc_sector_details_diff_response.rs
@@ -10,13 +10,14 @@ use kitsune2_api::decode_ids;
 use kitsune2_api::{K2Error, K2Result, Url};
 use kitsune2_dht::DhtSnapshotNextAction;
 use tokio::sync::OwnedMutexGuard;
+use crate::error::K2GossipResult;
 
 impl K2Gossip {
     pub(super) async fn respond_to_disc_sector_details_diff_response(
         &self,
         from_peer: Url,
         response: K2GossipDiscSectorDetailsDiffResponseMessage,
-    ) -> K2Result<Option<GossipMessage>> {
+    ) -> K2GossipResult<Option<GossipMessage>> {
         let (mut state, disc_sector_details) = self
             .check_disc_sectors_diff_response_state(
                 from_peer.clone(),

--- a/crates/gossip/src/respond/disc_sectors_diff.rs
+++ b/crates/gossip/src/respond/disc_sectors_diff.rs
@@ -1,17 +1,18 @@
+use crate::error::{K2GossipError, K2GossipResult};
 use crate::gossip::K2Gossip;
 use crate::protocol::{
     encode_agent_infos, GossipMessage, K2GossipAgentsMessage,
     K2GossipDiscSectorDetailsDiffMessage, K2GossipDiscSectorsDiffMessage,
+    K2GossipTerminateMessage,
 };
 use crate::state::{
     GossipRoundState, RoundStage, RoundStageAccepted,
     RoundStageDiscSectorDetailsDiff,
 };
-use kitsune2_api::{AgentId, K2Error, K2Result, Url};
+use kitsune2_api::{AgentId, K2Error, Url};
 use kitsune2_dht::DhtSnapshot;
 use kitsune2_dht::DhtSnapshotNextAction;
 use tokio::sync::OwnedMutexGuard;
-use crate::error::K2GossipResult;
 
 impl K2Gossip {
     pub(super) async fn respond_to_disc_sectors_diff(
@@ -87,8 +88,16 @@ impl K2Gossip {
                     },
                 )))
             }
-            _ => {
-                unreachable!("unexpected next action")
+            a => {
+                tracing::error!("Unexpected next action: {:?}", a);
+
+                // Remove round state
+                self.accepted_round_states.write().await.remove(&from_peer);
+
+                Ok(Some(GossipMessage::Terminate(K2GossipTerminateMessage {
+                    session_id: disc_sectors_diff.session_id,
+                    reason: "Unexpected next action".to_string(),
+                })))
             }
         }
     }
@@ -97,7 +106,8 @@ impl K2Gossip {
         &self,
         from_peer: Url,
         disc_sectors_diff: &K2GossipDiscSectorsDiffMessage,
-    ) -> K2Result<(OwnedMutexGuard<GossipRoundState>, RoundStageAccepted)> {
+    ) -> K2GossipResult<(OwnedMutexGuard<GossipRoundState>, RoundStageAccepted)>
+    {
         match self.accepted_round_states.read().await.get(&from_peer) {
             Some(state) => {
                 let state = state.clone().lock_owned().await;
@@ -110,7 +120,7 @@ impl K2Gossip {
 
                 Ok((state, accepted))
             }
-            None => Err(K2Error::other(format!(
+            None => Err(K2GossipError::peer_behavior(format!(
                 "Unsolicited DiscSectorsDiff message from peer: {:?}",
                 from_peer
             ))),
@@ -123,23 +133,24 @@ impl GossipRoundState {
         &self,
         from_peer: Url,
         disc_sectors_diff: &K2GossipDiscSectorsDiffMessage,
-    ) -> K2Result<&RoundStageAccepted> {
+    ) -> K2GossipResult<&RoundStageAccepted> {
         if self.session_with_peer != from_peer {
             return Err(K2Error::other(format!(
                 "DiscSectorsDiff message from wrong peer: {} != {}",
                 self.session_with_peer, from_peer
-            )));
+            ))
+            .into());
         }
 
         if self.session_id != disc_sectors_diff.session_id {
-            return Err(K2Error::other(format!(
+            return Err(K2GossipError::peer_behavior(format!(
                 "Session id mismatch: {:?} != {:?}",
                 self.session_id, disc_sectors_diff.session_id
             )));
         }
 
         let Some(snapshot) = &disc_sectors_diff.snapshot else {
-            return Err(K2Error::other(
+            return Err(K2GossipError::peer_behavior(
                 "Received DiscSectorsDiff message without snapshot",
             ));
         };
@@ -153,7 +164,7 @@ impl GossipRoundState {
             ) => {
                 let Some(accept_response) = &disc_sectors_diff.accept_response
                 else {
-                    return Err(K2Error::other(
+                    return Err(K2GossipError::peer_behavior(
                         "Received NoDiff message without accept response",
                     ));
                 };
@@ -163,14 +174,14 @@ impl GossipRoundState {
                     .iter()
                     .any(|a| !our_agents.contains(&AgentId::from(a.clone())))
                 {
-                    return Err(K2Error::other(
+                    return Err(K2GossipError::peer_behavior(
                         "NoDiff message contains agents that we didn't declare",
                     ));
                 }
 
                 for sector in &snapshot.disc_sectors {
                     if !common_arc_set.includes_sector_index(*sector) {
-                        return Err(K2Error::other(
+                        return Err(K2GossipError::peer_behavior(
                             "DiscSectorsDiff message contains sector that isn't in the common arc set",
                         ));
                     }
@@ -178,7 +189,7 @@ impl GossipRoundState {
 
                 Ok(out)
             }
-            stage => Err(K2Error::other(format!(
+            stage => Err(K2GossipError::peer_behavior(format!(
                 "Unexpected round state for accept: Accepted != {:?}",
                 stage
             ))),

--- a/crates/gossip/src/respond/disc_sectors_diff.rs
+++ b/crates/gossip/src/respond/disc_sectors_diff.rs
@@ -11,13 +11,14 @@ use kitsune2_api::{AgentId, K2Error, K2Result, Url};
 use kitsune2_dht::DhtSnapshot;
 use kitsune2_dht::DhtSnapshotNextAction;
 use tokio::sync::OwnedMutexGuard;
+use crate::error::K2GossipResult;
 
 impl K2Gossip {
     pub(super) async fn respond_to_disc_sectors_diff(
         &self,
         from_peer: Url,
         disc_sectors_diff: K2GossipDiscSectorsDiffMessage,
-    ) -> K2Result<Option<GossipMessage>> {
+    ) -> K2GossipResult<Option<GossipMessage>> {
         let (mut state, accepted) = self
             .check_disc_sectors_diff_state(
                 from_peer.clone(),

--- a/crates/gossip/src/respond/hashes.rs
+++ b/crates/gossip/src/respond/hashes.rs
@@ -1,8 +1,8 @@
+use crate::error::{K2GossipError, K2GossipResult};
 use crate::gossip::K2Gossip;
 use crate::protocol::{GossipMessage, K2GossipHashesMessage};
 use kitsune2_api::decode_ids;
-use kitsune2_api::{K2Error, Url};
-use crate::error::K2GossipResult;
+use kitsune2_api::Url;
 
 impl K2Gossip {
     pub(super) async fn respond_to_hashes(
@@ -71,7 +71,9 @@ impl K2Gossip {
         };
 
         if !handled_as_initiator && !handled_as_acceptor {
-            return Err(K2Error::other("Unsolicited Hashes message").into());
+            return Err(K2GossipError::peer_behavior(
+                "Unsolicited Hashes message",
+            ));
         }
 
         Ok(None)

--- a/crates/gossip/src/respond/hashes.rs
+++ b/crates/gossip/src/respond/hashes.rs
@@ -1,14 +1,15 @@
 use crate::gossip::K2Gossip;
 use crate::protocol::{GossipMessage, K2GossipHashesMessage};
 use kitsune2_api::decode_ids;
-use kitsune2_api::{K2Error, K2Result, Url};
+use kitsune2_api::{K2Error, Url};
+use crate::error::K2GossipResult;
 
 impl K2Gossip {
     pub(super) async fn respond_to_hashes(
         &self,
         from_peer: Url,
         hashes: K2GossipHashesMessage,
-    ) -> K2Result<Option<GossipMessage>> {
+    ) -> K2GossipResult<Option<GossipMessage>> {
         // This could be received from either the initiator or the acceptor.
         // So we have to check in both places!
 
@@ -70,7 +71,7 @@ impl K2Gossip {
         };
 
         if !handled_as_initiator && !handled_as_acceptor {
-            return Err(K2Error::other("Unsolicited Hashes message"));
+            return Err(K2Error::other("Unsolicited Hashes message").into());
         }
 
         Ok(None)

--- a/crates/gossip/src/respond/initiate.rs
+++ b/crates/gossip/src/respond/initiate.rs
@@ -1,3 +1,4 @@
+use crate::error::{K2GossipError, K2GossipResult};
 use crate::gossip::K2Gossip;
 use crate::protocol::k2_gossip_accept_message::SnapshotMinimalMessage;
 use crate::protocol::{
@@ -6,7 +7,6 @@ use crate::protocol::{
 };
 use kitsune2_api::{K2Error, Timestamp, Url};
 use kitsune2_dht::ArcSet;
-use crate::error::{K2GossipError, K2GossipResult};
 
 impl K2Gossip {
     pub(super) async fn respond_to_initiate(
@@ -39,7 +39,9 @@ impl K2Gossip {
         let other_arc_set = match &initiate.arc_set {
             Some(message) => ArcSet::decode(&message.value)?,
             None => {
-                return Err(K2Error::other("no arc set in initiate message").into());
+                return Err(
+                    K2Error::other("no arc set in initiate message").into()
+                );
             }
         };
 
@@ -119,7 +121,10 @@ impl K2Gossip {
         })))
     }
 
-    async fn check_peer_initiate_rate(&self, from_peer: Url) -> K2GossipResult<()> {
+    async fn check_peer_initiate_rate(
+        &self,
+        from_peer: Url,
+    ) -> K2GossipResult<()> {
         if let Some(timestamp) = self
             .peer_meta_store
             .last_gossip_timestamp(from_peer.clone())

--- a/crates/gossip/src/respond/no_diff.rs
+++ b/crates/gossip/src/respond/no_diff.rs
@@ -5,13 +5,14 @@ use crate::protocol::{
 };
 use crate::state::{GossipRoundState, RoundStage, RoundStageAccepted};
 use kitsune2_api::{AgentId, K2Error, K2Result, Url};
+use crate::error::K2GossipResult;
 
 impl K2Gossip {
     pub(super) async fn respond_to_no_diff(
         &self,
         from_peer: Url,
         no_diff: K2GossipNoDiffMessage,
-    ) -> K2Result<Option<GossipMessage>> {
+    ) -> K2GossipResult<Option<GossipMessage>> {
         self.check_no_diff_state_and_remove(from_peer.clone(), &no_diff)
             .await?;
 

--- a/crates/gossip/src/respond/ring_sector_details_diff.rs
+++ b/crates/gossip/src/respond/ring_sector_details_diff.rs
@@ -12,13 +12,14 @@ use kitsune2_api::{AgentId, K2Error, K2Result, Url};
 use kitsune2_dht::DhtSnapshot;
 use kitsune2_dht::DhtSnapshotNextAction;
 use tokio::sync::OwnedMutexGuard;
+use crate::error::K2GossipResult;
 
 impl K2Gossip {
     pub(super) async fn respond_to_ring_sector_details_diff(
         &self,
         from_peer: Url,
         ring_sector_details_diff: K2GossipRingSectorDetailsDiffMessage,
-    ) -> K2Result<Option<GossipMessage>> {
+    ) -> K2GossipResult<Option<GossipMessage>> {
         let (mut state, accepted) = self
             .check_ring_sector_details_diff_state(
                 from_peer.clone(),

--- a/crates/gossip/src/respond/ring_sector_details_diff.rs
+++ b/crates/gossip/src/respond/ring_sector_details_diff.rs
@@ -1,18 +1,18 @@
+use crate::error::{K2GossipError, K2GossipResult};
 use crate::gossip::K2Gossip;
 use crate::protocol::{
     encode_agent_infos, encode_op_ids, GossipMessage, K2GossipAgentsMessage,
     K2GossipRingSectorDetailsDiffMessage,
-    K2GossipRingSectorDetailsDiffResponseMessage,
+    K2GossipRingSectorDetailsDiffResponseMessage, K2GossipTerminateMessage,
 };
 use crate::state::{
     GossipRoundState, RoundStage, RoundStageAccepted,
     RoundStageRingSectorDetailsDiff,
 };
-use kitsune2_api::{AgentId, K2Error, K2Result, Url};
+use kitsune2_api::{AgentId, Url};
 use kitsune2_dht::DhtSnapshot;
 use kitsune2_dht::DhtSnapshotNextAction;
 use tokio::sync::OwnedMutexGuard;
-use crate::error::K2GossipResult;
 
 impl K2Gossip {
     pub(super) async fn respond_to_ring_sector_details_diff(
@@ -80,7 +80,13 @@ impl K2Gossip {
                         provided_agents: encode_agent_infos(send_agents)?,
                     })))
                 } else {
-                    Ok(None)
+                    Ok(Some(GossipMessage::Terminate(
+                        K2GossipTerminateMessage {
+                            session_id: ring_sector_details_diff.session_id,
+                            reason: "Nothing to compare and no agents"
+                                .to_string(),
+                        },
+                    )))
                 }
             }
             DhtSnapshotNextAction::NewSnapshotAndHashList(snapshot, op_ids) => {
@@ -99,8 +105,16 @@ impl K2Gossip {
                     },
                 )))
             }
-            _ => {
-                unreachable!("unexpected next action")
+            a => {
+                tracing::error!("Unexpected next action: {:?}", a);
+
+                // Remove round state
+                self.accepted_round_states.write().await.remove(&from_peer);
+
+                Ok(Some(GossipMessage::Terminate(K2GossipTerminateMessage {
+                    session_id: ring_sector_details_diff.session_id,
+                    reason: "Unexpected next action".to_string(),
+                })))
             }
         }
     }
@@ -109,7 +123,8 @@ impl K2Gossip {
         &self,
         from_peer: Url,
         ring_sector_details_diff: &K2GossipRingSectorDetailsDiffMessage,
-    ) -> K2Result<(OwnedMutexGuard<GossipRoundState>, RoundStageAccepted)> {
+    ) -> K2GossipResult<(OwnedMutexGuard<GossipRoundState>, RoundStageAccepted)>
+    {
         match self.accepted_round_states.read().await.get(&from_peer) {
             Some(state) => {
                 let state = state.clone().lock_owned().await;
@@ -122,7 +137,7 @@ impl K2Gossip {
 
                 Ok((state, out))
             }
-            None => Err(K2Error::other(format!(
+            None => Err(K2GossipError::peer_behavior(format!(
                 "Unsolicited RingSectorDetailsDiff message from peer: {:?}",
                 from_peer
             ))),
@@ -135,23 +150,23 @@ impl GossipRoundState {
         &self,
         from_peer: Url,
         ring_sector_details_diff: &K2GossipRingSectorDetailsDiffMessage,
-    ) -> K2Result<&RoundStageAccepted> {
+    ) -> K2GossipResult<&RoundStageAccepted> {
         if self.session_with_peer != from_peer {
-            return Err(K2Error::other(format!(
+            return Err(K2GossipError::peer_behavior(format!(
                 "RingSectorDetailsDiff message from wrong peer: {} != {}",
                 self.session_with_peer, from_peer
             )));
         }
 
         if self.session_id != ring_sector_details_diff.session_id {
-            return Err(K2Error::other(format!(
+            return Err(K2GossipError::peer_behavior(format!(
                 "Session id mismatch: {:?} != {:?}",
                 self.session_id, ring_sector_details_diff.session_id
             )));
         }
 
         let Some(snapshot) = &ring_sector_details_diff.snapshot else {
-            return Err(K2Error::other(
+            return Err(K2GossipError::peer_behavior(
                 "Received RingSectorDetailsDiff message without snapshot",
             ));
         };
@@ -160,7 +175,7 @@ impl GossipRoundState {
             RoundStage::Accepted(stage @ RoundStageAccepted { our_agents, common_arc_set, .. }) => {
                 let Some(accept_response) = &ring_sector_details_diff.accept_response
                 else {
-                    return Err(K2Error::other(
+                    return Err(K2GossipError::peer_behavior(
                         "Received RingSectorDetailsDiff message without accept response",
                     ));
                 };
@@ -170,14 +185,14 @@ impl GossipRoundState {
                     .iter()
                     .any(|a| !our_agents.contains(&AgentId::from(a.clone())))
                 {
-                    return Err(K2Error::other(
+                    return Err(K2GossipError::peer_behavior(
                         "RingSectorDetailsDiff message contains agents that we didn't declare",
                     ));
                 }
 
                 for sector in snapshot.ring_sector_hashes.iter().flat_map(|sh| sh.sector_indices.iter()) {
                     if !common_arc_set.includes_sector_index(*sector) {
-                        return Err(K2Error::other(
+                        return Err(K2GossipError::peer_behavior(
                             "RingSectorDetailsDiff message contains sector that isn't in the common arc set",
                         ));
                     }
@@ -186,7 +201,7 @@ impl GossipRoundState {
                 Ok(stage)
             }
             stage => {
-                Err(K2Error::other(format!(
+                Err(K2GossipError::peer_behavior(format!(
                     "Unexpected round state for ring sector details diff: Accepted != {:?}",
                     stage
                 )))

--- a/crates/gossip/src/respond/ring_sector_details_diff_response.rs
+++ b/crates/gossip/src/respond/ring_sector_details_diff_response.rs
@@ -1,17 +1,17 @@
+use crate::error::{K2GossipError, K2GossipResult};
 use crate::gossip::K2Gossip;
 use crate::protocol::{
     encode_op_ids, GossipMessage, K2GossipHashesMessage,
-    K2GossipRingSectorDetailsDiffResponseMessage,
+    K2GossipRingSectorDetailsDiffResponseMessage, K2GossipTerminateMessage,
 };
 use crate::state::{
     GossipRoundState, RoundStage, RoundStageRingSectorDetailsDiff,
 };
 use kitsune2_api::decode_ids;
-use kitsune2_api::{K2Error, K2Result, Url};
+use kitsune2_api::{K2Error, Url};
 use kitsune2_dht::DhtSnapshot;
 use kitsune2_dht::DhtSnapshotNextAction;
 use tokio::sync::MutexGuard;
-use crate::error::K2GossipResult;
 
 impl K2Gossip {
     pub(super) async fn respond_to_ring_sector_details_diff_response(
@@ -69,7 +69,10 @@ impl K2Gossip {
                 // Terminating the session, so remove the state.
                 state.take();
 
-                Ok(None)
+                Ok(Some(GossipMessage::Terminate(K2GossipTerminateMessage {
+                    session_id: response.session_id,
+                    reason: "Nothing to compare".to_string(),
+                })))
             }
             DhtSnapshotNextAction::HashList(op_ids) => {
                 // This is the final message we're going to send, remove state
@@ -80,8 +83,16 @@ impl K2Gossip {
                     missing_ids: encode_op_ids(op_ids),
                 })))
             }
-            _ => {
-                unreachable!("unexpected next action")
+            a => {
+                tracing::error!("Unexpected next action: {:?}", a);
+
+                // Remove the round state.
+                state.take();
+
+                Ok(Some(GossipMessage::Terminate(K2GossipTerminateMessage {
+                    session_id: response.session_id,
+                    reason: "Unexpected next action".to_string(),
+                })))
             }
         }
     }
@@ -90,7 +101,7 @@ impl K2Gossip {
         &'a self,
         from_peer: Url,
         ring_sector_details_diff_response: &K2GossipRingSectorDetailsDiffResponseMessage,
-    ) -> K2Result<(
+    ) -> K2GossipResult<(
         MutexGuard<'a, Option<GossipRoundState>>,
         RoundStageRingSectorDetailsDiff,
     )> {
@@ -103,7 +114,7 @@ impl K2Gossip {
                 )?
                 .clone(),
             None => {
-                return Err(K2Error::other(
+                return Err(K2GossipError::peer_behavior(
                     "Unsolicited RingSectorDetailsDiffResponse message",
                 ));
             }
@@ -118,23 +129,23 @@ impl GossipRoundState {
         &self,
         from_peer: Url,
         ring_sector_details_diff_response: &K2GossipRingSectorDetailsDiffResponseMessage,
-    ) -> K2Result<&RoundStageRingSectorDetailsDiff> {
+    ) -> K2GossipResult<&RoundStageRingSectorDetailsDiff> {
         if self.session_with_peer != from_peer {
             return Err(K2Error::other(format!(
                 "RingSectorDetailsDiffResponse message from wrong peer: {} != {}",
                 self.session_with_peer, from_peer
-            )));
+            )).into());
         }
 
         if self.session_id != ring_sector_details_diff_response.session_id {
-            return Err(K2Error::other(format!(
+            return Err(K2GossipError::peer_behavior(format!(
                 "Session id mismatch: {:?} != {:?}",
                 self.session_id, ring_sector_details_diff_response.session_id
             )));
         }
 
         let Some(snapshot) = &ring_sector_details_diff_response.snapshot else {
-            return Err(K2Error::other(
+            return Err(K2GossipError::peer_behavior(
                 "Received RingSectorDetailsDiffResponse message without snapshot",
             ));
         };
@@ -143,7 +154,7 @@ impl GossipRoundState {
             RoundStage::RingSectorDetailsDiff(state @ RoundStageRingSectorDetailsDiff { common_arc_set, .. }) => {
                 for sector in snapshot.ring_sector_hashes.iter().flat_map(|sh| sh.sector_indices.iter()) {
                     if !common_arc_set.includes_sector_index(*sector) {
-                        return Err(K2Error::other(
+                        return Err(K2GossipError::peer_behavior(
                             "RingSectorDetailsDiffResponse message contains sector that isn't in the common arc set",
                         ));
                     }
@@ -152,7 +163,7 @@ impl GossipRoundState {
                 Ok(state)
             }
             stage => {
-                Err(K2Error::other(format!(
+                Err(K2GossipError::peer_behavior(format!(
                     "Unexpected round state for ring sector details diff response: RingSectorDetailsDiff != {:?}",
                     stage
                 )))

--- a/crates/gossip/src/respond/ring_sector_details_diff_response.rs
+++ b/crates/gossip/src/respond/ring_sector_details_diff_response.rs
@@ -11,13 +11,14 @@ use kitsune2_api::{K2Error, K2Result, Url};
 use kitsune2_dht::DhtSnapshot;
 use kitsune2_dht::DhtSnapshotNextAction;
 use tokio::sync::MutexGuard;
+use crate::error::K2GossipResult;
 
 impl K2Gossip {
     pub(super) async fn respond_to_ring_sector_details_diff_response(
         &self,
         from_peer: Url,
         response: K2GossipRingSectorDetailsDiffResponseMessage,
-    ) -> K2Result<Option<GossipMessage>> {
+    ) -> K2GossipResult<Option<GossipMessage>> {
         let (mut state, ring_sector_details) = self
             .check_ring_sector_details_diff_response_state(
                 from_peer.clone(),

--- a/crates/gossip/src/respond/terminate.rs
+++ b/crates/gossip/src/respond/terminate.rs
@@ -1,0 +1,67 @@
+use crate::error::{K2GossipError, K2GossipResult};
+use crate::gossip::K2Gossip;
+use crate::protocol::{GossipMessage, K2GossipTerminateMessage};
+use kitsune2_api::Url;
+
+impl K2Gossip {
+    pub(super) async fn respond_to_terminate(
+        &self,
+        from_peer: Url,
+        terminate: K2GossipTerminateMessage,
+    ) -> K2GossipResult<Option<GossipMessage>> {
+        tracing::info!("Peer {from_peer} is attempting to terminate gossip session with reason: {}", terminate.reason);
+
+        let terminated_initiated_session = {
+            let mut initiate_lock = self.initiated_round_state.lock().await;
+            if let Some(state) = initiate_lock.as_ref() {
+                if state.session_with_peer == from_peer {
+                    if state.session_id == terminate.session_id {
+                        initiate_lock.take();
+                    } else {
+                        initiate_lock.take();
+                        return Err(K2GossipError::peer_behavior(format!(
+                            "Unsolicited terminate message from: {from_peer}"
+                        )));
+                    }
+                }
+
+                true
+            } else {
+                false
+            }
+        };
+
+        let terminated_accepted_session = if !terminated_initiated_session {
+            let read_guard = self.accepted_round_states.write().await;
+            let accepted = read_guard.get(&from_peer);
+
+            if let Some(state) = accepted.as_ref() {
+                let lock = state.lock().await;
+
+                self.accepted_round_states.write().await.remove(&from_peer);
+                if lock.session_id != terminate.session_id {
+                    return Err(K2GossipError::peer_behavior(format!(
+                        "Unsolicited terminate message from: {from_peer}"
+                    )));
+                }
+
+                true
+            } else {
+                false
+            }
+        } else {
+            false
+        };
+
+        if terminated_initiated_session || terminated_accepted_session {
+            self.peer_meta_store.incr_peer_terminated(from_peer).await?;
+        } else {
+            return Err(K2GossipError::peer_behavior(format!(
+                "Unsolicited termination message from: {from_peer}"
+            )));
+        }
+
+        // If there was no error then always respond with no message, the other side terminated
+        Ok(None)
+    }
+}


### PR DESCRIPTION
- Adds a new error type so that we can tell the difference between errors that happened locally (can't access our op store or clock is set wrong etc) and errors that were caused by the peer not following the protocol.
- Terminates gossip rounds that cannot proceed for errors that might be recoverable. For example, running into a logic error with a disc diff should not prevent recent ops and agents from syncing, so we don't need to error and close the connection. Similarly if we found a disc diff but the diff is resolved by the time we do the disc details diff, we don't need to error and close the connection. In these cases, we terminate to be nice to the other side and not force them to time out.
- Based on the improved error handling, adds several new peer meta values

Contributes to #42