### PR TITLE
chore: Downgrade to Rust edition 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ homepage = "https://github.com/holochain/kitsune2"
 keywords = ["holochain", "kitsune", "p2p", "dht", "networking"]
 categories = ["network-programming"]
 license = "Apache-2.0"
-edition = "2024"
+edition = "2021"
 
 [profile.release]
 panic = "abort"

--- a/crates/api/src/fetch.rs
+++ b/crates/api/src/fetch.rs
@@ -2,8 +2,8 @@
 
 use crate::op_store;
 use crate::{
-    BoxFut, DynOpStore, K2Result, OpId, SpaceId, Url, builder, config,
-    transport::DynTransport,
+    builder, config, transport::DynTransport, BoxFut, DynOpStore, K2Result,
+    OpId, SpaceId, Url,
 };
 use bytes::{Bytes, BytesMut};
 use prost::Message;
@@ -14,7 +14,7 @@ pub(crate) mod proto {
 }
 
 pub use proto::{
-    FetchRequest, FetchResponse, K2FetchMessage, k2_fetch_message::*,
+    k2_fetch_message::*, FetchRequest, FetchResponse, K2FetchMessage,
 };
 
 impl From<Vec<OpId>> for FetchRequest {

--- a/crates/api/src/gossip.rs
+++ b/crates/api/src/gossip.rs
@@ -4,8 +4,8 @@ use crate::fetch::DynFetch;
 use crate::peer_store::DynPeerStore;
 use crate::transport::DynTransport;
 use crate::{
-    BoxFut, DynLocalAgentStore, DynOpStore, DynPeerMetaStore, K2Result,
-    SpaceId, StoredOp, builder, config,
+    builder, config, BoxFut, DynLocalAgentStore, DynOpStore, DynPeerMetaStore,
+    K2Result, SpaceId, StoredOp,
 };
 use std::sync::Arc;
 
@@ -16,7 +16,7 @@ pub trait Gossip: 'static + Send + Sync + std::fmt::Debug {
     /// This is not expected to be called directly. It is intended to be used by the
     /// space that owns this gossip module. See [crate::space::Space::inform_ops_stored].
     fn inform_ops_stored(&self, ops: Vec<StoredOp>)
-    -> BoxFut<'_, K2Result<()>>;
+        -> BoxFut<'_, K2Result<()>>;
 }
 
 /// Trait-object [Gossip].

--- a/crates/api/src/id.rs
+++ b/crates/api/src/id.rs
@@ -134,13 +134,13 @@ imp_from!(bytes::Bytes, AgentId, i => i.0 .0);
 
 impl std::fmt::Display for AgentId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        display(&self.0.0, f, &AGENT_DISP)
+        display(&self.0 .0, f, &AGENT_DISP)
     }
 }
 
 impl std::fmt::Debug for AgentId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        display(&self.0.0, f, &AGENT_DISP)
+        display(&self.0 .0, f, &AGENT_DISP)
     }
 }
 
@@ -178,13 +178,13 @@ imp_from!(bytes::Bytes, SpaceId, i => i.0 .0);
 
 impl std::fmt::Display for SpaceId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        display(&self.0.0, f, &SPACE_DISP)
+        display(&self.0 .0, f, &SPACE_DISP)
     }
 }
 
 impl std::fmt::Debug for SpaceId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        display(&self.0.0, f, &SPACE_DISP)
+        display(&self.0 .0, f, &SPACE_DISP)
     }
 }
 
@@ -222,13 +222,13 @@ imp_from!(bytes::Bytes, OpId, i => i.0 .0);
 
 impl std::fmt::Display for OpId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        display(&self.0.0, f, &OP_DISP)
+        display(&self.0 .0, f, &OP_DISP)
     }
 }
 
 impl std::fmt::Debug for OpId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        display(&self.0.0, f, &OP_DISP)
+        display(&self.0 .0, f, &OP_DISP)
     }
 }
 
@@ -337,7 +337,7 @@ mod test {
                 .unwrap();
             assert_eq!(e, &r);
             let r: AgentId = serde_json::from_str(e).unwrap();
-            assert_eq!(d, &r.0.0);
+            assert_eq!(d, &r.0 .0);
         }
     }
 }

--- a/crates/api/src/local_agent_store.rs
+++ b/crates/api/src/local_agent_store.rs
@@ -1,5 +1,5 @@
 use crate::agent::DynLocalAgent;
-use crate::{BoxFut, K2Result, builder, config, id};
+use crate::{builder, config, id, BoxFut, K2Result};
 use std::sync::Arc;
 
 /// A store for local agents.

--- a/crates/api/src/op_store.rs
+++ b/crates/api/src/op_store.rs
@@ -1,7 +1,7 @@
 //! Kitsune2 op store types.
 
 use crate::{
-    BoxFut, DhtArc, K2Result, OpId, SpaceId, Timestamp, builder, config,
+    builder, config, BoxFut, DhtArc, K2Result, OpId, SpaceId, Timestamp,
 };
 use bytes::Bytes;
 use futures::future::BoxFuture;

--- a/crates/api/src/peer_meta_store.rs
+++ b/crates/api/src/peer_meta_store.rs
@@ -1,4 +1,4 @@
-use crate::{BoxFut, K2Result, Timestamp, Url, builder, config};
+use crate::{builder, config, BoxFut, K2Result, Timestamp, Url};
 use futures::future::BoxFuture;
 use std::sync::Arc;
 

--- a/crates/api/src/peer_store.rs
+++ b/crates/api/src/peer_store.rs
@@ -19,7 +19,7 @@ pub trait PeerStore: 'static + Send + Sync + std::fmt::Debug {
 
     /// Get all agents from the store.
     fn get_all(&self)
-    -> BoxFut<'_, K2Result<Vec<Arc<agent::AgentInfoSigned>>>>;
+        -> BoxFut<'_, K2Result<Vec<Arc<agent::AgentInfoSigned>>>>;
 
     /// Get the complete list of agents we know about that
     /// claim storage_arcs that overlap the provided storage arc.

--- a/crates/api/src/protocol.rs
+++ b/crates/api/src/protocol.rs
@@ -6,7 +6,7 @@ pub(crate) mod proto {
     include!("../proto/gen/kitsune2.wire.rs");
 }
 
-pub use proto::{K2Proto, k2_proto::K2WireType};
+pub use proto::{k2_proto::K2WireType, K2Proto};
 
 impl K2Proto {
     /// Decode this message from a byte array.

--- a/crates/api/src/publish.rs
+++ b/crates/api/src/publish.rs
@@ -1,8 +1,8 @@
 //! Kitsune2 publish types.
 
-use crate::{AgentInfoSigned, DynPeerStore, K2Error, builder, config};
+use crate::{builder, config, AgentInfoSigned, DynPeerStore, K2Error};
 use crate::{
-    BoxFut, DynFetch, K2Result, OpId, SpaceId, Url, transport::DynTransport,
+    transport::DynTransport, BoxFut, DynFetch, K2Result, OpId, SpaceId, Url,
 };
 use bytes::{Bytes, BytesMut};
 use prost::Message;
@@ -13,7 +13,7 @@ pub(crate) mod proto {
 }
 
 pub use proto::{
-    K2PublishMessage, PublishAgent, PublishOps, k2_publish_message::*,
+    k2_publish_message::*, K2PublishMessage, PublishAgent, PublishOps,
 };
 
 impl From<Vec<OpId>> for PublishOps {

--- a/crates/api/src/space.rs
+++ b/crates/api/src/space.rs
@@ -94,7 +94,7 @@ pub trait Space: 'static + Send + Sync + std::fmt::Debug {
     /// "new ops" mechanism, depending on the op store implementation, but that only makes them
     /// available briefly.
     fn inform_ops_stored(&self, ops: Vec<StoredOp>)
-    -> BoxFut<'_, K2Result<()>>;
+        -> BoxFut<'_, K2Result<()>>;
 }
 
 /// Trait-object [Space].

--- a/crates/bootstrap_srv/src/config.rs
+++ b/crates/bootstrap_srv/src/config.rs
@@ -82,9 +82,7 @@ impl Config {
             worker_thread_count: 2,
             max_entries_per_space: 32,
             request_listen_duration: std::time::Duration::from_millis(10),
-            listen_address_list: vec![
-                (std::net::Ipv4Addr::LOCALHOST, 0).into(),
-            ],
+            listen_address_list: vec![(std::net::Ipv4Addr::LOCALHOST, 0).into()],
             prune_interval: std::time::Duration::from_secs(10),
             tls_cert: None,
             tls_key: None,

--- a/crates/core/src/factories/core_fetch.rs
+++ b/crates/core/src/factories/core_fetch.rs
@@ -7,7 +7,7 @@ use std::{
     time::Duration,
 };
 use tokio::{
-    sync::mpsc::{Receiver, Sender, channel},
+    sync::mpsc::{channel, Receiver, Sender},
     task::JoinHandle,
 };
 

--- a/crates/core/src/factories/core_fetch/back_off.rs
+++ b/crates/core/src/factories/core_fetch/back_off.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{HashMap, hash_map::Entry},
+    collections::{hash_map::Entry, HashMap},
     time::{Duration, Instant},
 };
 

--- a/crates/core/src/factories/core_fetch/test/incoming_request_queue.rs
+++ b/crates/core/src/factories/core_fetch/test/incoming_request_queue.rs
@@ -1,8 +1,8 @@
 use crate::{
     default_test_builder,
     factories::{
+        core_fetch::{test::test_utils::make_op, CoreFetch, CoreFetchConfig},
         MemOpStoreFactory, MemoryOp,
-        core_fetch::{CoreFetch, CoreFetchConfig, test::test_utils::make_op},
     },
 };
 use bytes::Bytes;
@@ -134,19 +134,15 @@ async fn respond_to_multiple_requests() {
         }
     });
 
-    assert!(
-        responses_sent
-            .lock()
-            .unwrap()
-            .contains(&(vec![op_1.into(), op_2.into()], peer_url_1))
-    );
+    assert!(responses_sent
+        .lock()
+        .unwrap()
+        .contains(&(vec![op_1.into(), op_2.into()], peer_url_1)));
     // Only op 3 is in op store.
-    assert!(
-        responses_sent
-            .lock()
-            .unwrap()
-            .contains(&(vec![op_3.into()], peer_url_2))
-    );
+    assert!(responses_sent
+        .lock()
+        .unwrap()
+        .contains(&(vec![op_3.into()], peer_url_2)));
 }
 
 #[tokio::test(flavor = "multi_thread")]

--- a/crates/core/src/factories/core_fetch/test/incoming_response_queue.rs
+++ b/crates/core/src/factories/core_fetch/test/incoming_response_queue.rs
@@ -2,8 +2,8 @@ use super::test_utils::random_peer_url;
 use crate::{
     default_test_builder,
     factories::{
-        MemOpStoreFactory, MemoryOp,
         core_fetch::{CoreFetch, CoreFetchConfig},
+        MemOpStoreFactory, MemoryOp,
     },
 };
 use kitsune2_api::*;

--- a/crates/core/src/factories/core_fetch/test/outgoing_request_queue.rs
+++ b/crates/core/src/factories/core_fetch/test/outgoing_request_queue.rs
@@ -2,8 +2,8 @@ use super::test_utils::random_peer_url;
 use crate::{
     default_test_builder,
     factories::{
-        MemOpStoreFactory,
         core_fetch::{CoreFetch, CoreFetchConfig},
+        MemOpStoreFactory,
     },
 };
 use kitsune2_api::*;
@@ -135,13 +135,11 @@ async fn outgoing_request_queue() {
     let num_requests_sent = requests_sent.lock().unwrap().len();
 
     // Check that all requests have been made for the 1 op to the agent.
-    assert!(
-        requests_sent
-            .lock()
-            .unwrap()
-            .iter()
-            .all(|request| request == &(op_id.clone(), peer_url.clone()))
-    );
+    assert!(requests_sent
+        .lock()
+        .unwrap()
+        .iter()
+        .all(|request| request == &(op_id.clone(), peer_url.clone())));
 
     // Give time for more requests to be sent, which shouldn't happen now that the set of
     // ops to fetch is cleared.
@@ -360,14 +358,12 @@ async fn requests_are_dropped_when_max_back_off_expired() {
     tokio::time::sleep(Duration::from_millis(last_back_off_interval as u64))
         .await;
 
-    assert!(
-        fetch
-            .state
-            .lock()
-            .unwrap()
-            .back_off_list
-            .has_last_back_off_expired(&peer_url_1)
-    );
+    assert!(fetch
+        .state
+        .lock()
+        .unwrap()
+        .back_off_list
+        .has_last_back_off_expired(&peer_url_1));
 
     let current_number_of_requests_to_agent_1 = requests_sent
         .lock()
@@ -391,13 +387,11 @@ async fn requests_are_dropped_when_max_back_off_expired() {
         }
     });
 
-    assert!(
-        fetch
-            .state
-            .lock()
-            .unwrap()
-            .requests
-            .iter()
-            .all(|(_, peer_url)| *peer_url != peer_url_1),
-    );
+    assert!(fetch
+        .state
+        .lock()
+        .unwrap()
+        .requests
+        .iter()
+        .all(|(_, peer_url)| *peer_url != peer_url_1),);
 }

--- a/crates/core/src/factories/core_publish.rs
+++ b/crates/core/src/factories/core_publish.rs
@@ -46,7 +46,7 @@ use kitsune2_api::*;
 use message_handler::PublishMessageHandler;
 use std::sync::Arc;
 use tokio::{
-    sync::mpsc::{Receiver, Sender, channel},
+    sync::mpsc::{channel, Receiver, Sender},
     task::AbortHandle,
 };
 

--- a/crates/core/src/factories/core_publish/test.rs
+++ b/crates/core/src/factories/core_publish/test.rs
@@ -11,7 +11,7 @@ use kitsune2_test_utils::{
     space::TEST_SPACE_ID,
 };
 
-use crate::factories::{MemoryOp, core_publish::CorePublish};
+use crate::factories::{core_publish::CorePublish, MemoryOp};
 
 use super::CorePublishConfig;
 
@@ -238,8 +238,8 @@ async fn published_agent_can_be_retrieved() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn invalid_agent_is_not_inserted_into_peer_store_and_subsequent_publishes_succeed()
- {
+async fn invalid_agent_is_not_inserted_into_peer_store_and_subsequent_publishes_succeed(
+) {
     enable_tracing();
 
     let (core_publish_1, _, _, _, _) =

--- a/crates/core/src/factories/core_space.rs
+++ b/crates/core/src/factories/core_space.rs
@@ -456,20 +456,18 @@ async fn check_agent_infos(
 
         for agent in agents {
             // is this agent going to expire?
-            let should_re_sign = match peer_store
-                .get(agent.agent().clone())
-                .await
-            {
-                Ok(Some(info)) => info.expires_at <= cutoff,
-                Ok(None) => true,
-                Err(err) => {
-                    tracing::debug!(
+            let should_re_sign =
+                match peer_store.get(agent.agent().clone()).await {
+                    Ok(Some(info)) => info.expires_at <= cutoff,
+                    Ok(None) => true,
+                    Err(err) => {
+                        tracing::debug!(
                         ?err,
                         "error fetching agent in re-signing before expiry logic"
                     );
-                    true
-                }
-            };
+                        true
+                    }
+                };
 
             if should_re_sign {
                 // if so, re-sign it

--- a/crates/core/src/factories/mem_op_store/test.rs
+++ b/crates/core/src/factories/mem_op_store/test.rs
@@ -1,5 +1,5 @@
-use crate::factories::MemoryOp;
 use crate::factories::mem_op_store::Kitsune2MemoryOpStore;
+use crate::factories::MemoryOp;
 use kitsune2_api::{DhtArc, DynOpStore, Timestamp};
 use kitsune2_test_utils::space::TEST_SPACE_ID;
 use std::sync::Arc;

--- a/crates/core/src/factories/mem_peer_store/test.rs
+++ b/crates/core/src/factories/mem_peer_store/test.rs
@@ -65,13 +65,11 @@ fn prune_prunes_only_expired_agents() {
 fn happy_get() {
     let mut s = create();
 
-    s.insert(vec![
-        AgentBuilder {
-            agent: Some(AGENT_1),
-            ..Default::default()
-        }
-        .build(TestLocalAgent::default()),
-    ]);
+    s.insert(vec![AgentBuilder {
+        agent: Some(AGENT_1),
+        ..Default::default()
+    }
+    .build(TestLocalAgent::default())]);
 
     let a = s.get(AGENT_1).unwrap();
     assert_eq!(a.agent, AGENT_1);
@@ -140,14 +138,12 @@ fn fixture_get_by_overlapping_storage_arc() {
         let mut s = create();
 
         for (arc_name, arc) in arc_list.iter() {
-            s.insert(vec![
-                AgentBuilder {
-                    storage_arc: Some(*arc),
-                    url: Some(Some(sneak_url(arc_name))),
-                    ..Default::default()
-                }
-                .build(TestLocalAgent::default()),
-            ]);
+            s.insert(vec![AgentBuilder {
+                storage_arc: Some(*arc),
+                url: Some(Some(sneak_url(arc_name))),
+                ..Default::default()
+            }
+            .build(TestLocalAgent::default())]);
         }
 
         let mut got = s
@@ -168,16 +164,14 @@ fn fixture_get_near_location() {
 
     for idx in 0..8 {
         let loc = (u32::MAX / 8) * idx;
-        s.insert(vec![
-            AgentBuilder {
-                // for simplicity have agents claim arcs of len 1
-                storage_arc: Some(DhtArc::Arc(loc, loc + 1)),
-                // set the url to the idx for matching
-                url: Some(Some(sneak_url(&idx.to_string()))),
-                ..Default::default()
-            }
-            .build(TestLocalAgent::default()),
-        ]);
+        s.insert(vec![AgentBuilder {
+            // for simplicity have agents claim arcs of len 1
+            storage_arc: Some(DhtArc::Arc(loc, loc + 1)),
+            // set the url to the idx for matching
+            url: Some(Some(sneak_url(&idx.to_string()))),
+            ..Default::default()
+        }
+        .build(TestLocalAgent::default())]);
     }
 
     // these should not be returned because they are invalid.

--- a/crates/dht/src/dht.rs
+++ b/crates/dht/src/dht.rs
@@ -18,8 +18,8 @@
 //! to compare discs by exchanging [DhtSnapshot::Minimal], [DhtSnapshot::DiscSectors] and then
 //! [DhtSnapshot::DiscSectorDetails].
 
-use crate::HashPartition;
 use crate::arc_set::ArcSet;
+use crate::HashPartition;
 use kitsune2_api::{
     BoxFut, DynOpStore, K2Error, K2Result, OpId, StoredOp, Timestamp,
 };

--- a/crates/dht/src/dht/tests.rs
+++ b/crates/dht/src/dht/tests.rs
@@ -22,7 +22,7 @@ async fn take_minimal_snapshot() {
     let store = test_store().await;
     store
         .process_incoming_ops(vec![
-            MemoryOp::new(UNIX_TIMESTAMP, vec![7; 32]).into(),
+            MemoryOp::new(UNIX_TIMESTAMP, vec![7; 32]).into()
         ])
         .await
         .unwrap();

--- a/crates/dht/src/hash.rs
+++ b/crates/dht/src/hash.rs
@@ -62,7 +62,7 @@
 
 use crate::arc_set::ArcSet;
 use crate::combine::combine_hashes;
-use crate::{SECTOR_SIZE, TimePartition};
+use crate::{TimePartition, SECTOR_SIZE};
 use kitsune2_api::{
     DhtArc, DynOpStore, K2Error, K2Result, StoredOp, Timestamp,
 };
@@ -451,8 +451,8 @@ impl HashPartition {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::UNIT_TIME;
     use crate::test::test_store;
+    use crate::UNIT_TIME;
     use kitsune2_api::{OpId, UNIX_TIMESTAMP};
     use kitsune2_core::factories::MemoryOp;
     use kitsune2_test_utils::enable_tracing;
@@ -649,14 +649,12 @@ mod tests {
                 _ => panic!("Expected an arc"),
             };
             store
-                .process_incoming_ops(vec![
-                    MemoryOp::new(
-                        now,
-                        // Place the op within the current space partition
-                        (start + 1).to_le_bytes().as_slice().to_vec(),
-                    )
-                    .into(),
-                ])
+                .process_incoming_ops(vec![MemoryOp::new(
+                    now,
+                    // Place the op within the current space partition
+                    (start + 1).to_le_bytes().as_slice().to_vec(),
+                )
+                .into()])
                 .await
                 .unwrap();
         }

--- a/crates/dht/src/time.rs
+++ b/crates/dht/src/time.rs
@@ -266,7 +266,7 @@ impl TimePartition {
                     Some(hash) => {
                         let mut hash = bytes::BytesMut::from(hash);
                         // Combine the stored hash with the new op hash
-                        combine::combine_hashes(&mut hash, op.op_id.0.0);
+                        combine::combine_hashes(&mut hash, op.op_id.0 .0);
 
                         // and store the new value
                         store
@@ -283,7 +283,7 @@ impl TimePartition {
                             .store_slice_hash(
                                 self.sector_constraint,
                                 slice_index as u64,
-                                op.op_id.0.0,
+                                op.op_id.0 .0,
                             )
                             .await?;
                     }
@@ -319,7 +319,7 @@ impl TimePartition {
                     if op.created_at >= partial.start {
                         combine::combine_hashes(
                             &mut partial.hash,
-                            op.op_id.0.0,
+                            op.op_id.0 .0,
                         );
 
                         // Belongs in exactly one partial, stop after finding the right one.
@@ -1138,9 +1138,11 @@ mod tests {
 
         // Store a new op which will currently be outside the last partial slice
         store
-            .process_incoming_ops(vec![
-                MemoryOp::new(current_time, vec![13; 32]).into(),
-            ])
+            .process_incoming_ops(vec![MemoryOp::new(
+                current_time,
+                vec![13; 32],
+            )
+            .into()])
             .await
             .unwrap();
 
@@ -1201,13 +1203,11 @@ mod tests {
 
         // Store a new op, currently in the first partial slice, but will be in the next full slice.
         store
-            .process_incoming_ops(vec![
-                MemoryOp::new(
-                    pt.full_slice_end_timestamp(), // Start of the next full slice
-                    vec![13; 32],
-                )
-                .into(),
-            ])
+            .process_incoming_ops(vec![MemoryOp::new(
+                pt.full_slice_end_timestamp(), // Start of the next full slice
+                vec![13; 32],
+            )
+            .into()])
             .await
             .unwrap();
 
@@ -1352,10 +1352,11 @@ mod tests {
 
         // Now insert an op at the current time
         store
-            .process_incoming_ops(vec![
-                MemoryOp::new(pt.full_slice_end_timestamp(), vec![7; 32])
-                    .into(),
-            ])
+            .process_incoming_ops(vec![MemoryOp::new(
+                pt.full_slice_end_timestamp(),
+                vec![7; 32],
+            )
+            .into()])
             .await
             .unwrap();
         // and compute the new state in the future
@@ -1426,9 +1427,11 @@ mod tests {
         let store = test_store().await;
         // Insert a single op in the first time slice
         store
-            .process_incoming_ops(vec![
-                MemoryOp::new(UNIX_TIMESTAMP, vec![7, 0, 0, 0]).into(),
-            ])
+            .process_incoming_ops(vec![MemoryOp::new(
+                UNIX_TIMESTAMP,
+                vec![7, 0, 0, 0],
+            )
+            .into()])
             .await
             .unwrap();
 

--- a/crates/gossip/src/gossip.rs
+++ b/crates/gossip/src/gossip.rs
@@ -2,8 +2,8 @@ use crate::error::K2GossipError;
 use crate::initiate::spawn_initiate_task;
 use crate::peer_meta_store::K2PeerMetaStore;
 use crate::protocol::{
-    ArcSetMessage, GossipMessage, K2GossipInitiateMessage,
     deserialize_gossip_message, encode_agent_ids, serialize_gossip_message,
+    ArcSetMessage, GossipMessage, K2GossipInitiateMessage,
 };
 use crate::state::GossipRoundState;
 use crate::storage_arc::update_storage_arcs;
@@ -415,7 +415,7 @@ pub(crate) fn send_gossip_message(
 mod test {
     use super::*;
     use kitsune2_core::factories::MemoryOp;
-    use kitsune2_core::{Ed25519LocalAgent, default_test_builder};
+    use kitsune2_core::{default_test_builder, Ed25519LocalAgent};
     use kitsune2_dht::{SECTOR_SIZE, UNIT_TIME};
     use kitsune2_test_utils::enable_tracing;
     use kitsune2_test_utils::noop_bootstrap::NoopBootstrapFactory;
@@ -632,23 +632,19 @@ mod test {
         // Join extra agents for each peer. These will take a few seconds to be
         // found by bootstrap. Try to sync them with gossip.
         let secret_agent_1 = harness_1.join_local_agent(DhtArc::FULL).await;
-        assert!(
-            harness_2
-                .peer_store
-                .get(secret_agent_1.agent.clone())
-                .await
-                .unwrap()
-                .is_none()
-        );
+        assert!(harness_2
+            .peer_store
+            .get(secret_agent_1.agent.clone())
+            .await
+            .unwrap()
+            .is_none());
         let secret_agent_2 = harness_2.join_local_agent(DhtArc::FULL).await;
-        assert!(
-            harness_1
-                .peer_store
-                .get(secret_agent_2.agent.clone())
-                .await
-                .unwrap()
-                .is_none()
-        );
+        assert!(harness_1
+            .peer_store
+            .get(secret_agent_2.agent.clone())
+            .await
+            .unwrap()
+            .is_none());
 
         // Simulate peer discovery so that gossip can sync agents
         harness_2

--- a/crates/gossip/src/initiate.rs
+++ b/crates/gossip/src/initiate.rs
@@ -1,6 +1,6 @@
-use crate::K2GossipConfig;
 use crate::gossip::K2Gossip;
 use crate::peer_meta_store::K2PeerMetaStore;
+use crate::K2GossipConfig;
 use kitsune2_api::*;
 use kitsune2_api::{AgentId, DynLocalAgentStore, K2Result, Timestamp, Url};
 use rand::prelude::SliceRandom;

--- a/crates/gossip/src/protocol.rs
+++ b/crates/gossip/src/protocol.rs
@@ -5,7 +5,7 @@ use crate::protocol::k2_gossip_disc_sectors_diff_message::SnapshotDiscSectorsMes
 use bytes::{Bytes, BytesMut};
 use kitsune2_api::*;
 use kitsune2_dht::DhtSnapshot;
-use prost::{Message, bytes};
+use prost::{bytes, Message};
 use std::collections::HashMap;
 use std::sync::Arc;
 

--- a/crates/gossip/src/respond.rs
+++ b/crates/gossip/src/respond.rs
@@ -1,10 +1,10 @@
-use crate::K2GossipConfig;
 use crate::error::K2GossipResult;
-use crate::gossip::{K2Gossip, send_gossip_message};
+use crate::gossip::{send_gossip_message, K2Gossip};
 use crate::protocol::{
     AcceptResponseMessage, GossipMessage, K2GossipInitiateMessage,
 };
 use crate::state::GossipRoundState;
+use crate::K2GossipConfig;
 use bytes::Bytes;
 use kitsune2_api::*;
 use kitsune2_dht::{ArcSet, UNIT_TIME};

--- a/crates/gossip/src/respond/accept.rs
+++ b/crates/gossip/src/respond/accept.rs
@@ -1,10 +1,10 @@
 use crate::error::{K2GossipError, K2GossipResult};
 use crate::gossip::K2Gossip;
 use crate::protocol::{
-    AcceptResponseMessage, GossipMessage, K2GossipAcceptMessage,
-    K2GossipDiscSectorsDiffMessage, K2GossipNoDiffMessage,
-    K2GossipRingSectorDetailsDiffMessage, K2GossipTerminateMessage,
-    encode_agent_infos, encode_op_ids,
+    encode_agent_infos, encode_op_ids, AcceptResponseMessage, GossipMessage,
+    K2GossipAcceptMessage, K2GossipDiscSectorsDiffMessage,
+    K2GossipNoDiffMessage, K2GossipRingSectorDetailsDiffMessage,
+    K2GossipTerminateMessage,
 };
 use crate::state::{
     GossipRoundState, RoundStage, RoundStageDiscSectorsDiff,

--- a/crates/gossip/src/respond/disc_sector_details_diff.rs
+++ b/crates/gossip/src/respond/disc_sector_details_diff.rs
@@ -1,9 +1,8 @@
 use crate::error::{K2GossipError, K2GossipResult};
 use crate::gossip::K2Gossip;
 use crate::protocol::{
-    GossipMessage, K2GossipDiscSectorDetailsDiffMessage,
+    encode_op_ids, GossipMessage, K2GossipDiscSectorDetailsDiffMessage,
     K2GossipDiscSectorDetailsDiffResponseMessage, K2GossipTerminateMessage,
-    encode_op_ids,
 };
 use crate::state::{
     GossipRoundState, RoundStage, RoundStageDiscSectorDetailsDiff,

--- a/crates/gossip/src/respond/disc_sector_details_diff_response.rs
+++ b/crates/gossip/src/respond/disc_sector_details_diff_response.rs
@@ -1,8 +1,8 @@
 use crate::error::{K2GossipError, K2GossipResult};
 use crate::gossip::K2Gossip;
 use crate::protocol::{
-    GossipMessage, K2GossipDiscSectorDetailsDiffResponseMessage,
-    K2GossipHashesMessage, K2GossipTerminateMessage, encode_op_ids,
+    encode_op_ids, GossipMessage, K2GossipDiscSectorDetailsDiffResponseMessage,
+    K2GossipHashesMessage, K2GossipTerminateMessage,
 };
 use crate::state::{
     GossipRoundState, RoundStage, RoundStageDiscSectorDetailsDiff,

--- a/crates/gossip/src/respond/disc_sectors_diff.rs
+++ b/crates/gossip/src/respond/disc_sectors_diff.rs
@@ -1,9 +1,9 @@
 use crate::error::{K2GossipError, K2GossipResult};
 use crate::gossip::K2Gossip;
 use crate::protocol::{
-    GossipMessage, K2GossipAgentsMessage, K2GossipDiscSectorDetailsDiffMessage,
-    K2GossipDiscSectorsDiffMessage, K2GossipTerminateMessage,
-    encode_agent_infos,
+    encode_agent_infos, GossipMessage, K2GossipAgentsMessage,
+    K2GossipDiscSectorDetailsDiffMessage, K2GossipDiscSectorsDiffMessage,
+    K2GossipTerminateMessage,
 };
 use crate::state::{
     GossipRoundState, RoundStage, RoundStageAccepted,

--- a/crates/gossip/src/respond/harness.rs
+++ b/crates/gossip/src/respond/harness.rs
@@ -1,11 +1,11 @@
-use crate::K2GossipConfig;
 use crate::gossip::{DropAbortHandle, GossipResponse, K2Gossip};
 use crate::peer_meta_store::K2PeerMetaStore;
-use crate::protocol::{GossipMessage, deserialize_gossip_message};
+use crate::protocol::{deserialize_gossip_message, GossipMessage};
+use crate::K2GossipConfig;
 use base64::Engine;
 use bytes::Bytes;
 use kitsune2_api::*;
-use kitsune2_core::{Ed25519LocalAgent, default_test_builder};
+use kitsune2_core::{default_test_builder, Ed25519LocalAgent};
 use kitsune2_dht::Dht;
 use kitsune2_test_utils::agent::AgentBuilder;
 use kitsune2_test_utils::space::TEST_SPACE_ID;

--- a/crates/gossip/src/respond/hashes.rs
+++ b/crates/gossip/src/respond/hashes.rs
@@ -1,8 +1,8 @@
 use crate::error::{K2GossipError, K2GossipResult};
 use crate::gossip::K2Gossip;
 use crate::protocol::{GossipMessage, K2GossipHashesMessage};
-use kitsune2_api::Url;
 use kitsune2_api::decode_ids;
+use kitsune2_api::Url;
 
 impl K2Gossip {
     pub(super) async fn respond_to_hashes(

--- a/crates/gossip/src/respond/initiate.rs
+++ b/crates/gossip/src/respond/initiate.rs
@@ -2,8 +2,8 @@ use crate::error::{K2GossipError, K2GossipResult};
 use crate::gossip::K2Gossip;
 use crate::protocol::k2_gossip_accept_message::SnapshotMinimalMessage;
 use crate::protocol::{
-    ArcSetMessage, GossipMessage, K2GossipAcceptMessage, K2GossipBusyMessage,
-    K2GossipInitiateMessage, encode_agent_ids, encode_op_ids,
+    encode_agent_ids, encode_op_ids, ArcSetMessage, GossipMessage,
+    K2GossipAcceptMessage, K2GossipBusyMessage, K2GossipInitiateMessage,
 };
 use kitsune2_api::{K2Error, Timestamp, Url};
 use kitsune2_dht::ArcSet;
@@ -151,12 +151,12 @@ impl K2Gossip {
 
 #[cfg(test)]
 mod tests {
-    use crate::K2GossipConfig;
     use crate::protocol::{
-        ArcSetMessage, GossipMessage, K2GossipInitiateMessage, encode_agent_ids,
+        encode_agent_ids, ArcSetMessage, GossipMessage, K2GossipInitiateMessage,
     };
-    use crate::respond::harness::{RespondTestHarness, test_session_id};
+    use crate::respond::harness::{test_session_id, RespondTestHarness};
     use crate::state::{GossipRoundState, RoundStage};
+    use crate::K2GossipConfig;
     use kitsune2_api::{DhtArc, LocalAgent, Timestamp, Url};
     use kitsune2_core::Ed25519LocalAgent;
     use kitsune2_dht::{ArcSet, SECTOR_SIZE};

--- a/crates/gossip/src/respond/no_diff.rs
+++ b/crates/gossip/src/respond/no_diff.rs
@@ -1,8 +1,8 @@
 use crate::error::{K2GossipError, K2GossipResult};
 use crate::gossip::K2Gossip;
 use crate::protocol::{
-    GossipMessage, K2GossipAgentsMessage, K2GossipNoDiffMessage,
-    K2GossipTerminateMessage, encode_agent_infos,
+    encode_agent_infos, GossipMessage, K2GossipAgentsMessage,
+    K2GossipNoDiffMessage, K2GossipTerminateMessage,
 };
 use crate::state::{GossipRoundState, RoundStage, RoundStageAccepted};
 use kitsune2_api::{AgentId, K2Error, Url};

--- a/crates/gossip/src/respond/ring_sector_details_diff.rs
+++ b/crates/gossip/src/respond/ring_sector_details_diff.rs
@@ -1,9 +1,9 @@
 use crate::error::{K2GossipError, K2GossipResult};
 use crate::gossip::K2Gossip;
 use crate::protocol::{
-    GossipMessage, K2GossipAgentsMessage, K2GossipRingSectorDetailsDiffMessage,
+    encode_agent_infos, encode_op_ids, GossipMessage, K2GossipAgentsMessage,
+    K2GossipRingSectorDetailsDiffMessage,
     K2GossipRingSectorDetailsDiffResponseMessage, K2GossipTerminateMessage,
-    encode_agent_infos, encode_op_ids,
 };
 use crate::state::{
     GossipRoundState, RoundStage, RoundStageAccepted,

--- a/crates/gossip/src/respond/ring_sector_details_diff_response.rs
+++ b/crates/gossip/src/respond/ring_sector_details_diff_response.rs
@@ -1,9 +1,8 @@
 use crate::error::{K2GossipError, K2GossipResult};
 use crate::gossip::K2Gossip;
 use crate::protocol::{
-    GossipMessage, K2GossipHashesMessage,
+    encode_op_ids, GossipMessage, K2GossipHashesMessage,
     K2GossipRingSectorDetailsDiffResponseMessage, K2GossipTerminateMessage,
-    encode_op_ids,
 };
 use crate::state::{
     GossipRoundState, RoundStage, RoundStageRingSectorDetailsDiff,

--- a/crates/gossip/src/timeout.rs
+++ b/crates/gossip/src/timeout.rs
@@ -1,7 +1,7 @@
-use crate::K2GossipConfig;
 use crate::gossip::K2Gossip;
 use crate::peer_meta_store::K2PeerMetaStore;
 use crate::state::GossipRoundState;
+use crate::K2GossipConfig;
 use kitsune2_api::Url;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;

--- a/crates/kitsune2/src/lib.rs
+++ b/crates/kitsune2/src/lib.rs
@@ -14,8 +14,8 @@
 
 use kitsune2_api::*;
 use kitsune2_core::{
-    Ed25519Verifier,
     factories::{self, MemOpStoreFactory},
+    Ed25519Verifier,
 };
 use kitsune2_gossip::K2GossipFactory;
 use kitsune2_transport_tx5::Tx5TransportFactory;
@@ -63,11 +63,11 @@ mod test {
         KitsuneHandler, LocalAgent, OpId, SpaceHandler, SpaceId, Timestamp,
     };
     use kitsune2_core::{
-        Ed25519LocalAgent,
         factories::{
-            MemoryOp,
             config::{CoreBootstrapConfig, CoreBootstrapModConfig},
+            MemoryOp,
         },
+        Ed25519LocalAgent,
     };
     use kitsune2_gossip::{K2GossipConfig, K2GossipModConfig};
     use kitsune2_test_utils::{


### PR DESCRIPTION
I didn't realize that this would force all consumers to use Rust edition 2024. That will force us to upgrade Holochain and force everyone using Holochain to upgrade too. We don't need to be doing that work right now when we're trying to get 0.5 out. Let's plan to do this some other time.

All the code changes that were made to upgrade to 2024 are still valid on 2021 but the formatting is different so I had to `cargo fmt` to undo those changes.