### PR TITLE
Add bootstrap client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1413,6 +1413,7 @@ dependencies = [
  "ed25519-dalek",
  "futures",
  "kitsune2_api",
+ "kitsune2_bootstrap_client",
  "kitsune2_test_utils",
  "prost",
  "rand",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1368,6 +1368,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "kitsune2_bootstrap_client"
+version = "0.0.1-alpha3"
+dependencies = [
+ "kitsune2_api",
+ "kitsune2_bootstrap_srv",
+ "kitsune2_core",
+ "kitsune2_test_utils",
+ "tracing",
+ "ureq",
+]
+
+[[package]]
 name = "kitsune2_bootstrap_srv"
 version = "0.0.1-alpha3"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
   "crates/api",
+  "crates/bootstrap_client",
   "crates/bootstrap_srv",
   "crates/core",
   "crates/dht",
@@ -106,6 +107,7 @@ prost-build = "0.13.3"
 # above this section.
 # --- dev-dependencies ---
 kitsune2_bootstrap_srv = { path = "crates/bootstrap_srv" }
+kitsune2_bootstrap_client = { path = "crates/bootstrap_client" }
 kitsune2_core = { version = "0.0.1-alpha3", path = "crates/core" }
 kitsune2_test_utils = { path = "crates/test_utils" }
 

--- a/crates/bootstrap_client/Cargo.toml
+++ b/crates/bootstrap_client/Cargo.toml
@@ -20,6 +20,3 @@ ureq = { workspace = true, features = ["tls"] }
 kitsune2_core = { workspace = true }
 kitsune2_test_utils = { workspace = true }
 kitsune2_bootstrap_srv = { workspace = true }
-
-[features]
-default = []

--- a/crates/bootstrap_client/Cargo.toml
+++ b/crates/bootstrap_client/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "kitsune2_bootstrap_client"
+version.workspace = true
+description = "p2p / dht communication WAN discovery bootstrapping client"
+license.workspace = true
+homepage.workspace = true
+documentation = "https://docs.rs/kitsune2_bootstrap_client"
+authors.workspace = true
+keywords.workspace = true
+categories.workspace = true
+edition.workspace = true
+
+[dependencies]
+kitsune2_api = { workspace = true }
+
+tracing = { workspace = true }
+ureq = { workspace = true, features = ["tls"] }
+
+[dev-dependencies]
+kitsune2_core = { workspace = true }
+kitsune2_test_utils = { workspace = true }
+kitsune2_bootstrap_srv = { workspace = true }
+
+[features]
+default = []

--- a/crates/bootstrap_client/README.md
+++ b/crates/bootstrap_client/README.md
@@ -1,0 +1,18 @@
+# Kitsune2 Bootstrap Client
+
+[![Project](https://img.shields.io/badge/project-kitsune2-purple.svg?style=flat-square)](https://github.com/holochain/kitsune2)
+[![Crate](https://img.shields.io/crates/v/kitsune2_bootstrap_client.svg)](https://crates.io/crates/kitsune2_bootstrap_client)
+[![API Docs](https://docs.rs/kitsune2_bootstrap_client/badge.svg)](https://docs.rs/kitsune2_bootstrap_client)
+[![Discord](https://img.shields.io/badge/Discord-blue.svg?style=flat-square)](https://discord.gg/k55DS5dmPH)
+
+Bootstrap client to connect to the [kitsune2_bootstrap_srv](https://crates.io/crates/kitsune2_bootstrap_srv).
+
+## License
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
+
+Copyright (C) 2024 - 2025, Holochain Foundation
+
+This program is free software: you can redistribute it and/or modify it under the terms of the license
+provided in the LICENSE file (Apache 2.0).  This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+PURPOSE.

--- a/crates/bootstrap_client/src/lib.rs
+++ b/crates/bootstrap_client/src/lib.rs
@@ -1,0 +1,49 @@
+//! A client for the Kitsune2 bootstrap server.
+
+#![deny(missing_docs)]
+
+use kitsune2_api::{AgentInfoSigned, DynVerifier, K2Error, K2Result, SpaceId};
+use std::sync::Arc;
+
+/// Send the agent info, for the given space, to the bootstrap server.
+pub fn put(
+    server_url: Arc<str>,
+    agent_info: Arc<AgentInfoSigned>,
+) -> K2Result<()> {
+    let url = format!(
+        "{server_url}/bootstrap/{}/{}",
+        &agent_info.space, &agent_info.agent
+    );
+
+    let encoded = agent_info.encode()?;
+    ureq::put(&url)
+        .send_string(&encoded)
+        .map_err(|e| K2Error::other_src("Failed to put agent info", e))?;
+
+    Ok(())
+}
+
+/// Get all agent infos from the bootstrap server for the given space.
+pub fn get(
+    server_url: Arc<str>,
+    space: SpaceId,
+    verifier: DynVerifier,
+) -> K2Result<Vec<Arc<AgentInfoSigned>>> {
+    let url = format!("{server_url}/bootstrap/{}", space);
+
+    let encoded = ureq::get(&url)
+        .call()
+        .map_err(K2Error::other)?
+        .into_string()
+        .map_err(K2Error::other)?;
+
+    Ok(AgentInfoSigned::decode_list(&verifier, encoded.as_bytes())?
+        .into_iter()
+        .filter_map(|l| {
+            l.inspect_err(|err| {
+                tracing::debug!(?err, "failure decoding bootstrap agent info");
+            })
+            .ok()
+        })
+        .collect::<Vec<_>>())
+}

--- a/crates/bootstrap_client/src/lib.rs
+++ b/crates/bootstrap_client/src/lib.rs
@@ -6,9 +6,12 @@ use kitsune2_api::{AgentInfoSigned, DynVerifier, K2Error, K2Result, SpaceId};
 use std::sync::Arc;
 
 /// Send the agent info, for the given space, to the bootstrap server.
-pub fn put(
-    server_url: Arc<str>,
-    agent_info: Arc<AgentInfoSigned>,
+///
+/// Note the `blocking_` prefix. This is a hint to the caller that if the function is used in
+/// an async context, it should be treated as a blocking operation.
+pub fn blocking_put(
+    server_url: &str,
+    agent_info: &AgentInfoSigned,
 ) -> K2Result<()> {
     let url = format!(
         "{server_url}/bootstrap/{}/{}",
@@ -24,8 +27,11 @@ pub fn put(
 }
 
 /// Get all agent infos from the bootstrap server for the given space.
-pub fn get(
-    server_url: Arc<str>,
+///
+/// Note the `blocking_` prefix. This is a hint to the caller that if the function is used in
+/// an async context, it should be treated as a blocking operation.
+pub fn blocking_get(
+    server_url: &str,
     space: SpaceId,
     verifier: DynVerifier,
 ) -> K2Result<Vec<Arc<AgentInfoSigned>>> {

--- a/crates/bootstrap_client/tests/connect.rs
+++ b/crates/bootstrap_client/tests/connect.rs
@@ -1,0 +1,36 @@
+use kitsune2_bootstrap_srv::{BootstrapSrv, Config};
+use kitsune2_core::{Ed25519LocalAgent, Ed25519Verifier};
+use kitsune2_test_utils::enable_tracing;
+use std::sync::Arc;
+
+#[test]
+fn connect_with_client() {
+    enable_tracing();
+
+    let s = BootstrapSrv::new(Config::testing()).unwrap();
+
+    // Create a test agent
+    let local_agent: kitsune2_api::DynLocalAgent =
+        Arc::new(Ed25519LocalAgent::default());
+    let info =
+        kitsune2_test_utils::agent::AgentBuilder::default().build(local_agent);
+
+    // Build the server URL to connect to the test bootstrap server
+    let server_url: Arc<str> = format!("http://{:?}", s.listen_addrs()[0])
+        .into_boxed_str()
+        .into();
+
+    // Put the agent info to the server
+    kitsune2_bootstrap_client::put(server_url.clone(), info.clone()).unwrap();
+
+    // Get all agent infos from the server, should just be ours
+    let infos = kitsune2_bootstrap_client::get(
+        server_url,
+        info.space.clone(),
+        Arc::new(Ed25519Verifier),
+    )
+    .unwrap();
+
+    assert_eq!(1, infos.len());
+    assert_eq!(info, infos[0]);
+}

--- a/crates/bootstrap_client/tests/connect.rs
+++ b/crates/bootstrap_client/tests/connect.rs
@@ -21,11 +21,11 @@ fn connect_with_client() {
         .into();
 
     // Put the agent info to the server
-    kitsune2_bootstrap_client::put(server_url.clone(), info.clone()).unwrap();
+    kitsune2_bootstrap_client::blocking_put(&server_url, &info).unwrap();
 
     // Get all agent infos from the server, should just be ours
-    let infos = kitsune2_bootstrap_client::get(
-        server_url,
+    let infos = kitsune2_bootstrap_client::blocking_get(
+        &server_url,
         info.space.clone(),
         Arc::new(Ed25519Verifier),
     )

--- a/crates/bootstrap_srv/src/server.rs
+++ b/crates/bootstrap_srv/src/server.rs
@@ -288,6 +288,8 @@ impl Handler<'_> {
             return Err(std::io::Error::other("InvalidExpiresAt"));
         }
 
+        tracing::info!("Basic checks passed");
+
         // validate signature (do this at the end because it's more expensive)
         info.agent
             .verify(info.encoded.as_bytes(), &info.signature)

--- a/crates/bootstrap_srv/src/test.rs
+++ b/crates/bootstrap_srv/src/test.rs
@@ -849,9 +849,6 @@ fn expiration_prune() {
     assert_eq!(1, res.len());
 }
 
-/// Certificates created with:
-/// > openssl genrsa 2048 > certs/test_key.pem
-/// > openssl req -x509 -days 1000 -new -key certs/test_key.pem -out certs/test_cert.pem
 #[test]
 fn start_with_tls() {
     let cert =

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -12,6 +12,7 @@ edition.workspace = true
 
 [dependencies]
 kitsune2_api = { workspace = true }
+kitsune2_bootstrap_client = { workspace = true }
 
 backon = { workspace = true }
 bytes = { workspace = true }

--- a/crates/core/src/factories/core_bootstrap.rs
+++ b/crates/core/src/factories/core_bootstrap.rs
@@ -193,7 +193,7 @@ async fn push_task(
         match tokio::task::spawn_blocking({
             let server_url = server_url.clone();
             let info = info.clone();
-            move || kitsune2_bootstrap_client::put(server_url, info)
+            move || kitsune2_bootstrap_client::blocking_put(&server_url, &info)
         })
         .await
         {
@@ -246,8 +246,8 @@ async fn poll_task(
             let space = space.clone();
             let verifier = builder.verifier.clone();
             move || {
-                kitsune2_bootstrap_client::get(
-                    server_url,
+                kitsune2_bootstrap_client::blocking_get(
+                    &server_url,
                     space.clone(),
                     verifier,
                 )

--- a/crates/core/src/factories/core_bootstrap.rs
+++ b/crates/core/src/factories/core_bootstrap.rs
@@ -190,17 +190,10 @@ async fn push_task(
     let mut wait = None;
 
     while let Some(info) = push_recv.recv().await {
-        let url =
-            format!("{server_url}/bootstrap/{}/{}", &info.space, &info.agent);
-        let enc = match info.encode() {
-            Err(err) => {
-                tracing::error!(?err, "Could not encode agent info, dropping");
-                continue;
-            }
-            Ok(enc) => enc,
-        };
-        match tokio::task::spawn_blocking(move || {
-            ureq::put(&url).send_string(&enc)
+        match tokio::task::spawn_blocking({
+            let server_url = server_url.clone();
+            let info = info.clone();
+            move || kitsune2_bootstrap_client::put(server_url, info)
         })
         .await
         {
@@ -248,13 +241,17 @@ async fn poll_task(
     let mut wait = config.backoff_min();
 
     loop {
-        let url = format!("{server_url}/bootstrap/{space}");
-        match tokio::task::spawn_blocking(move || {
-            ureq::get(&url)
-                .call()
-                .map_err(K2Error::other)?
-                .into_string()
-                .map_err(K2Error::other)
+        match tokio::task::spawn_blocking({
+            let server_url = server_url.clone();
+            let space = space.clone();
+            let verifier = builder.verifier.clone();
+            move || {
+                kitsune2_bootstrap_client::get(
+                    server_url,
+                    space.clone(),
+                    verifier,
+                )
+            }
         })
         .await
         .map_err(|_| K2Error::other("task join error"))
@@ -262,36 +259,8 @@ async fn poll_task(
             Err(err) | Ok(Err(err)) => {
                 tracing::debug!(?err, "failure contacting bootstrap server");
             }
-            Ok(Ok(data)) => {
-                match AgentInfoSigned::decode_list(
-                    &builder.verifier,
-                    data.as_bytes(),
-                ) {
-                    Err(err) => tracing::debug!(
-                        ?err,
-                        "failure decoding bootstrap server response"
-                    ),
-                    Ok(list) => {
-                        // count decoding a success, and set the wait to max
-                        wait = config.backoff_max();
-
-                        let list = list
-                            .into_iter()
-                            .filter_map(|l| match l {
-                                Ok(l) => Some(l),
-                                Err(err) => {
-                                    tracing::debug!(
-                                        ?err,
-                                        "failure decoding bootstrap agent info"
-                                    );
-                                    None
-                                }
-                            })
-                            .collect::<Vec<_>>();
-
-                        let _ = peer_store.insert(list).await;
-                    }
-                }
+            Ok(Ok(list)) => {
+                let _ = peer_store.insert(list).await;
             }
         }
 


### PR DESCRIPTION
Adds a new bootstrap client crate. Extracted the bootstrap PUT and GET calls from core and we'll be able to re-use this crate in Holochain where we connect to the bootstrap server for debug purposes.