### PR TITLE
chore: Bump versions to alpha4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1335,7 +1335,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune2"
-version = "0.0.1-alpha3"
+version = "0.0.1-alpha4"
 dependencies = [
  "bytes",
  "futures",
@@ -1350,7 +1350,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_api"
-version = "0.0.1-alpha3"
+version = "0.0.1-alpha4"
 dependencies = [
  "base64",
  "bytes",
@@ -1369,7 +1369,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_bootstrap_client"
-version = "0.0.1-alpha3"
+version = "0.0.1-alpha4"
 dependencies = [
  "kitsune2_api",
  "kitsune2_bootstrap_srv",
@@ -1381,7 +1381,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_bootstrap_srv"
-version = "0.0.1-alpha3"
+version = "0.0.1-alpha4"
 dependencies = [
  "async-channel",
  "axum",
@@ -1406,7 +1406,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_core"
-version = "0.0.1-alpha3"
+version = "0.0.1-alpha4"
 dependencies = [
  "backon",
  "bytes",
@@ -1427,7 +1427,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_dht"
-version = "0.0.1-alpha3"
+version = "0.0.1-alpha4"
 dependencies = [
  "bytes",
  "kitsune2_api",
@@ -1441,7 +1441,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_gossip"
-version = "0.0.1-alpha3"
+version = "0.0.1-alpha4"
 dependencies = [
  "base64",
  "bytes",
@@ -1460,7 +1460,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_showcase"
-version = "0.0.1-alpha3"
+version = "0.0.1-alpha4"
 dependencies = [
  "bytes",
  "clap",
@@ -1488,7 +1488,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_transport_tx5"
-version = "0.0.1-alpha3"
+version = "0.0.1-alpha4"
 dependencies = [
  "bytes",
  "kitsune2_api",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.1-alpha3"
+version = "0.0.1-alpha4"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 homepage = "https://github.com/holochain/kitsune2"
 keywords = ["holochain", "kitsune", "p2p", "dht", "networking"]

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ proto:
 publish-all:
 	cargo publish -p kitsune2_api
 	cargo publish -p kitsune2_bootstrap_srv
+	cargo publish -p kitsune2_bootstrap_client
 	cargo publish -p kitsune2_core
 	cargo publish -p kitsune2_transport_tx5
 	cargo publish -p kitsune2_dht


### PR DESCRIPTION
Includes switching back from edition 2024 to 2021, and the new bootstrap client