### PR TITLE
Avoid computing hashes for empty slices

### DIFF
--- a/crates/api/src/op_store.rs
+++ b/crates/api/src/op_store.rs
@@ -130,6 +130,18 @@ pub trait OpStore: 'static + Send + Sync + std::fmt::Debug {
         limit_bytes: u32,
     ) -> BoxFuture<'_, K2Result<(Vec<OpId>, u32, Timestamp)>>;
 
+    /// Get the earliest op timestamp in the given arc.
+    ///
+    /// If there are no ops in the arc, return None.
+    /// Otherwise, return the earliest `created_at` timestamp of the ops in the arc.
+    ///
+    /// This is used to determine the earliest timestamp that the arc has seen. That is a lower
+    /// bound on the work that needs to be done when building a summary model of the DHT.
+    fn earliest_timestamp_in_arc(
+        &self,
+        arc: DhtArc,
+    ) -> BoxFuture<'_, K2Result<Option<Timestamp>>>;
+
     /// Store the combined hash of a time slice.
     fn store_slice_hash(
         &self,

--- a/crates/core/src/factories/mem_op_store.rs
+++ b/crates/core/src/factories/mem_op_store.rs
@@ -315,7 +315,6 @@ impl OpStore for Kitsune2MemoryOpStore {
         arc: DhtArc,
     ) -> BoxFuture<'_, K2Result<Option<Timestamp>>> {
         Box::pin(async move {
-
             Ok(self
                 .read()
                 .await

--- a/crates/core/src/factories/mem_op_store.rs
+++ b/crates/core/src/factories/mem_op_store.rs
@@ -310,6 +310,32 @@ impl OpStore for Kitsune2MemoryOpStore {
         })
     }
 
+    fn earliest_timestamp_in_arc(
+        &self,
+        arc: DhtArc,
+    ) -> BoxFuture<'_, K2Result<Option<Timestamp>>> {
+        Box::pin(async move {
+            println!(
+                "Getting earliest from: {:?}",
+                self.read().await.op_list.len()
+            );
+
+            Ok(self
+                .read()
+                .await
+                .op_list
+                .iter()
+                .filter_map(|(_, op)| {
+                    if arc.contains(op.op_id.loc()) {
+                        Some(op.created_at)
+                    } else {
+                        None
+                    }
+                })
+                .min())
+        })
+    }
+
     /// Store the combined hash of a time slice.
     ///
     /// The `slice_id` is the index of the time slice. This is a 0-based index. So for a given

--- a/crates/core/src/factories/mem_op_store.rs
+++ b/crates/core/src/factories/mem_op_store.rs
@@ -315,10 +315,6 @@ impl OpStore for Kitsune2MemoryOpStore {
         arc: DhtArc,
     ) -> BoxFuture<'_, K2Result<Option<Timestamp>>> {
         Box::pin(async move {
-            println!(
-                "Getting earliest from: {:?}",
-                self.read().await.op_list.len()
-            );
 
             Ok(self
                 .read()

--- a/crates/dht/src/dht.rs
+++ b/crates/dht/src/dht.rs
@@ -519,6 +519,7 @@ impl Dht {
     /// Creates the inner [HashPartition] using the store. The sizing for the sectors and time
     /// slices are currently hard-coded. This will create 512 sectors and each full time slice will
     /// be approximately 5.3 days.
+    #[tracing::instrument(level = "debug", skip(store))]
     pub async fn try_from_store(
         current_time: Timestamp,
         store: DynOpStore,

--- a/crates/dht/src/hash.rs
+++ b/crates/dht/src/hash.rs
@@ -105,6 +105,7 @@ impl HashPartition {
     /// Each sector owns a [TimePartition] structure that is responsible for managing the time
     /// slices for that sector. The parameters to this function are used to create the
     /// [TimePartition] structure.
+    #[tracing::instrument(level = "debug", skip(store))]
     pub async fn try_from_store(
         time_factor: u8,
         current_time: Timestamp,
@@ -166,7 +167,7 @@ impl HashPartition {
         current_time: Timestamp,
     ) -> K2Result<()> {
         for partition in self.sectors.iter_mut() {
-            partition.update(store.clone(), current_time).await?;
+            partition.update(current_time, store.clone()).await?;
         }
 
         Ok(())


### PR DESCRIPTION
I knew this was doing a lot of work on startup until the first full time slice hash was computed but it turns out, it's a silly amount of work. Tests in `holochain_p2p` were taking 45s when they only need to take 0.2s. 

We already avoid recomputing earlier full slice hashes if we have a stored count. We also avoid recomputing partial slice hashes if we already know their value. However, we were spending a lot of initialisation time on computing slice hashes from the `UNIX_TIMESTAMP` that we can easily rule out by bounding the start time of the query.

Before I got this set up right, the exists tests did a lot of complaining... so I think they are sufficient. This doesn't add any new logic or states, it's just avoiding work. So if everything that worked before still works then we're good. It should just run much faster.

Test run for `kitsune2_dht` on `main`: `test result: ok. 81 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.59s`
and after these changes: `test result: ok. 81 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.23s`

So you can see the difference even in memory. With a real database, it's much more noticeable.