### PR TITLE
feat: Add `dump_network_stats` to the transport

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1544,12 +1544,14 @@ dependencies = [
 name = "kitsune2_transport_tx5"
 version = "0.0.1-alpha.13"
 dependencies = [
+ "base64",
  "bytes",
  "kitsune2_api",
  "kitsune2_core",
  "kitsune2_test_utils",
  "sbd-server",
  "serde",
+ "serde_json",
  "tokio",
  "tracing",
  "tx5",

--- a/crates/core/src/factories/mem_transport.rs
+++ b/crates/core/src/factories/mem_transport.rs
@@ -127,6 +127,14 @@ impl TxImp for MemTransport {
             }
         })
     }
+
+    fn dump_network_stats(&self) -> BoxFut<'_, K2Result<serde_json::Value>> {
+        Box::pin(async move {
+            Ok(serde_json::json!({
+                "backend": "kitsune2-core-mem",
+            }))
+        })
+    }
 }
 
 type Res = tokio::sync::oneshot::Sender<K2Result<()>>;

--- a/crates/transport_tx5/Cargo.toml
+++ b/crates/transport_tx5/Cargo.toml
@@ -14,11 +14,13 @@ edition.workspace = true
 bytes = { workspace = true }
 kitsune2_api = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 tokio = { workspace = true, features = ["rt", "sync", "time"] }
 tracing = { workspace = true }
 tx5 = { workspace = true, default-features = false, features = [
   "backend-libdatachannel",
 ] }
+base64 = { workspace = true }
 
 [dev-dependencies]
 kitsune2_core = { workspace = true }

--- a/crates/transport_tx5/src/lib.rs
+++ b/crates/transport_tx5/src/lib.rs
@@ -254,11 +254,9 @@ impl TxImp for Tx5Transport {
 
     fn dump_network_stats(&self) -> BoxFut<'_, K2Result<serde_json::Value>> {
         Box::pin(async move {
-            let mut stats: serde_json::Value = serde_json::from_slice(
-                &serde_json::to_vec(&self.ep.get_stats())
-                    .map_err(K2Error::other)?,
-            )
-            .map_err(K2Error::other)?;
+            let mut stats: serde_json::Value =
+                serde_json::to_value(self.ep.get_stats())
+                    .map_err(K2Error::other)?;
 
             let connection_list = stats
                 .as_object_mut()

--- a/crates/transport_tx5/src/lib.rs
+++ b/crates/transport_tx5/src/lib.rs
@@ -1,6 +1,7 @@
 #![deny(missing_docs)]
 //! kitsune2 tx5 transport module.
 
+use base64::Engine;
 use kitsune2_api::*;
 use std::sync::Arc;
 
@@ -248,6 +249,51 @@ impl TxImp for Tx5Transport {
                 .send(peer, data.to_vec())
                 .await
                 .map_err(|e| K2Error::other_src("tx5 send error", e))
+        })
+    }
+
+    fn dump_network_stats(&self) -> BoxFut<'_, K2Result<serde_json::Value>> {
+        Box::pin(async move {
+            let mut stats: serde_json::Value = serde_json::from_slice(
+                &serde_json::to_vec(&self.ep.get_stats())
+                    .map_err(K2Error::other)?,
+            )
+            .map_err(K2Error::other)?;
+
+            let connection_list = stats
+                .as_object_mut()
+                .ok_or_else(|| K2Error::other("Stats should be an object"))?
+                .get_mut("connectionList")
+                .ok_or_else(|| K2Error::other("Missing connection list"))?
+                .as_array_mut()
+                .ok_or_else(|| {
+                    K2Error::other("Connection list not an array")
+                })?;
+
+            for conn in connection_list.iter_mut() {
+                let pub_key = conn
+                    .get_mut("pubKey")
+                    .ok_or_else(|| K2Error::other("Missing pubKey"))?;
+
+                *pub_key = serde_json::Value::String(
+                    base64::prelude::BASE64_URL_SAFE_NO_PAD.encode(
+                        pub_key
+                            .as_array()
+                            .ok_or_else(|| {
+                                K2Error::other("pubKey not an array")
+                            })?
+                            .iter()
+                            .map(|v| {
+                                v.as_u64().map(|v| v as u8).ok_or_else(|| {
+                                    K2Error::other("invalid pubKey")
+                                })
+                            })
+                            .collect::<K2Result<Vec<u8>>>()?,
+                    ),
+                );
+            }
+
+            Ok(stats)
         })
     }
 }


### PR DESCRIPTION
Adds `dump_network_stats` to the `Transport`

For datachannel, the output looks like:

```json
 {
  "backend": "backendLibDataChannel",
  "peerUrlList": [
    "ws://127.0.0.1:43427/_78iVW071_gH59btIMxrWnOuUZS8kbVAhdR3DkiV4A4"
  ],
  "connectionList": [
    {
      "pubKey": "anhRG-p_Myjf6SWobMF0Sujajiqb_1Pw_jifQkaMN7U",
      "sendMessageCount": 2,
      "sendBytes": 10,
      "recvMessageCount": 2,
      "recvBytes": 10,
      "openedAtS": 1742574018,
      "isWebrtc": true
    }
  ]
}
```

Note the transform of the `pubKey` field in the `connectionList`. I think that's good enough to let the end user list agents and join the stats output as desired, rather than doing the join automatically like we used to.