### PR TITLE
feat: Add state dumps for fetch and gossip modules

### DIFF
--- a/crates/api/src/fetch.rs
+++ b/crates/api/src/fetch.rs
@@ -1,12 +1,13 @@
 //! Kitsune2 fetch types.
 
-use crate::op_store;
 use crate::{
     builder, config, transport::DynTransport, BoxFut, DynOpStore, K2Result,
     OpId, SpaceId, Url,
 };
+use crate::{op_store, Timestamp};
 use bytes::{Bytes, BytesMut};
 use prost::Message;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 pub(crate) mod proto {
@@ -93,6 +94,9 @@ pub trait Fetch: 'static + Send + Sync + std::fmt::Debug {
         op_ids: Vec<OpId>,
         source: Url,
     ) -> BoxFut<'_, K2Result<()>>;
+
+    /// Get a state summary from the fetch module.
+    fn get_state_summary(&self) -> BoxFut<'_, K2Result<FetchStateSummary>>;
 }
 
 /// Trait object [Fetch].
@@ -119,6 +123,22 @@ pub trait FetchFactory: 'static + Send + Sync + std::fmt::Debug {
 
 /// Trait object [FetchFactory].
 pub type DynFetchFactory = Arc<dyn FetchFactory>;
+
+/// Summary of the fetch state.
+#[derive(Debug)]
+pub struct FetchStateSummary {
+    /// The op ids that are currently being fetched.
+    ///
+    /// Each op id is associated with one or more peer URL from which the op data could be
+    /// requested.
+    pub pending_requests: HashMap<OpId, Vec<Url>>,
+
+    /// The peer URL for nodes that are currently on backoff because of failed fetch requests.
+    ///
+    /// If peers are in here then they are not being used as potential sources in
+    /// [`FetchStateSummary::pending_requests`].
+    pub peers_on_backoff: HashMap<Url, Timestamp>,
+}
 
 #[cfg(test)]
 mod test {

--- a/crates/api/src/fetch.rs
+++ b/crates/api/src/fetch.rs
@@ -133,7 +133,7 @@ pub struct FetchStateSummary {
     /// requested.
     pub pending_requests: HashMap<OpId, Vec<Url>>,
 
-    /// The peer URL for nodes that are currently on backoff because of failed fetch requests.
+    /// The peer URL for nodes that are currently on backoff because of failed fetch requests, and the timestamp when that backoff will expire.
     ///
     /// If peers are in here then they are not being used as potential sources in
     /// [`FetchStateSummary::pending_requests`].

--- a/crates/api/src/gossip.rs
+++ b/crates/api/src/gossip.rs
@@ -9,6 +9,13 @@ use crate::{
 };
 use std::sync::Arc;
 
+/// Request for a gossip state summary.
+#[derive(Debug, Clone)]
+pub struct GossipStateSummaryRequest {
+    /// Include DHT summary in the response.
+    pub include_dht_summary: bool,
+}
+
 /// Represents the ability to sync DHT data with other agents through background communication.
 pub trait Gossip: 'static + Send + Sync + std::fmt::Debug {
     /// Inform the gossip module that a set of ops have been stored.
@@ -17,6 +24,12 @@ pub trait Gossip: 'static + Send + Sync + std::fmt::Debug {
     /// space that owns this gossip module. See [crate::space::Space::inform_ops_stored].
     fn inform_ops_stored(&self, ops: Vec<StoredOp>)
         -> BoxFut<'_, K2Result<()>>;
+
+    /// Get a state summary from the gossip module.
+    fn get_state_summary(
+        &self,
+        request: GossipStateSummaryRequest,
+    ) -> BoxFut<'_, K2Result<serde_json::Value>>;
 }
 
 /// Trait-object [Gossip].

--- a/crates/core/src/factories/core_fetch/back_off.rs
+++ b/crates/core/src/factories/core_fetch/back_off.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use backon::BackoffBuilder;
-use kitsune2_api::Url;
+use kitsune2_api::{Timestamp, Url};
 
 #[derive(Debug)]
 pub struct BackOffList {
@@ -114,6 +114,14 @@ impl BackOff {
     pub fn has_last_interval_expired(&self) -> bool {
         self.is_last_interval
             && self.interval_start.elapsed() > self.current_interval
+    }
+
+    /// Get the timestamp when the current back off will expire.
+    pub(crate) fn current_backoff_expiry(&self) -> Timestamp {
+        let remaining_duration = self
+            .current_interval
+            .saturating_sub(self.interval_start.elapsed());
+        Timestamp::now() + remaining_duration
     }
 }
 

--- a/crates/core/src/factories/core_gossip.rs
+++ b/crates/core/src/factories/core_gossip.rs
@@ -1,5 +1,5 @@
 use kitsune2_api::*;
-use serde_json::Value;
+use std::collections::HashMap;
 use std::sync::Arc;
 
 #[cfg(test)]
@@ -64,8 +64,15 @@ impl Gossip for CoreGossipStub {
     fn get_state_summary(
         &self,
         _request: GossipStateSummaryRequest,
-    ) -> BoxFut<'_, K2Result<Value>> {
-        Box::pin(async move { Ok(serde_json::json!({})) })
+    ) -> BoxFut<'_, K2Result<GossipStateSummary>> {
+        Box::pin(async move {
+            Ok(GossipStateSummary {
+                initiated_round: None,
+                accepted_rounds: Vec::with_capacity(0),
+                dht_summary: HashMap::with_capacity(0),
+                peer_meta: HashMap::with_capacity(0),
+            })
+        })
     }
 }
 

--- a/crates/core/src/factories/core_gossip.rs
+++ b/crates/core/src/factories/core_gossip.rs
@@ -1,4 +1,5 @@
 use kitsune2_api::*;
+use serde_json::Value;
 use std::sync::Arc;
 
 #[cfg(test)]
@@ -58,6 +59,13 @@ impl Gossip for CoreGossipStub {
             drop(ops);
             Ok(())
         })
+    }
+
+    fn get_state_summary(
+        &self,
+        _request: GossipStateSummaryRequest,
+    ) -> BoxFut<'_, K2Result<Value>> {
+        Box::pin(async move { Ok(serde_json::json!({})) })
     }
 }
 

--- a/crates/gossip/src/lib.rs
+++ b/crates/gossip/src/lib.rs
@@ -11,6 +11,9 @@ pub use constant::*;
 mod gossip;
 pub use gossip::*;
 
+mod update;
+pub use summary::*;
+
 mod error;
 mod initiate;
 mod peer_meta_store;
@@ -18,5 +21,5 @@ mod protocol;
 mod respond;
 mod state;
 mod storage_arc;
+mod summary;
 mod timeout;
-mod update;

--- a/crates/gossip/src/lib.rs
+++ b/crates/gossip/src/lib.rs
@@ -11,9 +11,6 @@ pub use constant::*;
 mod gossip;
 pub use gossip::*;
 
-mod update;
-pub use summary::*;
-
 mod error;
 mod initiate;
 mod peer_meta_store;
@@ -23,3 +20,4 @@ mod state;
 mod storage_arc;
 mod summary;
 mod timeout;
+mod update;

--- a/crates/gossip/src/summary.rs
+++ b/crates/gossip/src/summary.rs
@@ -1,0 +1,194 @@
+use crate::gossip::K2Gossip;
+use kitsune2_api::{DhtArc, K2Error, K2Result, LocalAgent, Timestamp, Url};
+use kitsune2_dht::{ArcSet, DhtSnapshot};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// DHT segment state.
+///
+/// See [`DhtSnapshot::Minimal`]
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DhtSegmentState {
+    /// The top hash of the DHT ring segment.
+    pub disc_top_hash: bytes::Bytes,
+    /// The boundary timestamp of the DHT ring segment.
+    pub disc_boundary: Timestamp,
+    /// The top hashes of each DHT ring segment.
+    pub ring_top_hashes: Vec<bytes::Bytes>,
+}
+
+/// Peer metadata dump.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct PeerMeta {
+    /// The timestamp of the last gossip round.
+    pub last_gossip_timestamp: Option<Timestamp>,
+    /// The bookmark of the last op bookmark received.
+    pub new_ops_bookmark: Option<Timestamp>,
+    /// The number of behavior errors observed.
+    pub peer_behavior_errors: Option<u32>,
+    /// The number of local errors.
+    pub local_errors: Option<u32>,
+    /// The number of busy peer errors.
+    pub peer_busy: Option<u32>,
+    /// The number of terminated rounds.
+    ///
+    /// Note that termination is not necessarily an error.
+    pub peer_terminated: Option<u32>,
+    /// The number of completed rounds.
+    pub completed_rounds: Option<u32>,
+    /// The number of peer timeouts.
+    pub peer_timeouts: Option<u32>,
+}
+
+/// Gossip round state summary.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GossipRoundStateSummary {
+    /// The URL of the peer with which the round is initiated.
+    pub session_with_peer: Url,
+}
+
+/// Gossip state summary.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GossipSummary {
+    /// The current initiated round summary.
+    pub initiated_round: Option<GossipRoundStateSummary>,
+    /// The list of accepted round summaries.
+    pub accepted_rounds: Vec<GossipRoundStateSummary>,
+    /// DHT summary.
+    pub dht_summary: HashMap<String, DhtSegmentState>,
+    /// Peer metadata dump for each agent in this space.
+    pub peer_meta: HashMap<Url, PeerMeta>,
+}
+
+impl K2Gossip {
+    pub async fn summary(
+        &self,
+        include_dht_summary: bool,
+    ) -> K2Result<serde_json::Value> {
+        let mut summary = GossipSummary {
+            initiated_round: None,
+            accepted_rounds: Vec::new(),
+            dht_summary: HashMap::new(),
+            peer_meta: HashMap::new(),
+        };
+
+        if let Some(current_round) =
+            self.initiated_round_state.lock().await.as_ref()
+        {
+            summary.initiated_round = Some(GossipRoundStateSummary {
+                session_with_peer: current_round.session_with_peer.clone(),
+            });
+        }
+
+        {
+            let accepted_states = self.accepted_round_states.read().await;
+            for url in accepted_states.keys() {
+                summary.accepted_rounds.push(GossipRoundStateSummary {
+                    session_with_peer: url.clone(),
+                })
+            }
+        }
+
+        let local_agents = self.local_agent_store.get_all().await?;
+
+        if include_dht_summary {
+            let current_arc_set = ArcSet::new(
+                local_agents
+                    .iter()
+                    .map(|l| l.get_tgt_storage_arc())
+                    .collect(),
+            )?;
+
+            for arc in current_arc_set.as_arcs() {
+                let arc_set = ArcSet::new(vec![arc])?;
+
+                let snapshot: DhtSnapshot = self
+                    .dht
+                    .read()
+                    .await
+                    .snapshot_minimal(arc_set.clone())
+                    .await?;
+                match snapshot {
+                    DhtSnapshot::Minimal {
+                        disc_top_hash,
+                        disc_boundary,
+                        ring_top_hashes,
+                    } => {
+                        summary.dht_summary.insert(
+                            match arc_set.as_arcs().first().ok_or_else(
+                                || K2Error::other("empty arc set"),
+                            )? {
+                                DhtArc::Arc(start, end) => {
+                                    format!("{}..{}", start, end)
+                                }
+                                DhtArc::Empty => {
+                                    return Err(K2Error::other("empty arc"))
+                                }
+                            },
+                            DhtSegmentState {
+                                disc_top_hash,
+                                disc_boundary,
+                                ring_top_hashes,
+                            },
+                        );
+                    }
+                    _ => {
+                        return Err(K2Error::other("unexpected snapshot type"))
+                    }
+                }
+            }
+        }
+
+        let agents = self.peer_store.get_all().await?;
+        for agent in agents {
+            if local_agents.iter().any(|l| l.agent() == &agent.agent) {
+                continue;
+            }
+
+            let Some(url) = agent.url.clone() else {
+                continue;
+            };
+
+            summary.peer_meta.insert(
+                url.clone(),
+                PeerMeta {
+                    last_gossip_timestamp: self
+                        .peer_meta_store
+                        .last_gossip_timestamp(url.clone())
+                        .await?,
+                    new_ops_bookmark: self
+                        .peer_meta_store
+                        .new_ops_bookmark(url.clone())
+                        .await?,
+                    peer_behavior_errors: self
+                        .peer_meta_store
+                        .peer_behavior_errors(url.clone())
+                        .await?,
+                    local_errors: self
+                        .peer_meta_store
+                        .local_errors(url.clone())
+                        .await?,
+                    peer_busy: self
+                        .peer_meta_store
+                        .peer_busy(url.clone())
+                        .await?,
+                    peer_terminated: self
+                        .peer_meta_store
+                        .peer_terminated(url.clone())
+                        .await?,
+                    completed_rounds: self
+                        .peer_meta_store
+                        .completed_rounds(url.clone())
+                        .await?,
+                    peer_timeouts: self
+                        .peer_meta_store
+                        .peer_timeouts(url.clone())
+                        .await?,
+                },
+            );
+        }
+
+        serde_json::to_value(summary)
+            .map_err(|e| K2Error::other_src("Failed to serialize summary", e))
+    }
+}

--- a/crates/gossip/src/summary.rs
+++ b/crates/gossip/src/summary.rs
@@ -79,7 +79,7 @@ impl K2Gossip {
                         );
                     }
                     _ => {
-                        return Err(K2Error::other("unexpected snapshot type"))
+                        unreachable!("unexpected snapshot type")
                     }
                 }
             }


### PR DESCRIPTION
Contributes to #95 but adding state dumps for fetch and gossip. The gossip dump optionally includes a rather detailed DHT dump.

Note that dumping the DHT state one segment at a time would make it easier to compare. We might want to consider making that change when we go to sharding. But for now, the arc is either going to empty and the summary will be too or it'll be full and splitting by segment is a little pointless.