### PR TITLE
feat: Expose the transport from the `Kitsune` trait

### DIFF
--- a/crates/api/src/fetch.rs
+++ b/crates/api/src/fetch.rs
@@ -7,6 +7,7 @@ use crate::{
 use crate::{op_store, Timestamp};
 use bytes::{Bytes, BytesMut};
 use prost::Message;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -125,7 +126,7 @@ pub trait FetchFactory: 'static + Send + Sync + std::fmt::Debug {
 pub type DynFetchFactory = Arc<dyn FetchFactory>;
 
 /// Summary of the fetch state.
-#[derive(Debug)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FetchStateSummary {
     /// The op ids that are currently being fetched.
     ///

--- a/crates/api/src/kitsune.rs
+++ b/crates/api/src/kitsune.rs
@@ -83,6 +83,9 @@ pub trait Kitsune: 'static + Send + Sync + std::fmt::Debug {
         &self,
         space: SpaceId,
     ) -> BoxFut<'_, Option<space::DynSpace>>;
+
+    /// Get the transport handle.
+    fn transport(&self) -> BoxFut<'_, K2Result<DynTransport>>;
 }
 
 /// Trait-object [Kitsune].

--- a/crates/core/src/factories/core_kitsune.rs
+++ b/crates/core/src/factories/core_kitsune.rs
@@ -169,6 +169,15 @@ impl Kitsune for CoreKitsune {
             fut.await.ok()
         })
     }
+
+    fn transport(&self) -> BoxFut<'_, K2Result<DynTransport>> {
+        Box::pin(async move {
+            self.tx
+                .get()
+                .cloned()
+                .ok_or_else(|| K2Error::other("Transport not registered yet"))
+        })
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
If we want to be able to get network stats, we need to access the `Transport` instance that Kitsune is using