### PR TITLE
feat: Make network stats typed

### DIFF
--- a/crates/api/src/transport.rs
+++ b/crates/api/src/transport.rs
@@ -141,11 +141,6 @@ pub trait TxImp: 'static + Send + Sync + std::fmt::Debug {
     fn send(&self, peer: Url, data: bytes::Bytes) -> BoxFut<'_, K2Result<()>>;
 
     /// Dump network stats.
-    ///
-    /// What this returns will depend on the transport implementation. The only guarantee is that
-    /// you can expect a JSON object that contains a `backend` key. The value of the `backend`
-    /// field will be a string that identifies the backend that is in use. That may be used as a
-    /// hint for processing the rest of the JSON object.
     fn dump_network_stats(&self) -> BoxFut<'_, K2Result<TransportStats>>;
 }
 
@@ -209,10 +204,6 @@ pub trait Transport: 'static + Send + Sync + std::fmt::Debug {
     ) -> BoxFut<'_, K2Result<()>>;
 
     /// Dump network stats.
-    ///
-    /// What this returns will depend on the transport implementation. It should contain any
-    /// information that might be relevant for diagnosing network issues or checking that
-    /// the transport is functioning as expected.
     fn dump_network_stats(&self) -> BoxFut<'_, K2Result<TransportStats>>;
 }
 

--- a/crates/api/src/transport.rs
+++ b/crates/api/src/transport.rs
@@ -3,6 +3,7 @@
 use crate::{protocol::*, *};
 #[cfg(feature = "mockall")]
 use mockall::automock;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
@@ -145,7 +146,7 @@ pub trait TxImp: 'static + Send + Sync + std::fmt::Debug {
     /// you can expect a JSON object that contains a `backend` key. The value of the `backend`
     /// field will be a string that identifies the backend that is in use. That may be used as a
     /// hint for processing the rest of the JSON object.
-    fn dump_network_stats(&self) -> BoxFut<'_, K2Result<serde_json::Value>>;
+    fn dump_network_stats(&self) -> BoxFut<'_, K2Result<TransportStats>>;
 }
 
 /// Trait-object [TxImp].
@@ -212,7 +213,7 @@ pub trait Transport: 'static + Send + Sync + std::fmt::Debug {
     /// What this returns will depend on the transport implementation. It should contain any
     /// information that might be relevant for diagnosing network issues or checking that
     /// the transport is functioning as expected.
-    fn dump_network_stats(&self) -> BoxFut<'_, K2Result<serde_json::Value>>;
+    fn dump_network_stats(&self) -> BoxFut<'_, K2Result<TransportStats>>;
 }
 
 /// Trait-object [Transport].
@@ -333,7 +334,7 @@ impl Transport for DefaultTransport {
         })
     }
 
-    fn dump_network_stats(&self) -> BoxFut<'_, K2Result<serde_json::Value>> {
+    fn dump_network_stats(&self) -> BoxFut<'_, K2Result<TransportStats>> {
         self.imp.dump_network_stats()
     }
 }
@@ -453,3 +454,43 @@ pub trait TransportFactory: 'static + Send + Sync + std::fmt::Debug {
 
 /// Trait-object [TransportFactory].
 pub type DynTransportFactory = Arc<dyn TransportFactory>;
+
+/// Stats for a transport connection.
+///
+/// This is intended to be a state dump that gives some insight into what the transport is doing.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransportStats {
+    /// The networking backend that is in use.
+    pub backend: String,
+
+    /// The list of peer urls that this Kitsune2 instance can currently be reached at.
+    pub peer_urls: Vec<Url>,
+
+    /// The list of current connections.
+    pub connections: Vec<TransportConnectionStats>,
+}
+
+/// Stats for a single transport connection.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TransportConnectionStats {
+    /// The public key of the remote peer.
+    pub pub_key: String,
+
+    /// The message count sent on this connection.
+    pub send_message_count: u64,
+
+    /// The bytes sent on this connection.
+    pub send_bytes: u64,
+
+    /// The message count received on this connection.
+    pub recv_message_count: u64,
+
+    /// The bytes received on this connection
+    pub recv_bytes: u64,
+
+    /// UNIX epoch timestamp in seconds when this connection was opened.
+    pub opened_at_s: u64,
+
+    /// True if this connection has successfully upgraded to webrtc.
+    pub is_webrtc: bool,
+}

--- a/crates/core/src/factories/mem_transport.rs
+++ b/crates/core/src/factories/mem_transport.rs
@@ -128,11 +128,13 @@ impl TxImp for MemTransport {
         })
     }
 
-    fn dump_network_stats(&self) -> BoxFut<'_, K2Result<serde_json::Value>> {
+    fn dump_network_stats(&self) -> BoxFut<'_, K2Result<TransportStats>> {
         Box::pin(async move {
-            Ok(serde_json::json!({
-                "backend": "kitsune2-core-mem",
-            }))
+            Ok(TransportStats {
+                backend: "kitsune2-core-mem".to_string(),
+                peer_urls: Vec::with_capacity(0),
+                connections: Vec::with_capacity(0),
+            })
         })
     }
 }

--- a/crates/transport_tx5/src/test.rs
+++ b/crates/transport_tx5/src/test.rs
@@ -485,54 +485,24 @@ async fn dump_network_stats() {
     let stats_1 = t1.dump_network_stats().await.unwrap();
     let stats_2 = t2.dump_network_stats().await.unwrap();
 
-    let backend = stats_1
-        .as_object()
-        .expect("Is an object")
-        .get("backend")
-        .expect("Has backend key")
-        .as_str()
-        .expect("Backend value is a string")
-        .to_string();
-    assert_eq!(backend, "backendLibDataChannel");
+    assert_eq!(stats_1.backend, "BackendLibDataChannel");
 
-    fn get_peer_url(stats: &serde_json::Value) -> Url {
-        Url::from_str(
-            stats
-                .as_object()
-                .unwrap()
-                .get("peerUrlList")
-                .unwrap()
-                .as_array()
-                .unwrap()
-                .first()
-                .unwrap()
-                .as_str()
-                .unwrap(),
-        )
-        .unwrap()
-    }
-
-    fn get_connection_list(stats: &serde_json::Value) -> HashSet<String> {
-        stats
-            .as_object()
-            .unwrap()
-            .get("connectionList")
-            .unwrap()
-            .as_array()
-            .unwrap()
-            .iter()
-            .map(|x| x.get("pubKey").unwrap().as_str().unwrap().to_string())
-            .collect()
-    }
-
-    let peer_url_1 = get_peer_url(&stats_1);
+    let peer_url_1 = stats_1.peer_urls.first().unwrap();
     let peer_id_1 = peer_url_1.peer_id().unwrap();
 
-    let peer_url_2 = get_peer_url(&stats_2);
+    let peer_url_2 = stats_2.peer_urls.first().unwrap();
     let peer_id_2 = peer_url_2.peer_id().unwrap();
 
-    let connection_list_1 = get_connection_list(&stats_1);
-    let connection_list_2 = get_connection_list(&stats_2);
+    let connection_list_1 = stats_1
+        .connections
+        .iter()
+        .map(|c| c.pub_key.clone())
+        .collect::<HashSet<_>>();
+    let connection_list_2 = stats_2
+        .connections
+        .iter()
+        .map(|c| c.pub_key.clone())
+        .collect::<HashSet<_>>();
 
     assert!(connection_list_1.contains(peer_id_2));
     assert!(connection_list_2.contains(peer_id_1));


### PR DESCRIPTION
Exposes tx5 network stats as typed. I hadn't looked closely enough to realize that the stats are constant and the backend is just a field to tell you what's loaded. 

To give us a little isolation to tx5 changes and let me make the format a bit friendlier (pubkey as bytes makes it less obvious that it's also in the URL), I've made this  a kitsune2_api type. That also means that Holochain doesn't have to put tx5 types in its API.