### PR TITLE
chore: Remove `get_local_agents` from the space API

### DIFF
--- a/crates/api/src/space.rs
+++ b/crates/api/src/space.rs
@@ -1,6 +1,5 @@
 //! Kitsune2 space related types.
 
-use crate::agent::DynLocalAgent;
 use crate::fetch::DynFetch;
 use crate::*;
 use std::sync::Arc;

--- a/crates/api/src/space.rs
+++ b/crates/api/src/space.rs
@@ -72,9 +72,6 @@ pub trait Space: 'static + Send + Sync + std::fmt::Debug {
     /// be made to publish this tombstone to peers in the space as well.
     fn local_agent_leave(&self, local_agent: id::AgentId) -> BoxFut<'_, ()>;
 
-    /// Get a list of all local agents currently joined to this space.
-    fn get_local_agents(&self) -> BoxFut<'_, K2Result<Vec<DynLocalAgent>>>;
-
     /// Send a message to a remote peer. The future returned from this
     /// function will track the message all the way down to the low-level
     /// network transport implementation. But once the data is handed off

--- a/crates/core/src/factories/core_space.rs
+++ b/crates/core/src/factories/core_space.rs
@@ -436,10 +436,6 @@ impl Space for CoreSpace {
         })
     }
 
-    fn get_local_agents(&self) -> BoxFut<'_, K2Result<Vec<DynLocalAgent>>> {
-        self.local_agent_store.get_all()
-    }
-
     fn send_notify(
         &self,
         to_peer: Url,


### PR DESCRIPTION
I believe when this was added, the local agent store wasn't exposed through the space. Now that it is, this isn't useful.