### PR TITLE
chore: Update to 0.1.0

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,6 +16,12 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      # we cannot use cmake 4 until openssl-src is updated
+      - name: cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.31.x'
+
       - name: Toml format
         run: make static-toml
 
@@ -41,6 +47,12 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: Swatinem/rust-cache@v2
+
+      # we cannot use cmake 4 until openssl-src is updated
+      - name: cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.31.x'
 
       - name: Build
         run: make build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -74,6 +74,12 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
+      # we cannot use cmake 4 until openssl-src is updated
+      - name: cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.31.x'
+
       - uses: johnwason/vcpkg-action@v6
         with:
           triplet: x64-windows-release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1386,7 +1386,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune2"
-version = "0.0.1-alpha.17"
+version = "0.1.0"
 dependencies = [
  "bytes",
  "futures",
@@ -1401,7 +1401,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_api"
-version = "0.0.1-alpha.17"
+version = "0.1.0"
 dependencies = [
  "base64",
  "bytes",
@@ -1420,7 +1420,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_bootstrap_client"
-version = "0.0.1-alpha.17"
+version = "0.1.0"
 dependencies = [
  "base64",
  "kitsune2_api",
@@ -1434,7 +1434,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_bootstrap_srv"
-version = "0.0.1-alpha.17"
+version = "0.1.0"
 dependencies = [
  "async-channel",
  "axum",
@@ -1462,7 +1462,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_core"
-version = "0.0.1-alpha.17"
+version = "0.1.0"
 dependencies = [
  "backon",
  "bytes",
@@ -1483,7 +1483,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_dht"
-version = "0.0.1-alpha.17"
+version = "0.1.0"
 dependencies = [
  "bytes",
  "kitsune2_api",
@@ -1497,7 +1497,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_gossip"
-version = "0.0.1-alpha.17"
+version = "0.1.0"
 dependencies = [
  "base64",
  "bytes",
@@ -1516,7 +1516,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_showcase"
-version = "0.0.1-alpha.17"
+version = "0.1.0"
 dependencies = [
  "bytes",
  "clap",
@@ -1530,7 +1530,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_test_utils"
-version = "0.0.1-alpha.17"
+version = "0.1.0"
 dependencies = [
  "axum",
  "bytes",
@@ -1544,7 +1544,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_transport_tx5"
-version = "0.0.1-alpha.17"
+version = "0.1.0"
 dependencies = [
  "base64",
  "bytes",
@@ -2918,7 +2918,7 @@ dependencies = [
 
 [[package]]
 name = "tool_proto_build"
-version = "0.0.1-alpha.17"
+version = "0.1.0"
 dependencies = [
  "prost-build",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.0.1-alpha.17"
+version = "0.1.0"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 homepage = "https://github.com/holochain/kitsune2"
 keywords = ["holochain", "kitsune", "p2p", "dht", "networking"]
@@ -33,12 +33,12 @@ panic = "abort"
 [workspace.dependencies]
 # Self dependencies for workspace crates to depend on each other.
 # For example, most crates will depend on the api crate.
-kitsune2 = { version = "=0.0.1-alpha.17", path = "crates/kitsune2" }
-kitsune2_api = { version = "=0.0.1-alpha.17", path = "crates/api" }
-kitsune2_dht = { version = "=0.0.1-alpha.17", path = "crates/dht" }
-kitsune2_gossip = { version = "=0.0.1-alpha.17", path = "crates/gossip" }
-kitsune2_transport_tx5 = { version = "=0.0.1-alpha.17", path = "crates/transport_tx5" }
-kitsune2_bootstrap_client = { version = "=0.0.1-alpha.17", path = "crates/bootstrap_client" }
+kitsune2 = { version = "0.1.0", path = "crates/kitsune2" }
+kitsune2_api = { version = "0.1.0", path = "crates/api" }
+kitsune2_dht = { version = "0.1.0", path = "crates/dht" }
+kitsune2_gossip = { version = "0.1.0", path = "crates/gossip" }
+kitsune2_transport_tx5 = { version = "0.1.0", path = "crates/transport_tx5" }
+kitsune2_bootstrap_client = { version = "0.1.0", path = "crates/bootstrap_client" }
 
 # used by bootstrap_srv for mpmc worker queue pattern.
 async-channel = "2.3.1"
@@ -111,8 +111,8 @@ prost-build = "0.13.3"
 # Please be careful to only include them in dev dependencies or move them
 # above this section.
 # --- dev-dependencies ---
-kitsune2_bootstrap_srv = { version = "=0.0.1-alpha.17", path = "crates/bootstrap_srv" }
-kitsune2_core = { version = "=0.0.1-alpha.17", path = "crates/core" }
+kitsune2_bootstrap_srv = { version = "0.1.0", path = "crates/bootstrap_srv" }
+kitsune2_core = { version = "0.1.0", path = "crates/core" }
 kitsune2_test_utils = { path = "crates/test_utils" }
 
 # used to test the bootstrap server with SBD enabled


### PR DESCRIPTION
The integration into Holochain is nearing completion. It's looking like Kitsune2 is ready to be used at this point and we can commit to a proper version number.