### PR TITLE
feat: Initiate first gossip round faster

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,8 +265,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49fef586913a57ff189f25c9b3d034356a5bf6b3fa9a7f067588fe1698ba1f5d"
 dependencies = [
  "fastrand",
- "gloo-timers",
- "tokio",
 ]
 
 [[package]]
@@ -1012,18 +1010,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
-name = "gloo-timers"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "h2"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1499,6 +1485,7 @@ dependencies = [
 name = "kitsune2_gossip"
 version = "0.1.1"
 dependencies = [
+ "backon",
  "base64",
  "bytes",
  "kitsune2_api",
@@ -3238,7 +3225,6 @@ checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
- "rustversion",
  "wasm-bindgen-macro",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ async-channel = "2.3.1"
 # this is used by bootstrap_srv as the http server implementation.
 axum = { version = "0.7", default-features = false }
 # used by fetch module to back off requests to unresponsive agents
-backon = "1.3"
+backon = { version = "1.3", default-features = false }
 # debugging is far easier when you can see short byte arrays
 # as base64 instead of decimal u8s.
 base64 = "0.22.1"

--- a/crates/gossip/Cargo.toml
+++ b/crates/gossip/Cargo.toml
@@ -23,6 +23,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 rand = { workspace = true }
 thiserror = { workspace = true }
+backon = { workspace = true }
 
 kitsune2_test_utils = { workspace = true, optional = true }
 

--- a/crates/gossip/src/config.rs
+++ b/crates/gossip/src/config.rs
@@ -29,6 +29,17 @@ pub struct K2GossipConfig {
     /// Default: 100MB
     pub max_request_gossip_op_bytes: u32,
 
+    /// The initial interval in milliseconds between initiating gossip rounds.
+    ///
+    /// This controls how often Kitsune will check for a peer to gossip with for its first gossip
+    /// round. Once a gossip round has been successfully initiated, this interval will no longer be
+    /// used. The value is used as an upper bound for an exponential backoff. The backoff runs from
+    /// 10ms, with a factor of 1.2, up to this value. Once the maximum value is reached, it
+    /// continues to be used as the upper bound for the backoff.
+    ///
+    /// Default: 5000 (5s)
+    pub initial_initiate_interval_ms: u32,
+
     /// The interval in milliseconds between initiating gossip rounds.
     ///
     /// This controls how often Kitsune will attempt to find a peer to gossip with.
@@ -98,6 +109,7 @@ impl Default for K2GossipConfig {
         Self {
             max_gossip_op_bytes: 100 * 1024 * 1024,
             max_request_gossip_op_bytes: 100 * 1024 * 1024,
+            initial_initiate_interval_ms: 5000,
             initiate_interval_ms: 120_000,
             initiate_jitter_ms: 10_000,
             min_initiate_interval_ms: 300_000,
@@ -108,6 +120,13 @@ impl Default for K2GossipConfig {
 }
 
 impl K2GossipConfig {
+    /// The initial interval in milliseconds between initiating gossip rounds.
+    pub(crate) fn initial_initiate_interval(&self) -> std::time::Duration {
+        std::time::Duration::from_millis(
+            self.initial_initiate_interval_ms as u64,
+        )
+    }
+
     /// The interval between initiating gossip rounds.
     pub(crate) fn initiate_interval(&self) -> std::time::Duration {
         std::time::Duration::from_millis(self.initiate_interval_ms as u64)

--- a/crates/gossip/src/gossip.rs
+++ b/crates/gossip/src/gossip.rs
@@ -707,6 +707,7 @@ mod test {
                 // Set the initiate interval low so that gossip will start quickly after
                 // bootstrapping but leave the min initiate interval high so that we can
                 // run a single gossip round during the test.
+                initial_initiate_interval_ms: 10,
                 initiate_interval_ms: 10,
                 initiate_jitter_ms: 0,
                 ..Default::default()
@@ -773,6 +774,7 @@ mod test {
                 // Set the initiate interval low so that gossip will start quickly after
                 // bootstrapping but leave the min initiate interval high so that we can
                 // run a single gossip round during the test.
+                initial_initiate_interval_ms: 10,
                 initiate_interval_ms: 10,
                 initiate_jitter_ms: 0,
                 ..Default::default()
@@ -871,6 +873,7 @@ mod test {
                 // Set the initiate interval low so that gossip will start quickly after
                 // bootstrapping but leave the min initiate interval high so that we can
                 // run a single gossip round during the test.
+                initial_initiate_interval_ms: 10,
                 initiate_interval_ms: 10,
                 initiate_jitter_ms: 0,
                 ..Default::default()

--- a/crates/gossip/src/initiate.rs
+++ b/crates/gossip/src/initiate.rs
@@ -1,6 +1,7 @@
 use crate::gossip::K2Gossip;
 use crate::peer_meta_store::K2PeerMetaStore;
 use crate::K2GossipConfig;
+use backon::BackoffBuilder;
 use kitsune2_api::*;
 use kitsune2_api::{AgentId, DynLocalAgentStore, K2Result, Timestamp, Url};
 use rand::prelude::SliceRandom;
@@ -15,17 +16,31 @@ pub fn spawn_initiate_task(
 ) -> AbortHandle {
     tracing::info!("Starting initiate task");
 
+    let mut rush_to_fist_initiated_round = true;
+
+    let initial_initiate_interval = config.initial_initiate_interval();
+    let mut rush_backoff = backon::ExponentialBuilder::new()
+        .with_min_delay(Duration::from_millis(10))
+        .with_max_delay(initial_initiate_interval)
+        .with_factor(1.2)
+        .with_jitter()
+        .build();
+
     let initiate_interval = config.initiate_interval();
     let initiate_jitter_ms = config.initiate_jitter_ms as u64;
     let min_initiate_interval = config.min_initiate_interval();
     tokio::task::spawn(async move {
         loop {
-            let jitter = if initiate_jitter_ms > 0 {
-                Duration::from_millis(rand::random::<u64>() % initiate_jitter_ms)
+            if rush_to_fist_initiated_round {
+                tokio::time::sleep(rush_backoff.next().unwrap_or(initiate_interval)).await;
             } else {
-                Duration::ZERO
-            };
-            tokio::time::sleep(initiate_interval + jitter).await;
+                let jitter = if initiate_jitter_ms > 0 {
+                    Duration::from_millis(rand::random::<u64>() % initiate_jitter_ms)
+                } else {
+                    Duration::ZERO
+                };
+                tokio::time::sleep(initiate_interval + jitter).await;
+            }
 
             if gossip.initiated_round_state.lock().await.is_some() {
                 tracing::info!("Not initiating gossip because there is already an initiated round");
@@ -43,6 +58,7 @@ pub fn spawn_initiate_task(
                 Ok(Some(url)) => {
                     match gossip.initiate_gossip(url.clone()).await {
                         Ok(true) => {
+                            rush_to_fist_initiated_round = true;
                             tracing::info!("Initiated gossip with {}", url);
                         }
                         Ok(false) => {

--- a/crates/gossip/src/initiate.rs
+++ b/crates/gossip/src/initiate.rs
@@ -16,7 +16,7 @@ pub fn spawn_initiate_task(
 ) -> AbortHandle {
     tracing::info!("Starting initiate task");
 
-    let mut rush_to_fist_initiated_round = true;
+    let mut rush_to_first_initiated_round = true;
 
     let initial_initiate_interval = config.initial_initiate_interval();
     let mut rush_backoff = backon::ExponentialBuilder::new()
@@ -31,7 +31,7 @@ pub fn spawn_initiate_task(
     let min_initiate_interval = config.min_initiate_interval();
     tokio::task::spawn(async move {
         loop {
-            if rush_to_fist_initiated_round {
+            if rush_to_first_initiated_round {
                 tokio::time::sleep(rush_backoff.next().unwrap_or(initiate_interval)).await;
             } else {
                 let jitter = if initiate_jitter_ms > 0 {
@@ -58,7 +58,7 @@ pub fn spawn_initiate_task(
                 Ok(Some(url)) => {
                     match gossip.initiate_gossip(url.clone()).await {
                         Ok(true) => {
-                            rush_to_fist_initiated_round = true;
+                            rush_to_first_initiated_round = true;
                             tracing::info!("Initiated gossip with {}", url);
                         }
                         Ok(false) => {


### PR DESCRIPTION
This is really only an experience enhancement. The first round might fail, or on a larger network there should be peers finding you and initiating gossip fairly quickly.

On smaller networks, this helps get gossip started a bit quicker.