### PR TITLE
refactor(api): remove config options unused warning

### DIFF
--- a/crates/api/src/builder.rs
+++ b/crates/api/src/builder.rs
@@ -94,8 +94,6 @@ impl Builder {
             gossip.default_config(config)?;
             local_agent_store.default_config(config)?;
             publish.default_config(config)?;
-
-            config.mark_defaults_set();
         }
 
         Ok(self)


### PR DESCRIPTION
I commented in the issue:

> There's no way to know if the option is valid or not. Not in kitsune, not in Holochain. It would make the most sense to check for type correctness in kitsune and not import all of those types into Holochain and check there.
But the configuration was purposely built type-free and generic, so it would be bigger refactor to address the issue. My proposal is to just eliminate the warning, as it's not an informative warning.

Not an offense! The warning was added with the intention to identify deprecated options being set. But the way the configuration must be used doesn't lend itself to identifying such cases, because the configuration is usually constructed with defaults and then module configurations are updated. That means the warning is always output. It'll probably confuse developers for a while and then they and we will become numb to the warning.

resolves #184 