### PR TITLE
feat!: Expose current URL instead of is_local_agent

### DIFF
--- a/crates/api/src/local_agent_store.rs
+++ b/crates/api/src/local_agent_store.rs
@@ -17,9 +17,6 @@ pub trait LocalAgentStore: 'static + Send + Sync + std::fmt::Debug {
 
     /// Get a list of all local agents currently in the store.
     fn get_all(&self) -> BoxFut<'_, K2Result<Vec<DynLocalAgent>>>;
-
-    /// Check whether an agent is local.
-    fn is_agent_local(&self, agent: id::AgentId) -> BoxFut<'_, K2Result<bool>>;
 }
 
 /// Trait-object version of kitsune2 [LocalAgentStore].

--- a/crates/api/src/space.rs
+++ b/crates/api/src/space.rs
@@ -57,6 +57,9 @@ pub trait Space: 'static + Send + Sync + std::fmt::Debug {
     /// Get a reference to the peer meta store being used by this space.
     fn peer_meta_store(&self) -> &DynPeerMetaStore;
 
+    /// The URL that this space is current reachable at, if any.
+    fn current_url(&self) -> Option<Url>;
+
     /// Indicate that an agent is now online, and should begin receiving
     /// messages and exchanging dht information.
     fn local_agent_join(

--- a/crates/api/src/space.rs
+++ b/crates/api/src/space.rs
@@ -57,7 +57,7 @@ pub trait Space: 'static + Send + Sync + std::fmt::Debug {
     /// Get a reference to the peer meta store being used by this space.
     fn peer_meta_store(&self) -> &DynPeerMetaStore;
 
-    /// The URL that this space is current reachable at, if any.
+    /// The URL that this space is currently reachable at, if any.
     fn current_url(&self) -> Option<Url>;
 
     /// Indicate that an agent is now online, and should begin receiving

--- a/crates/core/src/factories/core_fetch.rs
+++ b/crates/core/src/factories/core_fetch.rs
@@ -449,7 +449,8 @@ impl CoreFetch {
         state: Arc<Mutex<State>>,
     ) {
         while let Some(ops) = incoming_response_rx.recv().await {
-            tracing::debug!(?ops, "incoming op response");
+            let op_count = ops.len();
+            tracing::debug!(?op_count, "incoming op response");
             let ops_data = ops.clone().into_iter().map(|op| op.data).collect();
             match op_store.process_incoming_ops(ops_data).await {
                 Err(err) => {
@@ -459,7 +460,7 @@ impl CoreFetch {
                     continue;
                 }
                 Ok(processed_op_ids) => {
-                    tracing::info!(
+                    tracing::debug!(
                         "processed incoming ops with op ids {processed_op_ids:?}"
                     );
                     // Ops were processed successfully by op store. Op ids are returned.

--- a/crates/core/src/factories/core_local_agent_store.rs
+++ b/crates/core/src/factories/core_local_agent_store.rs
@@ -41,12 +41,6 @@ impl LocalAgentStore for CoreLocalAgentStore {
         let out = inner.values().cloned().collect();
         Box::pin(async { Ok(out) })
     }
-
-    fn is_agent_local(&self, agent: AgentId) -> BoxFut<'_, K2Result<bool>> {
-        let inner = self.inner.lock().unwrap();
-        let is_local = inner.contains_key(&agent);
-        Box::pin(async move { Ok(is_local) })
-    }
 }
 
 /// Factory for creating [CoreLocalAgentStore] instances.

--- a/crates/core/src/factories/mem_op_store.rs
+++ b/crates/core/src/factories/mem_op_store.rs
@@ -102,7 +102,7 @@ impl From<MemoryOp> for Bytes {
 ///
 /// Test data should create [MemoryOp]s and not be aware of this type.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-struct MemoryOpRecord {
+pub struct MemoryOpRecord {
     /// The id (hash) of the op
     pub op_id: OpId,
     /// The creation timestamp of this op
@@ -140,13 +140,17 @@ impl From<Op> for MemoryOp {
     }
 }
 
+/// The in-memory op store implementation for Kitsune2.
+///
+/// Intended for testing only, because it provides no persistence of op data.
 #[derive(Debug)]
-struct Kitsune2MemoryOpStore {
+pub struct Kitsune2MemoryOpStore {
     _space: SpaceId,
     inner: RwLock<Kitsune2MemoryOpStoreInner>,
 }
 
 impl Kitsune2MemoryOpStore {
+    /// Create a new [Kitsune2MemoryOpStore].
     pub fn new(space: SpaceId) -> Self {
         Self {
             _space: space,
@@ -163,10 +167,13 @@ impl std::ops::Deref for Kitsune2MemoryOpStore {
     }
 }
 
+/// The inner state of a [Kitsune2MemoryOpStore].
 #[derive(Debug, Default)]
-struct Kitsune2MemoryOpStoreInner {
-    op_list: HashMap<OpId, MemoryOpRecord>,
-    time_slice_hashes: TimeSliceHashStore,
+pub struct Kitsune2MemoryOpStoreInner {
+    /// The stored op data.
+    pub op_list: HashMap<OpId, MemoryOpRecord>,
+    /// The time slice hashes.
+    pub time_slice_hashes: TimeSliceHashStore,
 }
 
 impl OpStore for Kitsune2MemoryOpStore {

--- a/crates/dht/src/dht.rs
+++ b/crates/dht/src/dht.rs
@@ -477,7 +477,7 @@ impl DhtApi for Dht {
                                 .await?;
 
                             if (used_bytes + ub) as i32 <= max_op_data_bytes {
-                                tracing::info!(
+                                tracing::debug!(
                                     "Accepting op batch in sector: {}, ring: {}",
                                     sector_index,
                                     ring_index

--- a/crates/gossip/src/gossip.rs
+++ b/crates/gossip/src/gossip.rs
@@ -451,9 +451,13 @@ mod test {
         enable_tracing();
 
         let space = TEST_SPACE_ID;
-        let factory =
-            K2GossipFunctionalTestFactory::create(space.clone(), false, None)
-                .await;
+        let factory = K2GossipFunctionalTestFactory::create(
+            space.clone(),
+            false,
+            false,
+            None,
+        )
+        .await;
         let harness_1 = factory.new_instance().await;
         let agent_info_1 = harness_1.join_local_agent(DhtArc::FULL).await;
 
@@ -515,9 +519,13 @@ mod test {
         enable_tracing();
 
         let space = TEST_SPACE_ID;
-        let factory =
-            K2GossipFunctionalTestFactory::create(space.clone(), true, None)
-                .await;
+        let factory = K2GossipFunctionalTestFactory::create(
+            space.clone(),
+            true,
+            false,
+            None,
+        )
+        .await;
         let harness_1 = factory.new_instance().await;
         harness_1.join_local_agent(DhtArc::FULL).await;
         let op_1 = MemoryOp::new(Timestamp::now(), vec![1; 128]);
@@ -554,9 +562,13 @@ mod test {
         enable_tracing();
 
         let space = TEST_SPACE_ID;
-        let factory =
-            K2GossipFunctionalTestFactory::create(space.clone(), false, None)
-                .await;
+        let factory = K2GossipFunctionalTestFactory::create(
+            space.clone(),
+            false,
+            false,
+            None,
+        )
+        .await;
 
         let harness_1 = factory.new_instance().await;
         let agent_info_1 = harness_1.join_local_agent(DhtArc::FULL).await;
@@ -631,9 +643,13 @@ mod test {
         enable_tracing();
 
         let space = TEST_SPACE_ID;
-        let factory =
-            K2GossipFunctionalTestFactory::create(space.clone(), false, None)
-                .await;
+        let factory = K2GossipFunctionalTestFactory::create(
+            space.clone(),
+            false,
+            false,
+            None,
+        )
+        .await;
         let harness_1 = factory.new_instance().await;
         let agent_info_1 = harness_1.join_local_agent(DhtArc::FULL).await;
         let op_1 = MemoryOp::new(
@@ -716,6 +732,7 @@ mod test {
         let factory = K2GossipFunctionalTestFactory::create(
             space.clone(),
             true,
+            false,
             Some(K2GossipConfig {
                 max_gossip_op_bytes: 3 * 128,
                 // Set the initiate interval low so that gossip will start quickly after
@@ -783,6 +800,7 @@ mod test {
         let factory = K2GossipFunctionalTestFactory::create(
             space.clone(),
             true,
+            false,
             Some(K2GossipConfig {
                 max_gossip_op_bytes: 7 * 128,
                 // Set the initiate interval low so that gossip will start quickly after
@@ -882,6 +900,7 @@ mod test {
         let factory = K2GossipFunctionalTestFactory::create(
             space.clone(),
             true,
+            false,
             Some(K2GossipConfig {
                 max_gossip_op_bytes: 7 * 128,
                 // Set the initiate interval low so that gossip will start quickly after
@@ -980,9 +999,13 @@ mod test {
         enable_tracing();
 
         let space = TEST_SPACE_ID;
-        let factory =
-            K2GossipFunctionalTestFactory::create(space.clone(), true, None)
-                .await;
+        let factory = K2GossipFunctionalTestFactory::create(
+            space.clone(),
+            true,
+            false,
+            None,
+        )
+        .await;
         let harness_1 = factory.new_instance().await;
         harness_1.join_local_agent(DhtArc::FULL).await;
 
@@ -1026,6 +1049,7 @@ mod test {
         let space = TEST_SPACE_ID;
         let factory = K2GossipFunctionalTestFactory::create(
             space.clone(),
+            false,
             false,
             Some(K2GossipConfig {
                 initial_initiate_interval_ms: 10,

--- a/crates/gossip/src/gossip.rs
+++ b/crates/gossip/src/gossip.rs
@@ -451,13 +451,9 @@ mod test {
         enable_tracing();
 
         let space = TEST_SPACE_ID;
-        let factory = K2GossipFunctionalTestFactory::create(
-            space.clone(),
-            false,
-            false,
-            None,
-        )
-        .await;
+        let factory =
+            K2GossipFunctionalTestFactory::create(space.clone(), false, None)
+                .await;
         let harness_1 = factory.new_instance().await;
         let agent_info_1 = harness_1.join_local_agent(DhtArc::FULL).await;
 
@@ -519,13 +515,9 @@ mod test {
         enable_tracing();
 
         let space = TEST_SPACE_ID;
-        let factory = K2GossipFunctionalTestFactory::create(
-            space.clone(),
-            true,
-            false,
-            None,
-        )
-        .await;
+        let factory =
+            K2GossipFunctionalTestFactory::create(space.clone(), true, None)
+                .await;
         let harness_1 = factory.new_instance().await;
         harness_1.join_local_agent(DhtArc::FULL).await;
         let op_1 = MemoryOp::new(Timestamp::now(), vec![1; 128]);
@@ -562,13 +554,9 @@ mod test {
         enable_tracing();
 
         let space = TEST_SPACE_ID;
-        let factory = K2GossipFunctionalTestFactory::create(
-            space.clone(),
-            false,
-            false,
-            None,
-        )
-        .await;
+        let factory =
+            K2GossipFunctionalTestFactory::create(space.clone(), false, None)
+                .await;
 
         let harness_1 = factory.new_instance().await;
         let agent_info_1 = harness_1.join_local_agent(DhtArc::FULL).await;
@@ -643,13 +631,9 @@ mod test {
         enable_tracing();
 
         let space = TEST_SPACE_ID;
-        let factory = K2GossipFunctionalTestFactory::create(
-            space.clone(),
-            false,
-            false,
-            None,
-        )
-        .await;
+        let factory =
+            K2GossipFunctionalTestFactory::create(space.clone(), false, None)
+                .await;
         let harness_1 = factory.new_instance().await;
         let agent_info_1 = harness_1.join_local_agent(DhtArc::FULL).await;
         let op_1 = MemoryOp::new(
@@ -732,7 +716,6 @@ mod test {
         let factory = K2GossipFunctionalTestFactory::create(
             space.clone(),
             true,
-            false,
             Some(K2GossipConfig {
                 max_gossip_op_bytes: 3 * 128,
                 // Set the initiate interval low so that gossip will start quickly after
@@ -800,7 +783,6 @@ mod test {
         let factory = K2GossipFunctionalTestFactory::create(
             space.clone(),
             true,
-            false,
             Some(K2GossipConfig {
                 max_gossip_op_bytes: 7 * 128,
                 // Set the initiate interval low so that gossip will start quickly after
@@ -900,7 +882,6 @@ mod test {
         let factory = K2GossipFunctionalTestFactory::create(
             space.clone(),
             true,
-            false,
             Some(K2GossipConfig {
                 max_gossip_op_bytes: 7 * 128,
                 // Set the initiate interval low so that gossip will start quickly after
@@ -999,13 +980,9 @@ mod test {
         enable_tracing();
 
         let space = TEST_SPACE_ID;
-        let factory = K2GossipFunctionalTestFactory::create(
-            space.clone(),
-            true,
-            false,
-            None,
-        )
-        .await;
+        let factory =
+            K2GossipFunctionalTestFactory::create(space.clone(), true, None)
+                .await;
         let harness_1 = factory.new_instance().await;
         harness_1.join_local_agent(DhtArc::FULL).await;
 
@@ -1049,7 +1026,6 @@ mod test {
         let space = TEST_SPACE_ID;
         let factory = K2GossipFunctionalTestFactory::create(
             space.clone(),
-            false,
             false,
             Some(K2GossipConfig {
                 initial_initiate_interval_ms: 10,

--- a/crates/gossip/src/harness.rs
+++ b/crates/gossip/src/harness.rs
@@ -215,11 +215,11 @@ impl K2GossipFunctionalTestHarness {
                     tracing::info!("Waiting for op ids to be discovered: {} != {}. Have stored {}/{} and {}/{}", our_op_ids.len(), other_op_ids.len(), our_stored_op_ids.len(), our_op_ids.len(), other_stored_op_ids.len(), other_op_ids.len());
                 }
 
-                tokio::time::sleep(Duration::from_millis(50)).await;
+                tokio::time::sleep(Duration::from_millis(100)).await;
             }
         })
         .await
-        .expect("Timed out waiting for instances to sync");
+        .expect("Timed out waiting for ops to be discovered");
     }
 
     /// Wait for two instances to sync their op stores.

--- a/crates/gossip/src/harness.rs
+++ b/crates/gossip/src/harness.rs
@@ -1,22 +1,24 @@
 //! Functional test harness for K2Gossip.
 
+use crate::harness::op_store::K2GossipMemOpStoreFactory;
 use crate::peer_meta_store::K2PeerMetaStore;
 use crate::{K2GossipConfig, K2GossipFactory, K2GossipModConfig};
-use bytes::Bytes;
 use kitsune2_api::{
-    AgentId, AgentInfoSigned, BoxFut, Builder, Config, DhtArc, DynGossip,
-    DynOpStore, DynSpace, K2Error, K2Result, LocalAgent, MetaOp, OpId, OpStore,
-    OpStoreFactory, SpaceHandler, SpaceId, StoredOp, Timestamp, TxBaseHandler,
-    TxHandler, TxSpaceHandler, UNIX_TIMESTAMP,
+    AgentId, AgentInfoSigned, DhtArc, DynGossip, DynSpace, LocalAgent, OpId,
+    SpaceHandler, SpaceId, StoredOp, TxBaseHandler, TxHandler, TxSpaceHandler,
+    UNIX_TIMESTAMP,
 };
-use kitsune2_core::factories::{
-    Kitsune2MemoryOpStore, MemoryOp, MemoryOpRecord,
-};
+use kitsune2_core::factories::MemoryOp;
 use kitsune2_core::{default_test_builder, Ed25519LocalAgent};
 use kitsune2_test_utils::noop_bootstrap::NoopBootstrapFactory;
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::task::AbortHandle;
+
+mod op_store;
+
+pub use op_store::{GossipOpStore, MemoryOpRecord};
 
 /// A functional test harness for K2Gossip.
 ///
@@ -27,8 +29,23 @@ pub struct K2GossipFunctionalTestHarness {
     pub gossip: DynGossip,
     /// The space instance.
     pub space: DynSpace,
+    /// The op store instance.
+    ///
+    /// This can be used to author data directly to the op store.
+    pub op_store: GossipOpStore,
     /// The peer meta store.
     pub peer_meta_store: Arc<K2PeerMetaStore>,
+    /// The abort handle for the process task.
+    ///
+    /// This simulates the process of checking incoming ops and adding them to the DHT model.
+    pub process_abort_handle: AbortHandle,
+}
+
+impl Drop for K2GossipFunctionalTestHarness {
+    fn drop(&mut self) {
+        // Abort the process task
+        self.process_abort_handle.abort();
+    }
 }
 
 impl K2GossipFunctionalTestHarness {
@@ -218,8 +235,8 @@ impl K2GossipFunctionalTestHarness {
                 tokio::time::sleep(Duration::from_millis(100)).await;
             }
         })
-        .await
-        .expect("Timed out waiting for ops to be discovered");
+            .await
+            .expect("Timed out waiting for ops to be discovered");
     }
 
     /// Wait for two instances to sync their op stores.
@@ -331,14 +348,10 @@ impl K2GossipFunctionalTestHarness {
 pub struct K2GossipFunctionalTestFactory {
     /// The space ID to use for the test.
     space_id: SpaceId,
-    /// The builder for creating new instances.
-    builder: Arc<Builder>,
-    /// A sender for ops stored events.
-    ///
-    /// This must not be used for sending. If it is provided then the K2 mem op store is in use
-    /// and that will send ops through this channel. Use the sender to create new listeners so
-    /// that each space can update its DHT.
-    ops_stored_sender: Option<tokio::sync::broadcast::Sender<Vec<StoredOp>>>,
+    /// Whether bootstrap is enabled.
+    bootstrap: bool,
+    /// The Kitsune2 configuration to use.
+    config: K2GossipModConfig,
 }
 
 impl K2GossipFunctionalTestFactory {
@@ -346,32 +359,12 @@ impl K2GossipFunctionalTestFactory {
     pub async fn create(
         space: SpaceId,
         bootstrap: bool,
-        gossip_mem_op_store: bool,
         config: Option<K2GossipConfig>,
     ) -> K2GossipFunctionalTestFactory {
-        let mut builder = default_test_builder().with_default_config().unwrap();
-        // Replace the core builder with a real gossip factory
-        builder.gossip = K2GossipFactory::create();
-
-        if !bootstrap {
-            builder.bootstrap = Arc::new(NoopBootstrapFactory);
-        }
-
-        let ops_stored_sender = if gossip_mem_op_store {
-            let (tx, _) =
-                tokio::sync::broadcast::channel::<Vec<StoredOp>>(5000);
-            builder.op_store = Arc::new(K2GossipMemOpStoreFactory {
-                ops_stored: tx.clone(),
-            });
-
-            Some(tx)
-        } else {
-            None
-        };
-
-        builder
-            .config
-            .set_module_config(&K2GossipModConfig {
+        K2GossipFunctionalTestFactory {
+            space_id: space,
+            bootstrap,
+            config: K2GossipModConfig {
                 k2_gossip: if let Some(config) = config {
                     config
                 } else {
@@ -383,15 +376,7 @@ impl K2GossipFunctionalTestFactory {
                         ..Default::default()
                     }
                 },
-            })
-            .unwrap();
-
-        let builder = Arc::new(builder);
-
-        K2GossipFunctionalTestFactory {
-            space_id: space,
-            builder,
-            ops_stored_sender,
+            },
         }
     }
 
@@ -404,18 +389,33 @@ impl K2GossipFunctionalTestFactory {
         impl TxSpaceHandler for NoopHandler {}
         impl SpaceHandler for NoopHandler {}
 
-        let transport = self
-            .builder
+        let mut builder = default_test_builder().with_default_config().unwrap();
+        // Replace the core builder with a real gossip factory
+        builder.gossip = K2GossipFactory::create();
+
+        if !self.bootstrap {
+            builder.bootstrap = Arc::new(NoopBootstrapFactory);
+        }
+
+        let op_store: GossipOpStore = Default::default();
+        builder.op_store = Arc::new(K2GossipMemOpStoreFactory {
+            store: op_store.clone(),
+        });
+
+        builder.config.set_module_config(&self.config).unwrap();
+
+        let builder = Arc::new(builder);
+
+        let transport = builder
             .transport
-            .create(self.builder.clone(), Arc::new(NoopHandler))
+            .create(builder.clone(), Arc::new(NoopHandler))
             .await
             .unwrap();
 
-        let space = self
-            .builder
+        let space = builder
             .space
             .create(
-                self.builder.clone(),
+                builder.clone(),
                 Arc::new(NoopHandler),
                 self.space_id.clone(),
                 transport.clone(),
@@ -426,197 +426,55 @@ impl K2GossipFunctionalTestFactory {
         let peer_meta_store =
             K2PeerMetaStore::new(space.peer_meta_store().clone());
 
-        if let Some(ref sender) = self.ops_stored_sender {
+        let process_abort_handle = tokio::task::spawn({
+            let op_store = op_store.clone();
             let space = space.clone();
-            let mut receiver = sender.subscribe();
-            tokio::spawn(async move {
-                tracing::info!("Starting ops stored space informer");
-                while let Ok(op_ids) = receiver.recv().await {
-                    space.inform_ops_stored(op_ids).await.unwrap();
-                }
 
-                tracing::info!("Ops stored sender closed");
-            });
-        }
+            async move {
+                loop {
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+
+                    let new_ops = op_store
+                        .read()
+                        .await
+                        .op_list
+                        .iter()
+                        .filter_map(|(op_id, op)| {
+                            if !op.processed {
+                                Some(StoredOp {
+                                    op_id: op_id.clone(),
+                                    created_at: op.created_at,
+                                })
+                            } else {
+                                None
+                            }
+                        })
+                        .collect::<Vec<_>>();
+
+                    if new_ops.is_empty() {
+                        continue;
+                    }
+
+                    space.inform_ops_stored(new_ops.clone()).await.unwrap();
+
+                    let mut write_lock = op_store.write().await;
+                    for op in new_ops {
+                        if let Some(op) = write_lock.op_list.get_mut(&op.op_id)
+                        {
+                            op.processed = true;
+                        }
+                    }
+                }
+            }
+        })
+        .abort_handle();
 
         K2GossipFunctionalTestHarness {
             gossip: space.gossip().clone(),
             space,
+            op_store,
             peer_meta_store: Arc::new(peer_meta_store),
+            process_abort_handle,
         }
-    }
-}
-
-/// A factory for creating [K2GossipMemOpStore] instances.
-#[derive(Debug)]
-pub struct K2GossipMemOpStoreFactory {
-    /// The sender for ops stored events.
-    pub ops_stored: tokio::sync::broadcast::Sender<Vec<StoredOp>>,
-}
-
-impl OpStoreFactory for K2GossipMemOpStoreFactory {
-    fn default_config(&self, _config: &mut Config) -> K2Result<()> {
-        Ok(())
-    }
-
-    fn validate_config(&self, _config: &Config) -> K2Result<()> {
-        Ok(())
-    }
-
-    fn create(
-        &self,
-        _builder: Arc<Builder>,
-        space: SpaceId,
-    ) -> BoxFut<'static, K2Result<DynOpStore>> {
-        let sender = self.ops_stored.clone();
-        Box::pin(async move {
-            let op_store: DynOpStore =
-                Arc::new(K2GossipMemOpStore::create(space, sender));
-            Ok(op_store)
-        })
-    }
-}
-
-/// A K2Gossip specialization of the [Kitsune2MemoryOpStore].
-///
-/// This implementation deliberately breaks the op store contract by storing ops with their
-/// "stored at" time set to the "create at" time of the op. This allows gossip tests to create
-/// historical data that won't immediately be synced by the "what's new" mechanism.
-///
-/// The other behaviour change is that this op store can automatically notify the space when ops
-/// are stored, os the DHT model can be updated immediately.
-#[derive(Debug)]
-pub struct K2GossipMemOpStore {
-    inner: Kitsune2MemoryOpStore,
-    ops_stored: tokio::sync::broadcast::Sender<Vec<StoredOp>>,
-}
-
-impl K2GossipMemOpStore {
-    /// Create a new K2GossipMemOpStore.
-    pub fn create(
-        space_id: SpaceId,
-        ops_stored: tokio::sync::broadcast::Sender<Vec<StoredOp>>,
-    ) -> Self {
-        Self {
-            inner: Kitsune2MemoryOpStore::new(space_id),
-            ops_stored,
-        }
-    }
-}
-
-impl OpStore for K2GossipMemOpStore {
-    fn process_incoming_ops(
-        &self,
-        op_list: Vec<Bytes>,
-    ) -> BoxFut<'_, K2Result<Vec<OpId>>> {
-        Box::pin(async move {
-            let ops_to_add = op_list
-                .iter()
-                .map(|op| -> serde_json::Result<(OpId, MemoryOpRecord)> {
-                    let mut op = MemoryOpRecord::from(op.clone());
-
-                    // Behaviour difference from the inner implementation.
-                    op.stored_at = op.created_at;
-
-                    Ok((op.op_id.clone(), op))
-                })
-                .collect::<Result<Vec<_>, _>>().map_err(|e| {
-                K2Error::other_src("Failed to deserialize op data, are you using `Kitsune2MemoryOp`s?", e)
-            })?;
-
-            let mut op_ids = Vec::with_capacity(ops_to_add.len());
-            let mut newly_stored = Vec::with_capacity(ops_to_add.len());
-            let mut lock = self.inner.write().await;
-            for (op_id, record) in ops_to_add {
-                lock.op_list.entry(op_id.clone()).or_insert_with(|| {
-                    newly_stored.push(StoredOp {
-                        op_id: op_id.clone(),
-                        created_at: record.created_at,
-                    });
-                    record
-                });
-                op_ids.push(op_id);
-            }
-
-            // Notify the space that the ops have been stored.
-            // This is also a deviation from the inner implementation.
-            if !newly_stored.is_empty() {
-                if let Err(err) = self.ops_stored.send(newly_stored) {
-                    tracing::warn!(
-                        ?err,
-                        "Failed to send ops stored notification"
-                    );
-                }
-            }
-
-            Ok(op_ids)
-        })
-    }
-
-    fn retrieve_op_hashes_in_time_slice(
-        &self,
-        arc: DhtArc,
-        start: Timestamp,
-        end: Timestamp,
-    ) -> BoxFut<'_, K2Result<(Vec<OpId>, u32)>> {
-        self.inner.retrieve_op_hashes_in_time_slice(arc, start, end)
-    }
-
-    fn retrieve_ops(
-        &self,
-        op_ids: Vec<OpId>,
-    ) -> BoxFut<'_, K2Result<Vec<MetaOp>>> {
-        self.inner.retrieve_ops(op_ids)
-    }
-
-    fn filter_out_existing_ops(
-        &self,
-        op_ids: Vec<OpId>,
-    ) -> BoxFut<'_, K2Result<Vec<OpId>>> {
-        self.inner.filter_out_existing_ops(op_ids)
-    }
-
-    fn retrieve_op_ids_bounded(
-        &self,
-        arc: DhtArc,
-        start: Timestamp,
-        limit_bytes: u32,
-    ) -> BoxFut<'_, K2Result<(Vec<OpId>, u32, Timestamp)>> {
-        self.inner.retrieve_op_ids_bounded(arc, start, limit_bytes)
-    }
-
-    fn earliest_timestamp_in_arc(
-        &self,
-        arc: DhtArc,
-    ) -> BoxFut<'_, K2Result<Option<Timestamp>>> {
-        self.inner.earliest_timestamp_in_arc(arc)
-    }
-
-    fn store_slice_hash(
-        &self,
-        arc: DhtArc,
-        slice_index: u64,
-        slice_hash: Bytes,
-    ) -> BoxFut<'_, K2Result<()>> {
-        self.inner.store_slice_hash(arc, slice_index, slice_hash)
-    }
-
-    fn slice_hash_count(&self, arc: DhtArc) -> BoxFut<'_, K2Result<u64>> {
-        self.inner.slice_hash_count(arc)
-    }
-
-    fn retrieve_slice_hash(
-        &self,
-        arc: DhtArc,
-        slice_index: u64,
-    ) -> BoxFut<'_, K2Result<Option<Bytes>>> {
-        self.inner.retrieve_slice_hash(arc, slice_index)
-    }
-
-    fn retrieve_slice_hashes(
-        &self,
-        arc: DhtArc,
-    ) -> BoxFut<'_, K2Result<Vec<(u64, Bytes)>>> {
-        self.inner.retrieve_slice_hashes(arc)
     }
 }

--- a/crates/gossip/src/respond/accept.rs
+++ b/crates/gossip/src/respond/accept.rs
@@ -130,6 +130,8 @@ impl K2Gossip {
                     DhtSnapshotNextAction::NewSnapshot(snapshot) => {
                         match snapshot {
                             DhtSnapshot::DiscSectors { .. } => {
+                                tracing::info!(?accept.session_id, "Found a disc mismatch, starting to compare sectors");
+
                                 if let Some(state) = lock.as_mut() {
                                     state.stage = RoundStage::DiscSectorsDiff(
                                         RoundStageDiscSectorsDiff {
@@ -147,6 +149,8 @@ impl K2Gossip {
                                 )))
                             }
                             DhtSnapshot::RingSectorDetails { .. } => {
+                                tracing::info!(?accept.session_id, "Found a ring sector details mismatch, starting to compare ring sectors");
+
                                 if let Some(state) = lock.as_mut() {
                                     state.stage =
                                         RoundStage::RingSectorDetailsDiff(

--- a/crates/gossip/tests/historical_load.rs
+++ b/crates/gossip/tests/historical_load.rs
@@ -103,7 +103,7 @@ async fn historical_load() {
     let agent_2 = harness_2.join_local_agent(DhtArc::FULL).await;
 
     harness_1
-        .wait_for_ops_discovered(&harness_2, Duration::from_secs(60))
+        .wait_for_ops_discovered(&harness_2, Duration::from_secs(120))
         .await;
 
     let completed_rounds_with_agent_2 = harness_1

--- a/crates/gossip/tests/historical_load.rs
+++ b/crates/gossip/tests/historical_load.rs
@@ -51,8 +51,8 @@ async fn historical_load() {
 
     tracing::info!("Creating test data");
 
-    // Create an op every 6 hours for a year
-    let mut ops = Vec::<Bytes>::with_capacity(4 * 365);
+    // Create an op every 12 hours for a year
+    let mut ops = Vec::<Bytes>::with_capacity(2 * 365);
     while time < stop_time {
         let op_size = rand::random::<usize>()
             % (MAX_OP_SIZE_BYTES - MIN_OP_SIZE_BYTES)
@@ -61,7 +61,7 @@ async fn historical_load() {
         let op = MemoryOp::new(time, random_bytes(op_size as u16));
         ops.push(op.into());
 
-        time += Duration::from_secs(60 * 60 * 6);
+        time += Duration::from_secs(60 * 60 * 12);
     }
 
     let total_size = ops.iter().map(|op| op.len()).sum::<usize>();

--- a/crates/gossip/tests/historical_load.rs
+++ b/crates/gossip/tests/historical_load.rs
@@ -104,7 +104,7 @@ async fn historical_load() {
     let agent_2 = harness_2.join_local_agent(DhtArc::FULL).await;
 
     harness_1
-        .wait_for_ops_discovered(&harness_2, Duration::from_secs(120))
+        .wait_for_ops_discovered(&harness_2, Duration::from_secs(180))
         .await;
 
     let completed_rounds_with_agent_2 = harness_1

--- a/crates/gossip/tests/historical_load.rs
+++ b/crates/gossip/tests/historical_load.rs
@@ -8,7 +8,7 @@ use kitsune2_core::factories::MemoryOp;
 use kitsune2_gossip::harness::K2GossipFunctionalTestFactory;
 use kitsune2_gossip::K2GossipConfig;
 use kitsune2_test_utils::space::TEST_SPACE_ID;
-use kitsune2_test_utils::{enable_tracing, random_bytes};
+use kitsune2_test_utils::{enable_tracing_with_default_level, random_bytes};
 use std::time::Duration;
 
 /// The minimum size of an op in bytes.
@@ -22,7 +22,8 @@ const MAX_OP_SIZE_BYTES: usize = 1024 * 1024;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn historical_load() {
-    enable_tracing();
+    // We want less logging in this test, it create a lot of output at debug level.
+    enable_tracing_with_default_level(tracing::Level::INFO);
 
     let factory = K2GossipFunctionalTestFactory::create(
         TEST_SPACE_ID,

--- a/crates/test_utils/src/lib.rs
+++ b/crates/test_utils/src/lib.rs
@@ -13,11 +13,16 @@ pub mod space;
 ///
 /// This is intended to be used in tests, so it defaults to DEBUG level.
 pub fn enable_tracing() {
+    enable_tracing_with_default_level(tracing::Level::DEBUG);
+}
+
+/// Enable tracing with the RUST_LOG environment variable.
+pub fn enable_tracing_with_default_level(level: tracing::Level) {
     let _ = tracing_subscriber::fmt()
         .with_test_writer()
         .with_env_filter(
             tracing_subscriber::EnvFilter::builder()
-                .with_default_directive(tracing::Level::DEBUG.into())
+                .with_default_directive(level.into())
                 .from_env_lossy(),
         )
         .try_init();


### PR DESCRIPTION
I think this is a more useful way of doing the check. The local agent we're sending to might have left the space and won't be in the local agent store but we still want to avoid sending to ourselves. 

I started looking at why the historical sync test was flaky. It turns out it was really not doing what it was supposed to do and I found some issues along the way. See the inline comments.