### PR TITLE
refactor(bootstrap): move server address logging to binary

### DIFF
--- a/crates/bootstrap_srv/src/bin/kitsune2-bootstrap-srv.rs
+++ b/crates/bootstrap_srv/src/bin/kitsune2-bootstrap-srv.rs
@@ -157,6 +157,10 @@ fn main() {
 
     let srv = BootstrapSrv::new(config);
 
+    if let Ok(ref server) = srv{
+        server.print_addrs();
+    }
+
     let _ = recv.recv();
 
     tracing::info!("Terminating...");

--- a/crates/bootstrap_srv/src/bin/kitsune2-bootstrap-srv.rs
+++ b/crates/bootstrap_srv/src/bin/kitsune2-bootstrap-srv.rs
@@ -157,7 +157,7 @@ fn main() {
 
     let srv = BootstrapSrv::new(config);
 
-    if let Ok(ref server) = srv{
+    if let Ok(ref server) = srv {
         server.print_addrs();
     }
 

--- a/crates/bootstrap_srv/src/server.rs
+++ b/crates/bootstrap_srv/src/server.rs
@@ -78,11 +78,6 @@ impl BootstrapSrv {
         // get the address that was assigned
         let addrs = server.server_addrs().to_vec();
         tracing::info!(?addrs, "Listening");
-        for addr in addrs.iter() {
-            // print these incase someone wants to parse for them
-            println!("#kitsune2_bootstrap_srv#listening#{addr:?}#");
-        }
-        println!("#kitsune2_bootstrap_srv#running#");
 
         // spawn our worker threads
         let mut workers = Vec::with_capacity(config.worker_thread_count + 1);
@@ -138,6 +133,15 @@ impl BootstrapSrv {
     /// Get the bound listening addresses of this server.
     pub fn listen_addrs(&self) -> &[std::net::SocketAddr] {
         self.addrs.as_slice()
+    }
+
+    /// Print the address server started on
+    pub fn print_addrs(&self) {
+        println!("#kitsune2_bootstrap_srv#running#");
+        for addr in self.addrs.iter() {
+            // print these incase someone wants to parse for them
+            println!("#kitsune2_bootstrap_srv#listening#{addr:?}#");
+        }
     }
 }
 


### PR DESCRIPTION
#131 
When the bootstrap server is embedded as a library, it currently prints the server address on startup, which is not desirable for library users.
