### PR TITLE
chore: Fix feature logic for automock

### DIFF
--- a/crates/api/src/op_store.rs
+++ b/crates/api/src/op_store.rs
@@ -5,8 +5,6 @@ use crate::{
 };
 use bytes::Bytes;
 use futures::future::BoxFuture;
-#[cfg(feature = "mockall")]
-use mockall::automock;
 use std::cmp::Ordering;
 use std::sync::Arc;
 
@@ -66,7 +64,7 @@ impl PartialOrd for StoredOp {
 }
 
 /// The API that a kitsune2 host must implement to provide data persistence for kitsune2.
-#[cfg_attr(any(test, feature = "mockall"), automock)]
+#[cfg_attr(any(test, feature = "mockall"), mockall::automock)]
 pub trait OpStore: 'static + Send + Sync + std::fmt::Debug {
     /// Process incoming ops.
     ///

--- a/crates/api/src/transport.rs
+++ b/crates/api/src/transport.rs
@@ -1,8 +1,6 @@
 //! Kitsune2 transport related types.
 
 use crate::{protocol::*, *};
-#[cfg(feature = "mockall")]
-use mockall::automock;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex, Weak};
@@ -165,7 +163,7 @@ pub trait TxImp: 'static + Send + Sync + std::fmt::Debug {
 pub type DynTxImp = Arc<dyn TxImp>;
 
 /// A high-level wrapper around a low-level [DynTxImp] transport implementation.
-#[cfg_attr(any(test, feature = "mockall"), automock)]
+#[cfg_attr(any(test, feature = "mockall"), mockall::automock)]
 pub trait Transport: 'static + Send + Sync + std::fmt::Debug {
     /// Register a space handler for receiving incoming notifications.
     ///


### PR DESCRIPTION
Took me a while to realize why my IDE wasn't letting me navigate around the types with this annotation. We have different logic for when the import is available vs. the attribute applied. That is actually wrong, running the tests without that feature would be broken and it's fair enough that my IDE complains it can't find the import.