### PR TITLE
chore: use Google STUN

### DIFF
--- a/crates/kitsune2_showcase/src/app.rs
+++ b/crates/kitsune2_showcase/src/app.rs
@@ -93,10 +93,7 @@ impl App {
                     webrtc_config: WebRtcConfig {
                         ice_servers: vec![IceServers {
                             urls: vec![
-                                "stun:stun-0.main.infra.holo.host:443"
-                                    .to_string(),
-                                "stun:stun-1.main.infra.holo.host:443"
-                                    .to_string(),
+                                "stun://stun.l.google.com:19302".to_string()
                             ],
                             username: None,
                             credential: None,


### PR DESCRIPTION
We've observed during testing that the Holo STUN servers are reporting unusable ICE candidates for some users. The Google STUN server does a much better job of getting people connected.

People are free to configure other WebRTC settings, but this is a more reliable default for development and testing.