### PR TITLE
chore: add rust-analyzer as a toolchain component

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
 channel = "1.85.0"
-components = ["rustfmt", "clippy"]
+components = ["rustfmt", "clippy", "rust-analyzer"]
 profile = "minimal"


### PR DESCRIPTION
After switching to using `rustup` in the Nix devShell, in #213, the `rust-analyzer` from `rustup` is being invoked by my LSP. I don't see the harm in adding it as a component, but let me know if it causes problems and I'll just force my editor to use a different one.