### PR TITLE
bug fix and auth test binding change

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2821,9 +2821,9 @@ dependencies = [
 
 [[package]]
 name = "sbd-client"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b452ee98b4f998c06974eb8d76adb15c8ee690eee909502d97320b137004500"
+checksum = "b6fbb93bf789bd1a24deed43931e46d1280c1b97d343eba7e5db28890e2c419c"
 dependencies = [
  "base64",
  "ed25519-dalek",
@@ -2844,9 +2844,9 @@ dependencies = [
 
 [[package]]
 name = "sbd-e2e-crypto-client"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80c29c3ca89b21e2ce97249cd0976ddd9190ebbb41b5ac7d97aad96c0bf493e5"
+checksum = "0d97d0056c4c2826c48b8bbd94b65e35234800cda25c3a636d9cd81b28e4a102"
 dependencies = [
  "bytes",
  "sbd-client",
@@ -2857,9 +2857,9 @@ dependencies = [
 
 [[package]]
 name = "sbd-server"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a04b28404386ab199a7a588eae490eefcdead523779db5b65e05562f1128123"
+checksum = "66c65a7965b49c516a8a779bbad378ad1077cfd631b56ed1340623f2158214f8"
 dependencies = [
  "anstyle",
  "axum 0.8.4",
@@ -2872,6 +2872,7 @@ dependencies = [
  "rand 0.8.5",
  "rustls",
  "rustls-pemfile",
+ "serde",
  "serde_json",
  "slab",
  "tokio",
@@ -3552,9 +3553,9 @@ dependencies = [
 
 [[package]]
 name = "tx5"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ccd157ac19af148d622c5db1c28932f51e88429d608e5722dc7f5075e0c9101"
+checksum = "64e30ac79e042ea8342a28ba7bc191bea03823a22d8c74cb266cea46e72bec57"
 dependencies = [
  "base64",
  "futures",
@@ -3570,9 +3571,9 @@ dependencies = [
 
 [[package]]
 name = "tx5-connection"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a74eef5d805227321dd68030141d7373b4d22dc018aadf84d1fe761550d1cb72"
+checksum = "0920d5196e386dc2f99573b25a3c5023054446975a0f19bde99d5ae812ea482d"
 dependencies = [
  "bit_field",
  "datachannel",
@@ -3588,9 +3589,9 @@ dependencies = [
 
 [[package]]
 name = "tx5-core"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29768572a247f1bcd6048cf6d34b808408b01a4b0610a08c2bf4e3c9eb2c29f0"
+checksum = "c7168c24343e244c9513089d03116aecdf96eda95cb9edc4de81dc72d1bd933d"
 dependencies = [
  "app_dirs2",
  "base64",
@@ -3606,9 +3607,9 @@ dependencies = [
 
 [[package]]
 name = "tx5-signal"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22399b41623c926953f95c53e09d49f0d0054f1169a333c18647f59c3cf0d54"
+checksum = "5a8b450b2b8b76f7e8ce4a30804a82dd9a3e30e04fc4ca14768ea393d07e20e8"
 dependencies = [
  "rand 0.8.5",
  "sbd-e2e-crypto-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,15 +90,15 @@ url = "2.5.4"
 # to receive these logs.
 tracing = "0.1"
 # for init config
-tx5-core = "0.4.2"
+tx5-core = "0.4.3"
 # for the transport_tx5 crate
-tx5 = { version = "0.4.2", default-features = false }
+tx5 = { version = "0.4.3", default-features = false }
 # TLS support for the bootstrap server
 axum-server = { version = "0.7.1", default-features = false }
 # TLS support for the bootstrap server
 rustls = { version = "0.23", default-features = false }
 # embedded in the bootstrap server and to test the tx5 integration
-sbd-server = { version = "0.3.0" }
+sbd-server = { version = "0.3.1" }
 # axum-server integration with the SBD server
 tokio-rustls = "0.26"
 # for generating JSON schemas to help with checking configuration
@@ -122,7 +122,7 @@ kitsune2_core = { version = "0.2.4", path = "crates/core" }
 kitsune2_test_utils = { version = "0.2.4", path = "crates/test_utils" }
 
 # used to test the bootstrap server with SBD enabled
-sbd-client = "0.3.0"
+sbd-client = "0.3.1"
 
 # used to hash op data
 sha2 = "0.10.8"

--- a/crates/bootstrap_srv/examples/test-auth-hook-server.rs
+++ b/crates/bootstrap_srv/examples/test-auth-hook-server.rs
@@ -3,12 +3,13 @@ use rand::Rng;
 
 #[tokio::main]
 async fn main() {
-    const USAGE: &str = "usage: test-auth-hook-server <port>";
+    const USAGE: &str = "usage: test-auth-hook-server <0.0.0.0:0>";
     let mut arg_iter = std::env::args();
     arg_iter.next().expect(USAGE);
-    let port: u16 = arg_iter.next().expect(USAGE).parse().expect(USAGE);
+    let bind: std::net::SocketAddr =
+        arg_iter.next().expect(USAGE).parse().expect(USAGE);
 
-    println!("#STARTUP_PORT#{port}#");
+    println!("#STARTUP_AT#{bind}#");
 
     async fn handle_auth(body: bytes::Bytes) -> axum::response::Response {
         if &body[..] != b"valid" {
@@ -34,7 +35,7 @@ async fn main() {
     let h2 = h.clone();
 
     let task = tokio::task::spawn(async move {
-        axum_server::bind(([127, 0, 0, 1], port).into())
+        axum_server::bind(bind)
             .handle(h2)
             .serve(app.into_make_service_with_connect_info::<std::net::SocketAddr>())
             .await


### PR DESCRIPTION
Bumps SBD to a version that doesn't double up the "authToken", and updates the auth test hook server to take a full ip:port so we can choose the interface it binds on.