### PR TITLE
fix authorization

### DIFF
--- a/crates/bootstrap_srv/src/sbd.rs
+++ b/crates/bootstrap_srv/src/sbd.rs
@@ -155,7 +155,7 @@ pub async fn handle_sbd(
     State(state): State<AppState>,
 ) -> impl IntoResponse {
     let token: Option<Arc<str>> = headers
-        .get("Authenticate")
+        .get("Authorization")
         .and_then(|t| t.to_str().ok().map(<Arc<str>>::from));
 
     let maybe_auth = Some((token.clone(), state.token_tracker.clone()));


### PR DESCRIPTION
Apparently I missed one of these. Technically now that it's fixed, it is tested... in the sense that the server in no-hook mode was ignoring the correct header and not even running the token logic, and now will actually run it, and the tests pass.

It seems unlikely that somebody would somehow misspell this again in a future PR so it didn't seem worthy of a regression test, but let me know if you feel differently.