### PR TITLE
feat(api)!: add get/set to mark peer unresponsive in peer meta store

### DIFF
--- a/crates/api/src/peer_meta_store.rs
+++ b/crates/api/src/peer_meta_store.rs
@@ -1,4 +1,5 @@
 use crate::{builder, config, BoxFut, K2Result, Timestamp, Url};
+use bytes::Bytes;
 use futures::future::BoxFuture;
 use std::sync::Arc;
 
@@ -6,21 +7,34 @@ use std::sync::Arc;
 ///
 /// This is expected to be backed by a key-value store that keys by space, peer URL and key.
 pub trait PeerMetaStore: 'static + Send + Sync + std::fmt::Debug {
-    /// Store a key-value pair for a given space and peer.
+    /// Store a key-value pair for a peer.
     fn put(
         &self,
         peer: Url,
         key: String,
-        value: bytes::Bytes,
+        value: Bytes,
         expiry: Option<Timestamp>,
     ) -> BoxFuture<'_, K2Result<()>>;
 
-    /// Get a value by key for a given space and peer.
+    /// Get a value by key for a peer.
     fn get(
         &self,
         peer: Url,
         key: String,
     ) -> BoxFuture<'_, K2Result<Option<bytes::Bytes>>>;
+
+    /// Mark a peer url unresponsive with an expiration timestamp.
+    ///
+    /// After the expiry timestamp has passed, the peer url is supposed to be removed
+    /// from the store.
+    fn mark_peer_unresponsive(
+        &self,
+        peer: Url,
+        expiry: Timestamp,
+    ) -> BoxFuture<'_, K2Result<()>>;
+
+    /// Check if a peer is marked unresponsive in the store.
+    fn is_peer_unresponsive(&self, peer: Url) -> BoxFuture<'_, K2Result<bool>>;
 
     /// Delete a key-value pair for a given space and peer.
     fn delete(&self, peer: Url, key: String) -> BoxFuture<'_, K2Result<()>>;

--- a/crates/core/src/factories/mem_peer_meta_store.rs
+++ b/crates/core/src/factories/mem_peer_meta_store.rs
@@ -1,8 +1,11 @@
+use bytes::Bytes;
 use futures::future::BoxFuture;
 use kitsune2_api::*;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
+
+const KEY_PREFIX: &str = "root";
 
 #[cfg(test)]
 mod test;
@@ -51,6 +54,27 @@ impl PeerMetaStore for MemPeerMetaStore {
         Box::pin(async move {
             let inner = inner.lock().await;
             Ok(inner.get(&peer).and_then(|entry| entry.get(&key).cloned()))
+        })
+    }
+
+    fn mark_peer_unresponsive(
+        &self,
+        peer: Url,
+        expiry: Timestamp,
+    ) -> BoxFuture<'_, K2Result<()>> {
+        self.put(
+            peer,
+            format!("{KEY_PREFIX}:unresponsive"),
+            Bytes::new(),
+            Some(expiry),
+        )
+    }
+
+    fn is_peer_unresponsive(&self, peer: Url) -> BoxFuture<'_, K2Result<bool>> {
+        Box::pin(async move {
+            self.get(peer, format!("{KEY_PREFIX}:unresponsive"))
+                .await
+                .map(|r| r.is_some())
         })
     }
 

--- a/crates/core/src/factories/mem_peer_meta_store/test.rs
+++ b/crates/core/src/factories/mem_peer_meta_store/test.rs
@@ -105,3 +105,30 @@ async fn store_with_multiple_agents() {
         Some(timestamp_2)
     );
 }
+
+#[tokio::test]
+async fn store_unresponsive_peer() {
+    let factory = MemPeerMetaStoreFactory::create();
+    let store = factory
+        .create(
+            Arc::new(default_test_builder().with_default_config().unwrap()),
+            kitsune2_test_utils::space::TEST_SPACE_ID.clone(),
+        )
+        .await
+        .unwrap();
+
+    let peer = Url::from_str("ws://test-host:80/1").unwrap();
+
+    let is_peer_unresponsive =
+        store.is_peer_unresponsive(peer.clone()).await.unwrap();
+    assert!(!is_peer_unresponsive);
+
+    store
+        .mark_peer_unresponsive(peer.clone(), Timestamp::now())
+        .await
+        .unwrap();
+
+    let is_peer_unresponsive =
+        store.is_peer_unresponsive(peer.clone()).await.unwrap();
+    assert!(is_peer_unresponsive);
+}


### PR DESCRIPTION
Part 1 of #42, which adds methods to the peer meta store to mark and check unresponsive peers, with default implementations.

Added simple test that uses these new methods.