### PR TITLE
Move long tx5 transport test to integration tests

### DIFF
--- a/crates/kitsune2/Cargo.toml
+++ b/crates/kitsune2/Cargo.toml
@@ -19,7 +19,7 @@ bytes = { workspace = true }
 kitsune2_api = { workspace = true }
 kitsune2_core = { workspace = true }
 kitsune2_gossip = { workspace = true }
-kitsune2_transport_tx5 = { workspace = true }
+kitsune2_transport_tx5 = { workspace = true, features = ["test-utils"] }
 serde = { workspace = true, features = ["derive"] }
 
 # Feature: schema

--- a/crates/kitsune2/tests/integration.rs
+++ b/crates/kitsune2/tests/integration.rs
@@ -1,8 +1,9 @@
 use bytes::Bytes;
 use kitsune2::default_builder;
 use kitsune2_api::{
-    BoxFut, DhtArc, DynKitsune, DynSpace, DynSpaceHandler, K2Result,
-    KitsuneHandler, LocalAgent, OpId, SpaceHandler, SpaceId, Timestamp,
+    BoxFut, DhtArc, DynInnerError, DynKitsune, DynSpace, DynSpaceHandler,
+    K2Error, K2Result, KitsuneHandler, LocalAgent, OpId, SpaceHandler, SpaceId,
+    Timestamp, Url,
 };
 use kitsune2_core::{
     factories::{
@@ -16,11 +17,12 @@ use kitsune2_test_utils::{
     bootstrap::TestBootstrapSrv, enable_tracing, iter_check, random_bytes,
     space::TEST_SPACE_ID,
 };
-use kitsune2_transport_tx5::config::{
-    Tx5TransportConfig, Tx5TransportModConfig,
+use kitsune2_transport_tx5::{
+    config::{Tx5TransportConfig, Tx5TransportModConfig},
+    harness::{MockTxHandler, Tx5TransportTestHarness},
 };
 use sbd_server::SbdServer;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 fn create_op_list(num_ops: u16) -> (Vec<Bytes>, Vec<OpId>) {
     let mut ops = Vec::new();
@@ -355,4 +357,121 @@ async fn shutdown_space() {
     // The spaces should be gone.
     assert!(kitsune_1.space_if_exists(TEST_SPACE_ID).await.is_none());
     assert!(kitsune_2.space_if_exists(TEST_SPACE_ID).await.is_none());
+}
+
+/// Tests that a peer that goes offline gets marked unresponsive by the
+/// transport_tx5 module when a message is unsuccessfully attempted to be sent
+/// to it.
+///
+/// This test has been moved to integration tests because it's slow (~10 seconds).
+#[tokio::test(flavor = "multi_thread")]
+async fn offline_peer_marked_unresponsive() {
+    // set the tx5 timeout to 5 seconds to keep the test reasonably short
+    let test = Tx5TransportTestHarness::new(None, Some(5)).await;
+
+    let (unresp_send, mut unresp_recv) = tokio::sync::mpsc::unbounded_channel();
+
+    let url1 =
+        Arc::new(Mutex::new(Url::from_str("ws://bla.bla:38/1").unwrap()));
+    let url1_2 = url1.clone();
+    let tx_handler1 = Arc::new(MockTxHandler {
+        new_addr: Arc::new(move |url| {
+            *url1_2.lock().unwrap() = url;
+        }),
+        set_unresp: Arc::new({
+            move |url, when| {
+                unresp_send.send((url, when)).map_err(|_| K2Error::Other {
+                    ctx: "Failed to send url to oneshot channel".into(),
+                    src: DynInnerError::default(),
+                })
+            }
+        }),
+        ..Default::default()
+    });
+    let transport1 = test.build_transport(tx_handler1.clone()).await;
+    transport1.register_space_handler(TEST_SPACE_ID, tx_handler1.clone());
+    transport1.register_module_handler(
+        TEST_SPACE_ID,
+        "mod".into(),
+        tx_handler1.clone(),
+    );
+
+    let (s_send, mut s_recv) = tokio::sync::mpsc::unbounded_channel();
+    let url2 =
+        Arc::new(Mutex::new(Url::from_str("ws://bla.bla:38/1").unwrap()));
+    let url2_2 = url2.clone();
+    let tx_hanlder2 = Arc::new(MockTxHandler {
+        new_addr: Arc::new(move |url| {
+            *url2_2.lock().unwrap() = url;
+        }),
+        recv_space_not: Arc::new(move |url, space, data| {
+            let _ = s_send.send((url, space, data));
+            Ok(())
+        }),
+        ..Default::default()
+    });
+    let transport2 = test.build_transport(tx_hanlder2.clone()).await;
+    transport2.register_space_handler(TEST_SPACE_ID, tx_hanlder2.clone());
+    transport2.register_module_handler(
+        TEST_SPACE_ID,
+        "mod".into(),
+        tx_hanlder2.clone(),
+    );
+
+    let url2: Url = url2.lock().unwrap().clone();
+    println!("got url2: {}", url2);
+
+    // check that send works initially while peer 2 is still online
+    transport1
+        .send_space_notify(
+            url2.clone(),
+            TEST_SPACE_ID,
+            bytes::Bytes::from_static(b"hello"),
+        )
+        .await
+        .unwrap();
+
+    // checks that recv works
+    let (_, _, bytes) =
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            s_recv.recv().await
+        })
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(b"hello", bytes.as_ref());
+
+    // Check that the peer has not been marked as unresponsive
+    let r = unresp_recv.try_recv();
+    assert!(r.is_err());
+
+    // Now peer 2 goes offline and we check that it gets marked as unresponsive
+    drop(transport2);
+
+    // We need to wait for a while in order for the webrtc connection to get
+    // disconnected. If this test becomes flaky, this waiting period may need
+    // to be increased a bit.
+    tokio::time::sleep(std::time::Duration::from_secs(9)).await;
+
+    let res = transport1
+        .send_space_notify(
+            url2.clone(),
+            TEST_SPACE_ID,
+            bytes::Bytes::from_static(b"anyone here?"),
+        )
+        .await;
+
+    // We expect it to have timed out because peer 2 is offline now
+    assert!(res.is_err());
+
+    let r = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        unresp_recv.recv().await
+    })
+    .await
+    .unwrap();
+
+    let url = r.unwrap().0;
+
+    assert!(url2 == url);
 }

--- a/crates/transport_tx5/Cargo.toml
+++ b/crates/transport_tx5/Cargo.toml
@@ -25,11 +25,14 @@ url = { workspace = true }
 
 # Feature: schema
 schemars = { workspace = true, optional = true }
+# Feature: test-utils
+kitsune2_test_utils = { workspace = true, optional = true }
+# Feature: test-utils
+sbd-server = { workspace = true, optional = true }
+# Feature: test-utils
+kitsune2_core = { workspace = true, optional = true }
 
 [dev-dependencies]
-kitsune2_core = { workspace = true }
-kitsune2_test_utils = { workspace = true }
-sbd-server = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 
 [features]
@@ -38,3 +41,5 @@ default = ["datachannel-vendored"]
 datachannel-vendored = ["tx5/datachannel-vendored"]
 
 schema = ["dep:schemars", "tx5/schema"]
+
+test-utils = ["dep:kitsune2_test_utils", "dep:sbd-server", "dep:kitsune2_core"]

--- a/crates/transport_tx5/src/harness.rs
+++ b/crates/transport_tx5/src/harness.rs
@@ -1,0 +1,226 @@
+//! tx5 transport module test utilities
+
+use super::*;
+
+/// Test harness for the transport_tx5 module
+pub struct Tx5TransportTestHarness {
+    /// sbd server
+    pub srv: Option<sbd_server::SbdServer>,
+    /// server port
+    pub port: u16,
+    /// kitsune2 builder
+    pub builder: Arc<Builder>,
+}
+
+impl Tx5TransportTestHarness {
+    /// Create a new test harness
+    pub async fn new(
+        auth_material: Option<Vec<u8>>,
+        tx5_timeout_s: Option<u32>,
+    ) -> Self {
+        let mut this = Self {
+            srv: None,
+            port: 0,
+            builder: Arc::new(kitsune2_core::default_test_builder()),
+        };
+
+        // Note the `port: 0` above, so we get a free port the first time.
+        // This restart function will set the port to the actual value.
+        this.restart().await;
+
+        let builder = Builder {
+            auth_material,
+            transport: Tx5TransportFactory::create(),
+            ..kitsune2_core::default_test_builder()
+        };
+
+        builder
+            .config
+            .set_module_config(&config::Tx5TransportModConfig {
+                tx5_transport: config::Tx5TransportConfig {
+                    signal_allow_plain_text: true,
+                    server_url: format!("ws://127.0.0.1:{}", this.port),
+                    timeout_s: tx5_timeout_s.unwrap_or(60),
+                    ..Default::default()
+                },
+            })
+            .unwrap();
+
+        this.builder = Arc::new(builder);
+
+        this
+    }
+
+    /// Restart the sbd server, but re-use the port we first got in our
+    /// constructor so that already configured transports being tested
+    /// will be able to find the server automatically again.
+    ///
+    /// There is a small chance something else could grab the port
+    /// in the mean time, and this will error/flake.
+    pub async fn restart(&mut self) {
+        std::mem::drop(self.srv.take());
+
+        let mut srv = None;
+
+        let mut wait_ms = 250;
+        for _ in 0..5 {
+            srv = sbd_server::SbdServer::new(Arc::new(sbd_server::Config {
+                bind: vec![format!("127.0.0.1:{}", self.port)],
+                limit_clients: 100,
+                disable_rate_limiting: true,
+                ..Default::default()
+            }))
+            .await
+            .ok();
+
+            if srv.is_some() {
+                break;
+            }
+
+            // allow time for the original port to be cleaned up
+            tokio::time::sleep(std::time::Duration::from_millis(wait_ms)).await;
+            wait_ms *= 2;
+        }
+
+        if srv.is_none() {
+            panic!("could not start sbd server on port {}", self.port);
+        }
+
+        self.port = srv.as_ref().unwrap().bind_addrs().first().unwrap().port();
+        self.srv = srv;
+    }
+
+    /// Build a Transport trait implementation
+    pub async fn build_transport(&self, handler: DynTxHandler) -> DynTransport {
+        self.builder
+            .transport
+            .create(self.builder.clone(), handler)
+            .await
+            .unwrap()
+    }
+}
+
+/// A mock handler that implements the various TxHandler traits
+pub struct MockTxHandler {
+    /// Mock function to implement the new_listening_address() method of the
+    /// TxBaseHandler trait
+    pub new_addr: Arc<dyn Fn(Url) + 'static + Send + Sync>,
+    /// Mock function to implement the peer_connection() method of the
+    /// TxBaseHandler trait
+    pub peer_con: Arc<dyn Fn(Url) -> K2Result<()> + 'static + Send + Sync>,
+    /// Mock function to implement the peer_disconnection() method of the
+    /// TxBaseHandler trait
+    pub peer_dis: Arc<dyn Fn(Url, Option<String>) + 'static + Send + Sync>,
+    /// Mock function to implement the preflight_gather_outgoing() method of
+    /// the TxHandler trait
+    pub pre_out:
+        Arc<dyn Fn(Url) -> K2Result<bytes::Bytes> + 'static + Send + Sync>,
+    /// Mock function to implement the preflight_validate_incoming() method of
+    /// the TxHandler trait
+    pub pre_in:
+        Arc<dyn Fn(Url, bytes::Bytes) -> K2Result<()> + 'static + Send + Sync>,
+    /// Mock function to implement the recv_space_notify() method of the
+    /// TxSpaceHandler trait
+    pub recv_space_not: Arc<
+        dyn Fn(Url, SpaceId, bytes::Bytes) -> K2Result<()>
+            + 'static
+            + Send
+            + Sync,
+    >,
+    /// Mock function to implement the set_unresponsive() method of the
+    /// TxSpaceHandler trait
+    pub set_unresp:
+        Arc<dyn Fn(Url, Timestamp) -> K2Result<()> + 'static + Send + Sync>,
+    /// Mock function to implement the recv_module_msg() method of the
+    /// TxModuleHandler trait
+    pub recv_mod_msg: Arc<
+        dyn Fn(Url, SpaceId, String, bytes::Bytes) -> K2Result<()>
+            + 'static
+            + Send
+            + Sync,
+    >,
+}
+
+impl std::fmt::Debug for MockTxHandler {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MockTxHandler").finish()
+    }
+}
+
+impl Default for MockTxHandler {
+    fn default() -> Self {
+        Self {
+            new_addr: Arc::new(|_| {}),
+            peer_con: Arc::new(|_| Ok(())),
+            peer_dis: Arc::new(|_, _| {}),
+            pre_out: Arc::new(|_| Ok(bytes::Bytes::new())),
+            pre_in: Arc::new(|_, _| Ok(())),
+            recv_space_not: Arc::new(|_, _, _| Ok(())),
+            set_unresp: Arc::new(|_, _| Ok(())),
+            recv_mod_msg: Arc::new(|_, _, _, _| Ok(())),
+        }
+    }
+}
+
+impl TxBaseHandler for MockTxHandler {
+    fn new_listening_address(&self, this_url: Url) -> BoxFut<'static, ()> {
+        (self.new_addr)(this_url);
+        Box::pin(async {})
+    }
+
+    fn peer_connect(&self, peer: Url) -> K2Result<()> {
+        (self.peer_con)(peer)
+    }
+
+    fn peer_disconnect(&self, peer: Url, reason: Option<String>) {
+        (self.peer_dis)(peer, reason)
+    }
+}
+
+impl TxHandler for MockTxHandler {
+    fn preflight_gather_outgoing(
+        &self,
+        peer_url: Url,
+    ) -> K2Result<bytes::Bytes> {
+        (self.pre_out)(peer_url)
+    }
+
+    fn preflight_validate_incoming(
+        &self,
+        peer_url: Url,
+        data: bytes::Bytes,
+    ) -> K2Result<()> {
+        (self.pre_in)(peer_url, data)
+    }
+}
+
+impl TxSpaceHandler for MockTxHandler {
+    fn recv_space_notify(
+        &self,
+        peer: Url,
+        space: SpaceId,
+        data: bytes::Bytes,
+    ) -> K2Result<()> {
+        (self.recv_space_not)(peer, space, data)
+    }
+
+    fn set_unresponsive(
+        &self,
+        peer: Url,
+        when: Timestamp,
+    ) -> BoxFut<'_, K2Result<()>> {
+        Box::pin(async move { (self.set_unresp)(peer, when) })
+    }
+}
+
+impl TxModuleHandler for MockTxHandler {
+    fn recv_module_msg(
+        &self,
+        peer: Url,
+        space: SpaceId,
+        module: String,
+        data: bytes::Bytes,
+    ) -> K2Result<()> {
+        (self.recv_mod_msg)(peer, space, module, data)
+    }
+}

--- a/crates/transport_tx5/src/lib.rs
+++ b/crates/transport_tx5/src/lib.rs
@@ -460,5 +460,7 @@ async fn evt_task(
     }
 }
 
+#[cfg(any(test, feature = "test-utils"))]
+pub mod harness;
 #[cfg(test)]
-mod test;
+pub mod test;

--- a/crates/transport_tx5/src/test.rs
+++ b/crates/transport_tx5/src/test.rs
@@ -1,3 +1,7 @@
+//! tx5 transport module tests
+
+use crate::harness::{MockTxHandler, Tx5TransportTestHarness};
+
 use super::*;
 use kitsune2_test_utils::space::TEST_SPACE_ID;
 use std::collections::HashSet;
@@ -14,205 +18,6 @@ use std::sync::Mutex;
 // - That preflight generation and checking work, which are a little weird
 //   because in kitsune2 the check logic is handled in the same recv_data
 //   callback, where tx5 handles it as a special callback.
-
-struct Test {
-    pub srv: Option<sbd_server::SbdServer>,
-    pub port: u16,
-    pub builder: Arc<Builder>,
-}
-
-impl Test {
-    pub async fn new(
-        auth_material: Option<Vec<u8>>,
-        tx5_timeout_s: Option<u32>,
-    ) -> Self {
-        let mut this = Self {
-            srv: None,
-            port: 0,
-            builder: Arc::new(kitsune2_core::default_test_builder()),
-        };
-
-        // Note the `port: 0` above, so we get a free port the first time.
-        // This restart function will set the port to the actual value.
-        this.restart().await;
-
-        let builder = Builder {
-            auth_material,
-            transport: Tx5TransportFactory::create(),
-            ..kitsune2_core::default_test_builder()
-        };
-
-        builder
-            .config
-            .set_module_config(&config::Tx5TransportModConfig {
-                tx5_transport: config::Tx5TransportConfig {
-                    signal_allow_plain_text: true,
-                    server_url: format!("ws://127.0.0.1:{}", this.port),
-                    timeout_s: tx5_timeout_s.unwrap_or(60),
-                    ..Default::default()
-                },
-            })
-            .unwrap();
-
-        this.builder = Arc::new(builder);
-
-        this
-    }
-
-    /// Restart the sbd server, but re-use the port we first got in our
-    /// constructor so that already configured transports being tested
-    /// will be able to find the server automatically again.
-    ///
-    /// There is a small chance something else could grab the port
-    /// in the mean time, and this will error/flake.
-    pub async fn restart(&mut self) {
-        std::mem::drop(self.srv.take());
-
-        let mut srv = None;
-
-        let mut wait_ms = 250;
-        for _ in 0..5 {
-            srv = sbd_server::SbdServer::new(Arc::new(sbd_server::Config {
-                bind: vec![format!("127.0.0.1:{}", self.port)],
-                limit_clients: 100,
-                disable_rate_limiting: true,
-                ..Default::default()
-            }))
-            .await
-            .ok();
-
-            if srv.is_some() {
-                break;
-            }
-
-            // allow time for the original port to be cleaned up
-            tokio::time::sleep(std::time::Duration::from_millis(wait_ms)).await;
-            wait_ms *= 2;
-        }
-
-        if srv.is_none() {
-            panic!("could not start sbd server on port {}", self.port);
-        }
-
-        self.port = srv.as_ref().unwrap().bind_addrs().first().unwrap().port();
-        self.srv = srv;
-    }
-
-    pub async fn build_transport(&self, handler: DynTxHandler) -> DynTransport {
-        self.builder
-            .transport
-            .create(self.builder.clone(), handler)
-            .await
-            .unwrap()
-    }
-}
-
-struct CbHandler {
-    new_addr: Arc<dyn Fn(Url) + 'static + Send + Sync>,
-    peer_con: Arc<dyn Fn(Url) -> K2Result<()> + 'static + Send + Sync>,
-    peer_dis: Arc<dyn Fn(Url, Option<String>) + 'static + Send + Sync>,
-    pre_out: Arc<dyn Fn(Url) -> K2Result<bytes::Bytes> + 'static + Send + Sync>,
-    pre_in:
-        Arc<dyn Fn(Url, bytes::Bytes) -> K2Result<()> + 'static + Send + Sync>,
-    recv_space_notify: Arc<
-        dyn Fn(Url, SpaceId, bytes::Bytes) -> K2Result<()>
-            + 'static
-            + Send
-            + Sync,
-    >,
-    set_unresponsive:
-        Arc<dyn Fn(Url, Timestamp) -> K2Result<()> + 'static + Send + Sync>,
-    module: Arc<
-        dyn Fn(Url, SpaceId, String, bytes::Bytes) -> K2Result<()>
-            + 'static
-            + Send
-            + Sync,
-    >,
-}
-
-impl std::fmt::Debug for CbHandler {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("CbHandler").finish()
-    }
-}
-
-impl Default for CbHandler {
-    fn default() -> Self {
-        Self {
-            new_addr: Arc::new(|_| {}),
-            peer_con: Arc::new(|_| Ok(())),
-            peer_dis: Arc::new(|_, _| {}),
-            pre_out: Arc::new(|_| Ok(bytes::Bytes::new())),
-            pre_in: Arc::new(|_, _| Ok(())),
-            recv_space_notify: Arc::new(|_, _, _| Ok(())),
-            set_unresponsive: Arc::new(|_, _| Ok(())),
-            module: Arc::new(|_, _, _, _| Ok(())),
-        }
-    }
-}
-
-impl TxBaseHandler for CbHandler {
-    fn new_listening_address(&self, this_url: Url) -> BoxFut<'static, ()> {
-        (self.new_addr)(this_url);
-        Box::pin(async {})
-    }
-
-    fn peer_connect(&self, peer: Url) -> K2Result<()> {
-        (self.peer_con)(peer)
-    }
-
-    fn peer_disconnect(&self, peer: Url, reason: Option<String>) {
-        (self.peer_dis)(peer, reason)
-    }
-}
-
-impl TxHandler for CbHandler {
-    fn preflight_gather_outgoing(
-        &self,
-        peer_url: Url,
-    ) -> K2Result<bytes::Bytes> {
-        (self.pre_out)(peer_url)
-    }
-
-    fn preflight_validate_incoming(
-        &self,
-        peer_url: Url,
-        data: bytes::Bytes,
-    ) -> K2Result<()> {
-        (self.pre_in)(peer_url, data)
-    }
-}
-
-impl TxSpaceHandler for CbHandler {
-    fn recv_space_notify(
-        &self,
-        peer: Url,
-        space: SpaceId,
-        data: bytes::Bytes,
-    ) -> K2Result<()> {
-        (self.recv_space_notify)(peer, space, data)
-    }
-
-    fn set_unresponsive(
-        &self,
-        peer: Url,
-        when: Timestamp,
-    ) -> BoxFut<'_, K2Result<()>> {
-        Box::pin(async move { (self.set_unresponsive)(peer, when) })
-    }
-}
-
-impl TxModuleHandler for CbHandler {
-    fn recv_module_msg(
-        &self,
-        peer: Url,
-        space: SpaceId,
-        module: String,
-        data: bytes::Bytes,
-    ) -> K2Result<()> {
-        (self.module)(peer, space, module, data)
-    }
-}
 
 #[test]
 fn validate_bad_server_url() {
@@ -259,12 +64,12 @@ fn validate_plain_server_url() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn restart_addr() {
-    let mut test = Test::new(None, None).await;
+    let mut test = Tx5TransportTestHarness::new(None, None).await;
 
     let addr = Arc::new(Mutex::new(Vec::new()));
     let addr2 = addr.clone();
 
-    let h = Arc::new(CbHandler {
+    let h = Arc::new(MockTxHandler {
         new_addr: Arc::new(move |url| {
             addr2.lock().unwrap().push(url);
         }),
@@ -294,11 +99,11 @@ async fn restart_addr() {
 #[tokio::test(flavor = "multi_thread")]
 #[ignore = "disconnects currently broken in tx5"]
 async fn peer_connect_disconnect() {
-    let test = Test::new(None, None).await;
+    let test = Tx5TransportTestHarness::new(None, None).await;
 
     let u1 = Arc::new(Mutex::new(Url::from_str("ws://bla.bla:38/1").unwrap()));
     let u1_2 = u1.clone();
-    let h1 = Arc::new(CbHandler {
+    let h1 = Arc::new(MockTxHandler {
         new_addr: Arc::new(move |url| {
             *u1_2.lock().unwrap() = url;
         }),
@@ -310,7 +115,7 @@ async fn peer_connect_disconnect() {
     let u2 = Arc::new(Mutex::new(Url::from_str("ws://bla.bla:38/1").unwrap()));
     let u2_2 = u2.clone();
     let s_send_2 = s_send.clone();
-    let h2 = Arc::new(CbHandler {
+    let h2 = Arc::new(MockTxHandler {
         new_addr: Arc::new(move |url| {
             *u2_2.lock().unwrap() = url;
         }),
@@ -375,9 +180,9 @@ async fn peer_connect_disconnect() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn message_send_recv() {
-    let test = Test::new(None, None).await;
+    let test = Tx5TransportTestHarness::new(None, None).await;
 
-    let h1 = Arc::new(CbHandler {
+    let h1 = Arc::new(MockTxHandler {
         ..Default::default()
     });
     let t1 = test.build_transport(h1.clone()).await;
@@ -387,11 +192,11 @@ async fn message_send_recv() {
     let (s_send, mut s_recv) = tokio::sync::mpsc::unbounded_channel();
     let u2 = Arc::new(Mutex::new(Url::from_str("ws://bla.bla:38/1").unwrap()));
     let u2_2 = u2.clone();
-    let h2 = Arc::new(CbHandler {
+    let h2 = Arc::new(MockTxHandler {
         new_addr: Arc::new(move |url| {
             *u2_2.lock().unwrap() = url;
         }),
-        recv_space_notify: Arc::new(move |url, space, data| {
+        recv_space_not: Arc::new(move |url, space, data| {
             let _ = s_send.send((url, space, data));
             Ok(())
         }),
@@ -427,9 +232,9 @@ async fn message_send_recv() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn message_send_recv_auth() {
-    let test = Test::new(Some(b"hello".into()), None).await;
+    let test = Tx5TransportTestHarness::new(Some(b"hello".into()), None).await;
 
-    let h1 = Arc::new(CbHandler {
+    let h1 = Arc::new(MockTxHandler {
         ..Default::default()
     });
     let t1 = test.build_transport(h1.clone()).await;
@@ -439,11 +244,11 @@ async fn message_send_recv_auth() {
     let (s_send, mut s_recv) = tokio::sync::mpsc::unbounded_channel();
     let u2 = Arc::new(Mutex::new(Url::from_str("ws://bla.bla:38/1").unwrap()));
     let u2_2 = u2.clone();
-    let h2 = Arc::new(CbHandler {
+    let h2 = Arc::new(MockTxHandler {
         new_addr: Arc::new(move |url| {
             *u2_2.lock().unwrap() = url;
         }),
-        recv_space_notify: Arc::new(move |url, space, data| {
+        recv_space_not: Arc::new(move |url, space, data| {
             let _ = s_send.send((url, space, data));
             Ok(())
         }),
@@ -480,12 +285,12 @@ async fn message_send_recv_auth() {
 #[tokio::test(flavor = "multi_thread")]
 async fn preflight_send_recv() {
     use std::sync::atomic::*;
-    let test = Test::new(None, None).await;
+    let test = Tx5TransportTestHarness::new(None, None).await;
 
     let r1 = Arc::new(AtomicBool::new(false));
     let r1_2 = r1.clone();
 
-    let h1 = Arc::new(CbHandler {
+    let h1 = Arc::new(MockTxHandler {
         pre_out: Arc::new(|_| Ok(bytes::Bytes::from_static(b"hello"))),
         pre_in: Arc::new(move |_, data| {
             assert_eq!(b"world", data.as_ref());
@@ -501,7 +306,7 @@ async fn preflight_send_recv() {
 
     let u2 = Arc::new(Mutex::new(Url::from_str("ws://bla.bla:38/1").unwrap()));
     let u2_2 = u2.clone();
-    let h2 = Arc::new(CbHandler {
+    let h2 = Arc::new(MockTxHandler {
         pre_out: Arc::new(|_| Ok(bytes::Bytes::from_static(b"world"))),
         pre_in: Arc::new(move |_, data| {
             assert_eq!(b"hello", data.as_ref());
@@ -543,12 +348,12 @@ async fn preflight_send_recv() {
 #[tokio::test(flavor = "multi_thread")]
 async fn nonexistent_peer_marked_unresponsive() {
     // set the tx5 timeout to 5 seconds to keep the test reasonably short
-    let test = Test::new(None, Some(5)).await;
+    let test = Tx5TransportTestHarness::new(None, Some(3)).await;
 
     let (unresp_send, mut unresp_recv) = tokio::sync::mpsc::unbounded_channel();
 
-    let tx_handler1 = Arc::new(CbHandler {
-        set_unresponsive: Arc::new({
+    let tx_handler1 = Arc::new(MockTxHandler {
+        set_unresp: Arc::new({
             move |url, when| {
                 unresp_send.send((url, when)).map_err(|_| K2Error::Other {
                     ctx: "Failed to send url to oneshot channel".into(),
@@ -599,18 +404,18 @@ async fn nonexistent_peer_marked_unresponsive() {
 #[tokio::test(flavor = "multi_thread")]
 async fn offline_peer_marked_unresponsive() {
     // set the tx5 timeout to 5 seconds to keep the test reasonably short
-    let test = Test::new(None, Some(5)).await;
+    let test = Tx5TransportTestHarness::new(None, Some(5)).await;
 
     let (unresp_send, mut unresp_recv) = tokio::sync::mpsc::unbounded_channel();
 
     let url1 =
         Arc::new(Mutex::new(Url::from_str("ws://bla.bla:38/1").unwrap()));
     let url1_2 = url1.clone();
-    let tx_handler1 = Arc::new(CbHandler {
+    let tx_handler1 = Arc::new(MockTxHandler {
         new_addr: Arc::new(move |url| {
             *url1_2.lock().unwrap() = url;
         }),
-        set_unresponsive: Arc::new({
+        set_unresp: Arc::new({
             move |url, when| {
                 unresp_send.send((url, when)).map_err(|_| K2Error::Other {
                     ctx: "Failed to send url to oneshot channel".into(),
@@ -632,11 +437,11 @@ async fn offline_peer_marked_unresponsive() {
     let url2 =
         Arc::new(Mutex::new(Url::from_str("ws://bla.bla:38/1").unwrap()));
     let url2_2 = url2.clone();
-    let tx_hanlder2 = Arc::new(CbHandler {
+    let tx_hanlder2 = Arc::new(MockTxHandler {
         new_addr: Arc::new(move |url| {
             *url2_2.lock().unwrap() = url;
         }),
-        recv_space_notify: Arc::new(move |url, space, data| {
+        recv_space_not: Arc::new(move |url, space, data| {
             let _ = s_send.send((url, space, data));
             Ok(())
         }),
@@ -710,15 +515,15 @@ async fn offline_peer_marked_unresponsive() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn dump_network_stats() {
-    let test = Test::new(None, None).await;
+    let test = Tx5TransportTestHarness::new(None, None).await;
 
-    let h1 = Arc::new(CbHandler {
+    let h1 = Arc::new(MockTxHandler {
         ..Default::default()
     });
     let t1 = test.build_transport(h1.clone()).await;
 
     let u2 = Arc::new(Mutex::new(Url::from_str("ws://bla.bla:38/1").unwrap()));
-    let h2 = Arc::new(CbHandler {
+    let h2 = Arc::new(MockTxHandler {
         new_addr: Arc::new({
             let u2 = u2.clone();
             move |url| {


### PR DESCRIPTION
- extracts the test harness of tx5 into a separate module and expose it through the test-utils feature
- moves a long tx5 transport module test to the integration tests 