### PR TITLE
chore: Update Cargo.toml use repository instead of homepage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,8 @@ resolver = "2"
 [workspace.package]
 version = "0.2.8"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
-homepage = "https://github.com/holochain/kitsune2"
+homepage = "https://www.holochain.org/"
+repository = "https://github.com/holochain/kitsune2"
 keywords = ["holochain", "kitsune", "p2p", "dht", "networking"]
 categories = ["network-programming"]
 license = "Apache-2.0"

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 description = "p2p / dht communication framework api"
 license.workspace = true
 homepage.workspace = true
+repository.workspace = true
 documentation = "https://docs.rs/kitsune2_api"
 authors.workspace = true
 keywords.workspace = true

--- a/crates/bootstrap_client/Cargo.toml
+++ b/crates/bootstrap_client/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 description = "p2p / dht communication WAN discovery bootstrapping client"
 license.workspace = true
 homepage.workspace = true
+repository.workspace = true
 documentation = "https://docs.rs/kitsune2_bootstrap_client"
 authors.workspace = true
 keywords.workspace = true

--- a/crates/bootstrap_srv/Cargo.toml
+++ b/crates/bootstrap_srv/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 description = "p2p / dht communication WAN discovery bootstrapping server"
 license.workspace = true
 homepage.workspace = true
+repository.workspace = true
 documentation = "https://docs.rs/kitsune2_bootstrap_srv"
 authors.workspace = true
 keywords.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 description = "p2p / dht communication framework core and testing modules"
 license.workspace = true
 homepage.workspace = true
+repository.workspace = true
 documentation = "https://docs.rs/kitsune2_core"
 authors.workspace = true
 keywords.workspace = true

--- a/crates/dht/Cargo.toml
+++ b/crates/dht/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 description = "The DHT model for kitsune2"
 license.workspace = true
 homepage.workspace = true
+repository.workspace = true
 documentation = "https://docs.rs/kitsune2_dht"
 authors.workspace = true
 keywords.workspace = true

--- a/crates/gossip/Cargo.toml
+++ b/crates/gossip/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 description = "Gossip implementation for kitsune2"
 license.workspace = true
 homepage.workspace = true
+repository.workspace = true
 documentation = "https://docs.rs/kitsune2_gossip"
 authors.workspace = true
 keywords.workspace = true

--- a/crates/kitsune2/Cargo.toml
+++ b/crates/kitsune2/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 description = "p2p / dht communication framework api"
 license.workspace = true
 homepage.workspace = true
+repository.workspace = true
 documentation = "https://docs.rs/kitsune2"
 authors.workspace = true
 keywords.workspace = true

--- a/crates/kitsune2_showcase/Cargo.toml
+++ b/crates/kitsune2_showcase/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 description = "kitsune2 p2p / dht showcase app"
 license.workspace = true
 homepage.workspace = true
+repository.workspace = true
 documentation = "https://docs.rs/kitsune2_showcase"
 authors.workspace = true
 keywords.workspace = true

--- a/crates/test_utils/Cargo.toml
+++ b/crates/test_utils/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 description = "Test utilities for kitsune2"
 license.workspace = true
 homepage.workspace = true
+repository.workspace = true
 documentation = "https://docs.rs/kitsune2_test_utils"
 authors.workspace = true
 keywords.workspace = true

--- a/crates/tool_proto_build/Cargo.toml
+++ b/crates/tool_proto_build/Cargo.toml
@@ -3,6 +3,7 @@ name = "tool_proto_build"
 version.workspace = true
 publish = false
 edition.workspace = true
+repository.workspace = true
 
 [dependencies]
 prost-build = { workspace = true }

--- a/crates/transport_tx5/Cargo.toml
+++ b/crates/transport_tx5/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 description = "The Tx5-based transport implementation for kitsune2"
 license.workspace = true
 homepage.workspace = true
+repository.workspace = true
 documentation = "https://docs.rs/kitsune2_transport_tx5"
 authors.workspace = true
 keywords.workspace = true


### PR DESCRIPTION
According to the [manifset](https://doc.rust-lang.org/cargo/reference/manifest.html) it seems the `repository` field is preferable.  More explanation https://github.com/szabgab/rust-digger/issues/91