### PR TITLE
ci: add job to generate changelog preview with git-cliff

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -132,6 +132,10 @@ jobs:
       - name: Build
         run: docker buildx build -f docker/kitsune2_test_auth_hook_server/Dockerfile .
 
+  changelog-preview-comment:
+      name: Add comment of changelog preview
+      uses: holochain/actions/.github/workflows/changelog-preview-comment.yml@v1.2.0
+
   ci_pass:
     if: ${{ always() }}
     runs-on: "ubuntu-latest"


### PR DESCRIPTION
PR to add a comment to this and future PRs to show what will be added to the generated changelog, including what version bump will happen due to these changes. See [the comment below](https://github.com/holochain/kitsune2/pull/254#issuecomment-3000465692) for an example.