### PR TITLE
feat: rename constructor of the DefaultTransport struct

### DIFF
--- a/crates/api/src/transport.rs
+++ b/crates/api/src/transport.rs
@@ -284,7 +284,7 @@ impl DefaultTransport {
     /// to produce the [Transport] struct.
     ///
     /// [DefaultTransport] is built to be used with the provided [TxImpHnd].
-    pub fn create(hnd: &TxImpHnd, imp: DynTxImp) -> DynTransport {
+    pub fn new(hnd: &TxImpHnd, imp: DynTxImp) -> DynTransport {
         let out: DynTransport = Arc::new(DefaultTransport {
             imp,
             space_map: hnd.space_map.clone(),

--- a/crates/core/src/factories/mem_transport.rs
+++ b/crates/core/src/factories/mem_transport.rs
@@ -35,7 +35,7 @@ impl TransportFactory for MemTransportFactory {
         Box::pin(async move {
             let handler = TxImpHnd::new(handler);
             let imp = MemTransport::create(handler.clone()).await;
-            Ok(DefaultTransport::create(&handler, imp))
+            Ok(DefaultTransport::new(&handler, imp))
         })
     }
 }

--- a/crates/transport_tx5/src/lib.rs
+++ b/crates/transport_tx5/src/lib.rs
@@ -198,7 +198,7 @@ impl TransportFactory for Tx5TransportFactory {
                 builder.auth_material.clone(),
             )
             .await?;
-            Ok(DefaultTransport::create(&handler, imp))
+            Ok(DefaultTransport::new(&handler, imp))
         })
     }
 }


### PR DESCRIPTION
This PR renames the constructor of a `DefaultTransport` from `create` to `new` since it's not a factory that creates instances of a different type but instead constructs an instance of itself.