### PR TITLE
chore: downgrade "no peers" gossip tracing messages

### DIFF
--- a/crates/gossip/src/initiate.rs
+++ b/crates/gossip/src/initiate.rs
@@ -183,7 +183,7 @@ async fn select_next_target(
     // wider and gossip with agents that might still be growing their arc and have some ops
     // or agent infos that we are missing
     if all_agents.is_empty() {
-        tracing::info!(
+        tracing::debug!(
             "No agents with overlapping arcs available, selecting from all agents"
         );
 
@@ -219,7 +219,7 @@ async fn select_next_target(
     match possible_target {
         None => {
             // All options exhausted, give up for now
-            tracing::info!("No agents to gossip with");
+            tracing::debug!("No agents to gossip with");
             Ok(None)
         }
         Some(target) => Ok(Some(target)),


### PR DESCRIPTION
Downgrade "no peers" gossip tracing messages from info to debug because they're too noisy when no other peers are available on the network