### PR TITLE
Make `Kitsune2MemoryOpStore` generic over its op type

### DIFF
--- a/crates/core/src/factories/core_bootstrap.rs
+++ b/crates/core/src/factories/core_bootstrap.rs
@@ -78,20 +78,24 @@ impl BootstrapFactory for CoreBootstrapFactory {
     }
 
     fn validate_config(&self, config: &Config) -> K2Result<()> {
-        const ERR: &str = "invalid bootstrap server_url";
-
         let config: CoreBootstrapModConfig = config.get_module_config()?;
 
+        let err = format!(
+            "invalid bootstrap server_url: {:?}",
+            config.core_bootstrap.server_url
+        );
+        let err = err.as_str();
+
         let url = url::Url::parse(&config.core_bootstrap.server_url)
-            .map_err(|e| K2Error::other_src(ERR, e))?;
+            .map_err(|e| K2Error::other_src(err, e))?;
 
         if url.cannot_be_a_base() {
-            return Err(K2Error::other(ERR));
+            return Err(K2Error::other(err));
         }
 
         match url.scheme() {
             "http" | "https" => Ok(()),
-            _ => Err(K2Error::other(ERR)),
+            _ => Err(K2Error::other(err)),
         }
     }
 

--- a/crates/core/src/factories/core_fetch/test.rs
+++ b/crates/core/src/factories/core_fetch/test.rs
@@ -4,7 +4,7 @@ mod outgoing_request_queue;
 
 #[cfg(test)]
 pub(crate) mod test_utils {
-    use crate::factories::MemoryOp;
+    use crate::factories::TestMemoryOp;
     use kitsune2_api::{Timestamp, Url};
     use rand::RngCore;
 
@@ -13,7 +13,7 @@ pub(crate) mod test_utils {
         Url::from_str(format!("ws://test:80/{id}")).unwrap()
     }
 
-    pub fn make_op(data: Vec<u8>) -> MemoryOp {
-        MemoryOp::new(Timestamp::now(), data)
+    pub fn make_op(data: Vec<u8>) -> TestMemoryOp {
+        TestMemoryOp::new(Timestamp::now(), data)
     }
 }

--- a/crates/core/src/factories/core_fetch/test/incoming_request_queue.rs
+++ b/crates/core/src/factories/core_fetch/test/incoming_request_queue.rs
@@ -2,7 +2,7 @@ use crate::{
     default_test_builder,
     factories::{
         core_fetch::{test::test_utils::make_op, CoreFetch, CoreFetchConfig},
-        MemOpStoreFactory, MemoryOp, TestMemoryOp,
+        MemOpStoreFactory, TestMemoryOp,
     },
 };
 use bytes::Bytes;

--- a/crates/core/src/factories/core_fetch/test/incoming_request_queue.rs
+++ b/crates/core/src/factories/core_fetch/test/incoming_request_queue.rs
@@ -2,7 +2,7 @@ use crate::{
     default_test_builder,
     factories::{
         core_fetch::{test::test_utils::make_op, CoreFetch, CoreFetchConfig},
-        MemOpStoreFactory, MemoryOp,
+        MemOpStoreFactory, MemoryOp, TestMemoryOp,
     },
 };
 use bytes::Bytes;
@@ -28,7 +28,7 @@ struct TestCase {
 async fn setup_test() -> TestCase {
     let builder =
         Arc::new(default_test_builder().with_default_config().unwrap());
-    let op_store = MemOpStoreFactory::create()
+    let op_store = MemOpStoreFactory::<TestMemoryOp>::create()
         .create(builder.clone(), TEST_SPACE_ID)
         .await
         .unwrap();
@@ -220,7 +220,7 @@ async fn fail_to_respond_once_then_succeed() {
                 K2FetchMessage::decode(data).unwrap().data,
             )
             .unwrap();
-            let ops: Vec<MemoryOp> =
+            let ops: Vec<TestMemoryOp> =
                 response.ops.into_iter().map(Into::into).collect::<Vec<_>>();
             responses_sent.lock().unwrap().push((ops, peer));
             Box::pin(async move { Ok(()) })

--- a/crates/core/src/factories/core_fetch/test/incoming_response_queue.rs
+++ b/crates/core/src/factories/core_fetch/test/incoming_response_queue.rs
@@ -3,7 +3,7 @@ use crate::{
     default_test_builder,
     factories::{
         core_fetch::{CoreFetch, CoreFetchConfig},
-        MemPeerMetaStore, MemoryOp,
+        MemPeerMetaStore, MemoryOp, TestMemoryOp,
     },
 };
 use kitsune2_api::*;
@@ -93,9 +93,9 @@ async fn incoming_ops_are_written_to_op_store() {
         fetch, op_store, ..
     } = setup_test().await;
 
-    let incoming_op_1 = MemoryOp::new(Timestamp::now(), vec![1]);
+    let incoming_op_1 = TestMemoryOp::new(Timestamp::now(), vec![1]);
     let incoming_op_id_1 = incoming_op_1.compute_op_id();
-    let incoming_op_2 = MemoryOp::new(Timestamp::now(), vec![2]);
+    let incoming_op_2 = TestMemoryOp::new(Timestamp::now(), vec![2]);
     let incoming_op_id_2 = incoming_op_2.compute_op_id();
 
     let incoming_op_ids =
@@ -156,7 +156,7 @@ async fn requests_for_received_ops_are_removed_from_state() {
     let another_peer_url = random_peer_url();
 
     // Add 1 op that'll be removed and another op that won't be.
-    let incoming_op = MemoryOp::new(Timestamp::now(), vec![1]);
+    let incoming_op = TestMemoryOp::new(Timestamp::now(), vec![1]);
     let incoming_op_id = incoming_op.compute_op_id();
     let another_op_id = random_op_id();
 
@@ -231,7 +231,7 @@ async fn op_ids_are_not_removed_when_storing_op_failed() {
 
     let peer_url = random_peer_url();
 
-    let incoming_op = MemoryOp::new(Timestamp::now(), vec![1]);
+    let incoming_op = TestMemoryOp::new(Timestamp::now(), vec![1]);
     let incoming_op_id = incoming_op.compute_op_id();
 
     fetch

--- a/crates/core/src/factories/core_fetch/test/outgoing_request_queue.rs
+++ b/crates/core/src/factories/core_fetch/test/outgoing_request_queue.rs
@@ -1,8 +1,9 @@
 use super::test_utils::random_peer_url;
 use crate::{
     default_test_builder,
-    factories::core_fetch::{
-        test::test_utils::make_op, CoreFetch, CoreFetchConfig,
+    factories::{
+        core_fetch::{test::test_utils::make_op, CoreFetch, CoreFetchConfig},
+        MemoryOp,
     },
 };
 use kitsune2_api::*;

--- a/crates/core/src/factories/core_publish/test.rs
+++ b/crates/core/src/factories/core_publish/test.rs
@@ -1,7 +1,7 @@
 use super::CorePublishConfig;
 use crate::{
     default_test_builder,
-    factories::{core_publish::CorePublish, MemoryOp},
+    factories::{core_publish::CorePublish, MemoryOp, TestMemoryOp},
 };
 use kitsune2_api::{
     AgentId, AgentInfo, AgentInfoSigned, BoxFut, Builder, DhtArc, DynOpStore,
@@ -34,9 +34,9 @@ async fn published_ops_can_be_retrieved() {
         ..
     } = Test::setup().await;
 
-    let incoming_op_1 = MemoryOp::new(Timestamp::now(), vec![1]);
+    let incoming_op_1 = TestMemoryOp::new(Timestamp::now(), vec![1]);
     let incoming_op_id_1 = incoming_op_1.compute_op_id();
-    let incoming_op_2 = MemoryOp::new(Timestamp::now(), vec![2]);
+    let incoming_op_2 = TestMemoryOp::new(Timestamp::now(), vec![2]);
     let incoming_op_id_2 = incoming_op_2.compute_op_id();
 
     op_store_1
@@ -87,9 +87,9 @@ async fn publish_to_invalid_url_does_not_impede_subsequent_publishes() {
         ..
     } = Test::setup().await;
 
-    let incoming_op_1 = MemoryOp::new(Timestamp::now(), vec![1]);
+    let incoming_op_1 = TestMemoryOp::new(Timestamp::now(), vec![1]);
     let incoming_op_id_1 = incoming_op_1.compute_op_id();
-    let incoming_op_2 = MemoryOp::new(Timestamp::now(), vec![2]);
+    let incoming_op_2 = TestMemoryOp::new(Timestamp::now(), vec![2]);
     let incoming_op_id_2 = incoming_op_2.compute_op_id();
 
     op_store_1
@@ -318,7 +318,7 @@ async fn no_publish_to_unresponsive_url() {
     let (publish, _, _, peer_meta_store) =
         create_publish(builder, transport).await;
 
-    let op = MemoryOp::new(Timestamp::now(), vec![1]);
+    let op = TestMemoryOp::new(Timestamp::now(), vec![1]);
     let op_id = op.compute_op_id();
     // Set unresponsive URL in peer meta store.
     peer_meta_store

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -162,7 +162,7 @@ pub fn default_test_builder() -> Builder {
         bootstrap: factories::MemBootstrapFactory::create(),
         fetch: factories::CoreFetchFactory::create(),
         transport: factories::MemTransportFactory::create(),
-        op_store: factories::MemOpStoreFactory::create(),
+        op_store: factories::MemOpStoreFactory::<TestMemoryOp>::create(),
         peer_meta_store: factories::MemPeerMetaStoreFactory::create(),
         gossip: factories::CoreGossipStubFactory::create(),
         local_agent_store: factories::CoreLocalAgentStoreFactory::create(),
@@ -174,6 +174,8 @@ pub mod factories;
 
 mod common;
 pub use common::*;
+
+use crate::factories::TestMemoryOp;
 
 #[cfg(any(doc, docsrs))]
 pub mod doc;

--- a/crates/core/tests/fetch.rs
+++ b/crates/core/tests/fetch.rs
@@ -1,6 +1,6 @@
 use kitsune2_api::*;
-use kitsune2_core::factories::{CoreFetchConfig, CoreFetchModConfig};
-use kitsune2_core::{default_test_builder, factories::MemoryOp};
+use kitsune2_core::factories::{CoreFetchConfig, CoreFetchModConfig, MemoryOp};
+use kitsune2_core::{default_test_builder, factories::TestMemoryOp};
 use kitsune2_test_utils::{
     enable_tracing, iter_check, random_bytes, space::TEST_SPACE_ID,
 };
@@ -18,11 +18,11 @@ impl TxBaseHandler for MockTxHandler {
 }
 impl TxHandler for MockTxHandler {}
 
-fn create_op_list(num_ops: u16) -> (Vec<MemoryOp>, Vec<OpId>) {
+fn create_op_list(num_ops: u16) -> (Vec<TestMemoryOp>, Vec<OpId>) {
     let mut ops = Vec::new();
     let mut op_ids = Vec::new();
     for _ in 0..num_ops {
-        let op = MemoryOp::new(Timestamp::now(), random_bytes(32));
+        let op = TestMemoryOp::new(Timestamp::now(), random_bytes(32));
         let op_id = op.compute_op_id();
         ops.push(op);
         op_ids.push(op_id);

--- a/crates/dht/src/dht/tests/harness.rs
+++ b/crates/dht/src/dht/tests/harness.rs
@@ -5,7 +5,7 @@ use crate::{Dht, DhtApi, DhtSnapshotNextAction};
 use kitsune2_api::{
     AgentId, DhtArc, DynOpStore, K2Result, OpId, StoredOp, Timestamp,
 };
-use kitsune2_core::factories::MemoryOp;
+use kitsune2_core::factories::TestMemoryOp;
 use rand::RngCore;
 use std::collections::HashMap;
 
@@ -49,7 +49,7 @@ impl DhtSyncHarness {
 
     pub(crate) async fn inject_ops(
         &mut self,
-        op_list: Vec<MemoryOp>,
+        op_list: Vec<TestMemoryOp>,
     ) -> K2Result<()> {
         self.store
             .process_incoming_ops(
@@ -416,7 +416,7 @@ async fn transfer_ops(
 
     let stored_ops = selected
         .into_iter()
-        .map(|op| MemoryOp::from(op).into())
+        .map(|op| TestMemoryOp::from(op).into())
         .collect::<Vec<StoredOp>>();
     target_dht.inform_ops_stored(stored_ops).await?;
 

--- a/crates/dht/src/hash.rs
+++ b/crates/dht/src/hash.rs
@@ -453,7 +453,7 @@ mod tests {
     use crate::test::test_store;
     use crate::UNIT_TIME;
     use kitsune2_api::{OpId, UNIX_TIMESTAMP};
-    use kitsune2_core::factories::MemoryOp;
+    use kitsune2_core::factories::TestMemoryOp;
     use kitsune2_test_utils::enable_tracing;
     use std::time::Duration;
 
@@ -648,7 +648,7 @@ mod tests {
                 _ => panic!("Expected an arc"),
             };
             store
-                .process_incoming_ops(vec![MemoryOp::new(
+                .process_incoming_ops(vec![TestMemoryOp::new(
                     now,
                     // Place the op within the current space partition
                     (start + 1).to_le_bytes().as_slice().to_vec(),

--- a/crates/dht/src/test.rs
+++ b/crates/dht/src/test.rs
@@ -3,7 +3,9 @@
 use bytes::Bytes;
 use kitsune2_api::*;
 use kitsune2_core::default_test_builder;
-use kitsune2_core::factories::{CoreBootstrapFactory, MemOpStoreFactory};
+use kitsune2_core::factories::{
+    CoreBootstrapFactory, MemOpStoreFactory, TestMemoryOp,
+};
 use std::sync::Arc;
 
 #[derive(Debug)]
@@ -27,7 +29,7 @@ pub async fn test_store() -> DynOpStore {
     }
     .with_default_config()
     .unwrap();
-    MemOpStoreFactory::create()
+    MemOpStoreFactory::<TestMemoryOp>::create()
         .create(
             Arc::new(builder),
             SpaceId::from(Bytes::from_static("test-space".as_bytes())),

--- a/crates/dht/src/time.rs
+++ b/crates/dht/src/time.rs
@@ -715,7 +715,7 @@ mod tests {
     use super::*;
     use crate::test::test_store;
     use kitsune2_api::OpId;
-    use kitsune2_core::factories::MemoryOp;
+    use kitsune2_core::factories::TestMemoryOp;
     use kitsune2_test_utils::enable_tracing;
 
     #[test]
@@ -894,9 +894,12 @@ mod tests {
         let store = test_store().await;
         store
             .process_incoming_ops(vec![
-                MemoryOp::new((current_time - UNIT_TIME).unwrap(), vec![7; 32])
-                    .into(),
-                MemoryOp::new(
+                TestMemoryOp::new(
+                    (current_time - UNIT_TIME).unwrap(),
+                    vec![7; 32],
+                )
+                .into(),
+                TestMemoryOp::new(
                     (current_time - UNIT_TIME).unwrap(),
                     vec![23; 32],
                 )
@@ -976,8 +979,8 @@ mod tests {
         let store = test_store().await;
         store
             .process_incoming_ops(vec![
-                MemoryOp::new(UNIX_TIMESTAMP, vec![7; 32]).into(),
-                MemoryOp::new(UNIX_TIMESTAMP, vec![23; 32]).into(),
+                TestMemoryOp::new(UNIX_TIMESTAMP, vec![7; 32]).into(),
+                TestMemoryOp::new(UNIX_TIMESTAMP, vec![23; 32]).into(),
             ])
             .await
             .unwrap();
@@ -1026,14 +1029,14 @@ mod tests {
         let store = test_store().await;
         store
             .process_incoming_ops(vec![
-                MemoryOp::new(UNIX_TIMESTAMP, vec![7; 32]).into(),
-                MemoryOp::new(UNIX_TIMESTAMP, vec![23; 32]).into(),
-                MemoryOp::new(
+                TestMemoryOp::new(UNIX_TIMESTAMP, vec![7; 32]).into(),
+                TestMemoryOp::new(UNIX_TIMESTAMP, vec![23; 32]).into(),
+                TestMemoryOp::new(
                     (current_time - UNIT_TIME).unwrap(),
                     vec![11; 32],
                 )
                 .into(),
-                MemoryOp::new(
+                TestMemoryOp::new(
                     (current_time - UNIT_TIME).unwrap(),
                     vec![29; 32],
                 )
@@ -1089,8 +1092,8 @@ mod tests {
         let store = test_store().await;
         store
             .process_incoming_ops(vec![
-                MemoryOp::new(UNIX_TIMESTAMP, vec![7; 32]).into(),
-                MemoryOp::new(
+                TestMemoryOp::new(UNIX_TIMESTAMP, vec![7; 32]).into(),
+                TestMemoryOp::new(
                     (current_time - UNIT_TIME).unwrap(),
                     vec![11; 32],
                 )
@@ -1144,9 +1147,12 @@ mod tests {
             .unwrap();
         store
             .process_incoming_ops(vec![
-                MemoryOp::new((current_time - UNIT_TIME).unwrap(), vec![7; 32])
-                    .into(),
-                MemoryOp::new(
+                TestMemoryOp::new(
+                    (current_time - UNIT_TIME).unwrap(),
+                    vec![7; 32],
+                )
+                .into(),
+                TestMemoryOp::new(
                     (current_time - UNIT_TIME).unwrap(),
                     vec![29; 32],
                 )
@@ -1170,7 +1176,7 @@ mod tests {
 
         // Store a new op which will currently be outside the last partial slice
         store
-            .process_incoming_ops(vec![MemoryOp::new(
+            .process_incoming_ops(vec![TestMemoryOp::new(
                 current_time,
                 vec![13; 32],
             )
@@ -1207,8 +1213,8 @@ mod tests {
         let store = test_store().await;
         store
             .process_incoming_ops(vec![
-                MemoryOp::new(UNIX_TIMESTAMP, vec![7; 32]).into(),
-                MemoryOp::new(UNIX_TIMESTAMP, vec![23; 32]).into(),
+                TestMemoryOp::new(UNIX_TIMESTAMP, vec![7; 32]).into(),
+                TestMemoryOp::new(UNIX_TIMESTAMP, vec![23; 32]).into(),
             ])
             .await
             .unwrap();
@@ -1235,7 +1241,7 @@ mod tests {
 
         // Store a new op, currently in the first partial slice, but will be in the next full slice.
         store
-            .process_incoming_ops(vec![MemoryOp::new(
+            .process_incoming_ops(vec![TestMemoryOp::new(
                 pt.full_slice_end_timestamp(), // Start of the next full slice
                 vec![13; 32],
             )
@@ -1298,16 +1304,16 @@ mod tests {
         store
             .process_incoming_ops(vec![
                 // Store two new ops at the unix timestamp, to go into the first complete slice
-                MemoryOp::new(UNIX_TIMESTAMP, vec![7; 32]).into(),
-                MemoryOp::new(UNIX_TIMESTAMP, vec![23; 32]).into(),
+                TestMemoryOp::new(UNIX_TIMESTAMP, vec![7; 32]).into(),
+                TestMemoryOp::new(UNIX_TIMESTAMP, vec![23; 32]).into(),
                 // Store two new ops at the unix timestamp plus one full time slice,
                 // to go into the second complete slice
-                MemoryOp::new(
+                TestMemoryOp::new(
                     UNIX_TIMESTAMP + pt.full_slice_duration,
                     vec![11; 32],
                 )
                 .into(),
-                MemoryOp::new(
+                TestMemoryOp::new(
                     UNIX_TIMESTAMP + pt.full_slice_duration,
                     vec![37; 32],
                 )
@@ -1384,7 +1390,7 @@ mod tests {
 
         // Now insert an op at the current time
         store
-            .process_incoming_ops(vec![MemoryOp::new(
+            .process_incoming_ops(vec![TestMemoryOp::new(
                 pt.full_slice_end_timestamp(),
                 vec![7; 32],
             )
@@ -1459,7 +1465,7 @@ mod tests {
         let store = test_store().await;
         // Insert a single op in the first time slice
         store
-            .process_incoming_ops(vec![MemoryOp::new(
+            .process_incoming_ops(vec![TestMemoryOp::new(
                 UNIX_TIMESTAMP,
                 vec![7, 0, 0, 0],
             )
@@ -1568,12 +1574,12 @@ mod tests {
         let store = test_store().await;
         store
             .process_incoming_ops(vec![
-                MemoryOp::new(
+                TestMemoryOp::new(
                     UNIX_TIMESTAMP + Duration::from_secs(10),
                     vec![7, 0, 0, 0],
                 )
                 .into(),
-                MemoryOp::new(
+                TestMemoryOp::new(
                     (current_time - Duration::from_secs(30)).unwrap(),
                     vec![31, 0, 0, 0],
                 )

--- a/crates/gossip/src/gossip.rs
+++ b/crates/gossip/src/gossip.rs
@@ -445,7 +445,7 @@ impl TxModuleHandler for K2Gossip {
 mod test {
     use super::*;
     use crate::harness::K2GossipFunctionalTestFactory;
-    use kitsune2_core::factories::MemoryOp;
+    use kitsune2_core::factories::{MemoryOp, TestMemoryOp};
     use kitsune2_dht::UNIT_TIME;
     use kitsune2_test_utils::space::TEST_SPACE_ID;
     use kitsune2_test_utils::{enable_tracing, iter_check};
@@ -524,7 +524,7 @@ mod test {
                 .await;
         let harness_1 = factory.new_instance().await;
         harness_1.join_local_agent(DhtArc::FULL).await;
-        let op_1 = MemoryOp::new(Timestamp::now(), vec![1; 128]);
+        let op_1 = TestMemoryOp::new(Timestamp::now(), vec![1; 128]);
         let op_id_1 = op_1.compute_op_id();
         harness_1
             .space
@@ -535,7 +535,7 @@ mod test {
 
         let harness_2 = factory.new_instance().await;
         harness_2.join_local_agent(DhtArc::FULL).await;
-        let op_2 = MemoryOp::new(Timestamp::now(), vec![2; 128]);
+        let op_2 = TestMemoryOp::new(Timestamp::now(), vec![2; 128]);
         let op_id_2 = op_2.compute_op_id();
         harness_2
             .space
@@ -564,7 +564,7 @@ mod test {
 
         let harness_1 = factory.new_instance().await;
         let agent_info_1 = harness_1.join_local_agent(DhtArc::FULL).await;
-        let op_1 = MemoryOp::new(Timestamp::from_micros(100), vec![1; 128]);
+        let op_1 = TestMemoryOp::new(Timestamp::from_micros(100), vec![1; 128]);
         let op_id_1 = op_1.compute_op_id();
         harness_1
             .space
@@ -580,7 +580,7 @@ mod test {
 
         let harness_2 = factory.new_instance().await;
         let agent_info_2 = harness_2.join_local_agent(DhtArc::FULL).await;
-        let op_2 = MemoryOp::new(Timestamp::from_micros(500), vec![2; 128]);
+        let op_2 = TestMemoryOp::new(Timestamp::from_micros(500), vec![2; 128]);
         let op_id_2 = op_2.compute_op_id();
         harness_2
             .space
@@ -640,7 +640,7 @@ mod test {
                 .await;
         let harness_1 = factory.new_instance().await;
         let agent_info_1 = harness_1.join_local_agent(DhtArc::FULL).await;
-        let op_1 = MemoryOp::new(
+        let op_1 = TestMemoryOp::new(
             (Timestamp::now() - 2 * UNIT_TIME).unwrap(),
             vec![1; 128],
         );
@@ -659,7 +659,7 @@ mod test {
 
         let harness_2 = factory.new_instance().await;
         let agent_info_2 = harness_2.join_local_agent(DhtArc::FULL).await;
-        let op_2 = MemoryOp::new(
+        let op_2 = TestMemoryOp::new(
             (Timestamp::now() - 2 * UNIT_TIME).unwrap(),
             vec![2; 128],
         );
@@ -725,7 +725,7 @@ mod test {
 
         let harness_2 = factory.new_instance().await;
         let local_agent_2 = harness_2.join_local_agent(DhtArc::FULL).await;
-        let op_2 = MemoryOp::new(Timestamp::now(), vec![2; 128]);
+        let op_2 = TestMemoryOp::new(Timestamp::now(), vec![2; 128]);
         let op_id_2 = op_2.compute_op_id();
         harness_2
             .space

--- a/crates/gossip/src/harness.rs
+++ b/crates/gossip/src/harness.rs
@@ -8,7 +8,7 @@ use kitsune2_api::{
     GossipStateSummaryRequest, LocalAgent, OpId, SpaceHandler, SpaceId,
     StoredOp, TxBaseHandler, TxHandler, TxSpaceHandler, UNIX_TIMESTAMP,
 };
-use kitsune2_core::factories::MemoryOp;
+use kitsune2_core::factories::TestMemoryOp;
 use kitsune2_core::{default_test_builder, Ed25519LocalAgent};
 use kitsune2_test_utils::noop_bootstrap::NoopBootstrapFactory;
 use std::collections::HashSet;
@@ -117,7 +117,7 @@ impl K2GossipFunctionalTestHarness {
     }
 
     /// Wait for the given ops to be in our op store.
-    pub async fn wait_for_ops(&self, op_ids: Vec<OpId>) -> Vec<MemoryOp> {
+    pub async fn wait_for_ops(&self, op_ids: Vec<OpId>) -> Vec<TestMemoryOp> {
         tokio::time::timeout(Duration::from_millis(500), {
             let this = self.clone();
             async move {
@@ -143,7 +143,7 @@ impl K2GossipFunctionalTestHarness {
                     return ops
                         .into_iter()
                         .map(|op| {
-                            let out: MemoryOp = op.op_data.into();
+                            let out: TestMemoryOp = op.op_data.into();
 
                             out
                         })

--- a/crates/gossip/src/harness/op_store.rs
+++ b/crates/gossip/src/harness/op_store.rs
@@ -3,6 +3,7 @@ use kitsune2_api::{
     BoxFut, Builder, Config, DhtArc, DynOpStore, K2Error, K2Result, MetaOp,
     OpId, OpStore, OpStoreFactory, SpaceId, Timestamp,
 };
+use kitsune2_core::factories::MemoryOp;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
@@ -62,7 +63,7 @@ pub struct MemoryOpRecord {
 
 impl From<Bytes> for MemoryOpRecord {
     fn from(value: Bytes) -> Self {
-        let inner: kitsune2_core::factories::MemoryOp = value.into();
+        let inner: kitsune2_core::factories::TestMemoryOp = value.into();
         Self {
             op_id: inner.compute_op_id(),
             created_at: inner.created_at,
@@ -168,7 +169,7 @@ impl OpStore for K2GossipMemoryOpStore {
                 .filter_map(|op_id| {
                     self_lock.op_list.get(op_id).map(|op| MetaOp {
                         op_id: op.op_id.clone(),
-                        op_data: kitsune2_core::factories::MemoryOp {
+                        op_data: kitsune2_core::factories::TestMemoryOp {
                             created_at: op.created_at,
                             op_data: op.op_data.clone(),
                         }

--- a/crates/gossip/src/respond/accept.rs
+++ b/crates/gossip/src/respond/accept.rs
@@ -322,7 +322,7 @@ mod tests {
     use kitsune2_api::{
         decode_ids, DhtArc, Gossip, LocalAgent, OpId, Timestamp, UNIX_TIMESTAMP,
     };
-    use kitsune2_core::factories::MemoryOp;
+    use kitsune2_core::factories::TestMemoryOp;
     use kitsune2_dht::{ArcSet, DhtSnapshot};
     use kitsune2_test_utils::enable_tracing;
 
@@ -356,7 +356,7 @@ mod tests {
 
         let mut ops = Vec::new();
         for i in 0u8..available_ops {
-            let op = MemoryOp::new(Timestamp::now(), vec![i; op_size]);
+            let op = TestMemoryOp::new(Timestamp::now(), vec![i; op_size]);
             ops.push(op);
         }
 

--- a/crates/gossip/src/respond/disc_sector_details_diff.rs
+++ b/crates/gossip/src/respond/disc_sector_details_diff.rs
@@ -197,7 +197,7 @@ mod tests {
     use crate::K2GossipConfig;
     use bytes::Bytes;
     use kitsune2_api::{decode_ids, DhtArc, Gossip, OpId, Timestamp};
-    use kitsune2_core::factories::MemoryOp;
+    use kitsune2_core::factories::TestMemoryOp;
     use kitsune2_dht::{ArcSet, DhtSnapshot, SECTOR_SIZE};
     use kitsune2_test_utils::enable_tracing;
 
@@ -245,7 +245,7 @@ mod tests {
             op_data.resize(128, 0);
 
             let op =
-                MemoryOp::new(Timestamp::from_micros(100 + i as i64), op_data);
+                TestMemoryOp::new(Timestamp::from_micros(100 + i as i64), op_data);
             ops.push(op);
         }
 

--- a/crates/gossip/src/respond/disc_sector_details_diff_response.rs
+++ b/crates/gossip/src/respond/disc_sector_details_diff_response.rs
@@ -185,7 +185,7 @@ mod tests {
     use crate::K2GossipConfig;
     use bytes::Bytes;
     use kitsune2_api::{decode_ids, DhtArc, Gossip, OpId, Timestamp};
-    use kitsune2_core::factories::MemoryOp;
+    use kitsune2_core::factories::TestMemoryOp;
     use kitsune2_dht::{ArcSet, DhtSnapshot, SECTOR_SIZE};
     use kitsune2_test_utils::enable_tracing;
     use std::collections::HashMap;
@@ -256,7 +256,7 @@ mod tests {
             op_data.resize(128, 0);
 
             let op =
-                MemoryOp::new(Timestamp::from_micros(100 + i as i64), op_data);
+                TestMemoryOp::new(Timestamp::from_micros(100 + i as i64), op_data);
             ops.push(op);
         }
 

--- a/crates/gossip/src/respond/initiate.rs
+++ b/crates/gossip/src/respond/initiate.rs
@@ -184,7 +184,7 @@ mod tests {
         decode_ids, DhtArc, Gossip, LocalAgent, OpId, Timestamp, Url,
         UNIX_TIMESTAMP,
     };
-    use kitsune2_core::factories::MemoryOp;
+    use kitsune2_core::factories::TestMemoryOp;
     use kitsune2_core::Ed25519LocalAgent;
     use kitsune2_dht::{ArcSet, SECTOR_SIZE};
     use kitsune2_test_utils::enable_tracing;
@@ -609,7 +609,7 @@ mod tests {
 
         let mut ops = Vec::new();
         for i in 0u8..available_ops {
-            let op = MemoryOp::new(Timestamp::now(), vec![i; op_size]);
+            let op = TestMemoryOp::new(Timestamp::now(), vec![i; op_size]);
             ops.push(op);
         }
 

--- a/crates/gossip/src/respond/ring_sector_details_diff.rs
+++ b/crates/gossip/src/respond/ring_sector_details_diff.rs
@@ -234,7 +234,7 @@ mod tests {
     use crate::K2GossipConfig;
     use bytes::Bytes;
     use kitsune2_api::{decode_ids, DhtArc, Gossip, OpId, Timestamp};
-    use kitsune2_core::factories::MemoryOp;
+    use kitsune2_core::factories::TestMemoryOp;
     use kitsune2_dht::{ArcSet, DhtSnapshot, SECTOR_SIZE};
     use kitsune2_test_utils::enable_tracing;
 
@@ -298,7 +298,7 @@ mod tests {
             let mut op_data = (i as u32 * SECTOR_SIZE).to_le_bytes().to_vec();
             op_data.resize(op_size, 0);
 
-            let op = MemoryOp::new(
+            let op = TestMemoryOp::new(
                 // Ops created just after the disc boundary so that they'll be in the first ring
                 disc_boundary + std::time::Duration::from_secs(30 + i as u64),
                 op_data,

--- a/crates/gossip/src/respond/ring_sector_details_diff_response.rs
+++ b/crates/gossip/src/respond/ring_sector_details_diff_response.rs
@@ -192,7 +192,7 @@ mod tests {
     use crate::K2GossipConfig;
     use bytes::Bytes;
     use kitsune2_api::{decode_ids, DhtArc, Gossip, OpId};
-    use kitsune2_core::factories::MemoryOp;
+    use kitsune2_core::factories::TestMemoryOp;
     use kitsune2_dht::{ArcSet, DhtSnapshot, SECTOR_SIZE};
     use kitsune2_test_utils::enable_tracing;
     use std::collections::HashMap;
@@ -268,7 +268,7 @@ mod tests {
             let mut op_data = (i as u32 * SECTOR_SIZE).to_le_bytes().to_vec();
             op_data.resize(op_size, 0);
 
-            let op = MemoryOp::new(
+            let op = TestMemoryOp::new(
                 // Ops created just after the disc boundary so that they'll be in the first ring
                 disc_boundary + std::time::Duration::from_secs(30 + i as u64),
                 op_data,

--- a/crates/gossip/src/respond/tests.rs
+++ b/crates/gossip/src/respond/tests.rs
@@ -16,7 +16,7 @@ use bytes::Bytes;
 use kitsune2_api::{
     decode_ids, DhtArc, Gossip, OpId, Timestamp, UNIX_TIMESTAMP,
 };
-use kitsune2_core::factories::MemoryOp;
+use kitsune2_core::factories::TestMemoryOp;
 use kitsune2_dht::{ArcSet, DhtSnapshot, SECTOR_SIZE};
 use kitsune2_test_utils::enable_tracing;
 use rand::RngCore;
@@ -53,7 +53,7 @@ async fn initiate_respect_size_limit_for_new_ops_and_disc() {
 
     let mut ops = Vec::new();
     for i in 0u8..(available_new_ops as u8) {
-        let op = MemoryOp::new(Timestamp::now(), vec![i; op_size]);
+        let op = TestMemoryOp::new(Timestamp::now(), vec![i; op_size]);
         ops.push(op);
     }
 
@@ -159,7 +159,7 @@ async fn initiate_respect_size_limit_for_new_ops_and_disc() {
         let mut op_data = (i as u32 * SECTOR_SIZE).to_le_bytes().to_vec();
         op_data.resize(op_size, 0);
 
-        let op = MemoryOp::new(Timestamp::from_micros(100 + i as i64), op_data);
+        let op = TestMemoryOp::new(Timestamp::from_micros(100 + i as i64), op_data);
         ops.push(op);
     }
 
@@ -277,7 +277,7 @@ async fn accept_respect_size_limit_for_new_ops_and_disc() {
 
     let mut ops = Vec::new();
     for i in 0u8..(available_new_ops as u8) {
-        let op = MemoryOp::new(Timestamp::now(), vec![i; op_size]);
+        let op = TestMemoryOp::new(Timestamp::now(), vec![i; op_size]);
         ops.push(op);
     }
 
@@ -398,7 +398,7 @@ async fn accept_respect_size_limit_for_new_ops_and_disc() {
         let mut op_data = (i as u32 * SECTOR_SIZE).to_le_bytes().to_vec();
         op_data.resize(op_size, 0);
 
-        let op = MemoryOp::new(Timestamp::from_micros(100 + i as i64), op_data);
+        let op = TestMemoryOp::new(Timestamp::from_micros(100 + i as i64), op_data);
         ops.push(op);
     }
 

--- a/crates/gossip/tests/historical_load.rs
+++ b/crates/gossip/tests/historical_load.rs
@@ -3,7 +3,7 @@
 //! This test uses the default network transport and creates enough data to be realistic.
 
 use kitsune2_api::{DhtArc, Timestamp};
-use kitsune2_core::factories::MemoryOp;
+use kitsune2_core::factories::{MemoryOp, TestMemoryOp};
 use kitsune2_gossip::harness::{K2GossipFunctionalTestFactory, MemoryOpRecord};
 use kitsune2_gossip::K2GossipConfig;
 use kitsune2_test_utils::space::TEST_SPACE_ID;
@@ -56,7 +56,7 @@ async fn historical_load() {
             % (MAX_OP_SIZE_BYTES - MIN_OP_SIZE_BYTES)
             + MIN_OP_SIZE_BYTES;
 
-        let op = MemoryOp::new(time, random_bytes(op_size as u16));
+        let op = TestMemoryOp::new(time, random_bytes(op_size as u16));
         ops.push(MemoryOpRecord {
             op_id: op.compute_op_id(),
             op_data: op.op_data,

--- a/crates/gossip/tests/initial_sync.rs
+++ b/crates/gossip/tests/initial_sync.rs
@@ -3,7 +3,7 @@
 //! This is a UX test more than a functional test.
 
 use kitsune2_api::{DhtArc, Timestamp};
-use kitsune2_core::factories::MemoryOp;
+use kitsune2_core::factories::{MemoryOp, TestMemoryOp};
 use kitsune2_gossip::harness::{K2GossipFunctionalTestFactory, MemoryOpRecord};
 use kitsune2_test_utils::space::TEST_SPACE_ID;
 use kitsune2_test_utils::{enable_tracing_with_default_level, random_bytes};
@@ -30,7 +30,8 @@ async fn two_new_agents_sync() {
     for _ in 0..NUM_OPS {
         let op_size = rand::random::<usize>() % 1000 + 500;
 
-        let op = MemoryOp::new(Timestamp::now(), random_bytes(op_size as u16));
+        let op =
+            TestMemoryOp::new(Timestamp::now(), random_bytes(op_size as u16));
         ops.push(MemoryOpRecord {
             op_id: op.compute_op_id(),
             op_data: op.op_data,
@@ -92,7 +93,8 @@ async fn new_agent_joins_existing_network() {
     for _ in 0..NUM_OPS {
         let op_size = rand::random::<usize>() % 1000 + 500;
 
-        let op = MemoryOp::new(Timestamp::now(), random_bytes(op_size as u16));
+        let op =
+            TestMemoryOp::new(Timestamp::now(), random_bytes(op_size as u16));
         ops.push(MemoryOpRecord {
             op_id: op.compute_op_id(),
             op_data: op.op_data,

--- a/crates/kitsune2/src/lib.rs
+++ b/crates/kitsune2/src/lib.rs
@@ -14,7 +14,7 @@
 
 use kitsune2_api::*;
 use kitsune2_core::{
-    factories::{self, MemOpStoreFactory},
+    factories::{self, MemOpStoreFactory, TestMemoryOp},
     Ed25519Verifier,
 };
 use kitsune2_gossip::K2GossipFactory;
@@ -47,7 +47,7 @@ pub fn default_builder() -> Builder {
         bootstrap: factories::CoreBootstrapFactory::create(),
         fetch: factories::CoreFetchFactory::create(),
         transport: Tx5TransportFactory::create(),
-        op_store: MemOpStoreFactory::create(),
+        op_store: MemOpStoreFactory::<TestMemoryOp>::create(),
         peer_meta_store: factories::MemPeerMetaStoreFactory::create(),
         gossip: K2GossipFactory::create(),
         local_agent_store: factories::CoreLocalAgentStoreFactory::create(),

--- a/crates/kitsune2/tests/integration.rs
+++ b/crates/kitsune2/tests/integration.rs
@@ -7,7 +7,7 @@ use kitsune2_api::{
 use kitsune2_core::{
     factories::{
         config::{CoreBootstrapConfig, CoreBootstrapModConfig},
-        MemoryOp,
+        MemoryOp, TestMemoryOp,
     },
     Ed25519LocalAgent,
 };
@@ -26,7 +26,8 @@ fn create_op_list(num_ops: u16) -> (Vec<Bytes>, Vec<OpId>) {
     let mut ops = Vec::new();
     let mut op_ids = Vec::new();
     for _ in 0..num_ops {
-        let op = MemoryOp::new(Timestamp::from_micros(0), random_bytes(256));
+        let op =
+            TestMemoryOp::new(Timestamp::from_micros(0), random_bytes(256));
         let op_id = op.compute_op_id();
         ops.push(op.into());
         op_ids.push(op_id);

--- a/crates/kitsune2_showcase/src/app.rs
+++ b/crates/kitsune2_showcase/src/app.rs
@@ -4,7 +4,10 @@ use chrono::{DateTime, Local};
 use file_data::FileData;
 use file_op_store::{FileOpStoreFactory, FileStoreLookup};
 use kitsune2_api::*;
-use kitsune2_core::{factories::MemoryOp, get_all_remote_agents};
+use kitsune2_core::{
+    factories::{MemoryOp, TestMemoryOp},
+    get_all_remote_agents,
+};
 use kitsune2_transport_tx5::{IceServers, WebRtcConfig};
 use std::{ffi::OsStr, fmt::Debug, path::Path, sync::Arc, time::SystemTime};
 use tokio::{
@@ -272,7 +275,7 @@ impl App {
             .await
             .expect("Failed to print message");
 
-        let op = MemoryOp::new(Timestamp::now(), data.into_bytes());
+        let op = TestMemoryOp::new(Timestamp::now(), data.into_bytes());
         let op_id = op.compute_op_id();
 
         self.space
@@ -346,7 +349,7 @@ impl App {
                 .expect("Failed to print message");
 
             for op in stored_ops {
-                let mem_op = MemoryOp::from(op.op_data);
+                let mem_op = TestMemoryOp::from(op.op_data);
                 let created_at = DateTime::<Local>::from(SystemTime::from(
                     mem_op.created_at,
                 ));
@@ -388,7 +391,7 @@ impl App {
             if let Some(file_data) = stored_ops
                 .into_iter()
                 .filter_map(|op| {
-                    let mem_op = MemoryOp::from(op.op_data);
+                    let mem_op = TestMemoryOp::from(op.op_data);
                     serde_json::from_slice::<FileData>(&mem_op.op_data).ok()
                 })
                 .find(|file_data| file_data.name == file_name)

--- a/crates/kitsune2_showcase/src/app/file_op_store.rs
+++ b/crates/kitsune2_showcase/src/app/file_op_store.rs
@@ -74,8 +74,8 @@ impl OpStore for FileOpStore {
             let file_names = op_list
                 .iter()
                 .map(|op| {
-                    let mem_op = MemoryOpRecord::<TestMemoryOp>::from(op.clone());
-                     serde_json::from_slice::<FileData>(mem_op.op_data())
+                    let record = MemoryOpRecord::<TestMemoryOp>::new(op.clone()).unwrap();
+                     serde_json::from_slice::<FileData>(record.op.to_bytes().as_ref())
                         .map(|f| f.name)
                 })
                 .collect::<Result<Vec<_>, _>>().map_err(|e| {

--- a/crates/transport_tx5/src/lib.rs
+++ b/crates/transport_tx5/src/lib.rs
@@ -33,8 +33,9 @@ trait SigUrlExt {
 
 impl SigUrlExt for &str {
     fn to_sig_url(&self) -> K2Result<tx5::SigUrl> {
-        tx5::SigUrl::parse(self)
-            .map_err(|e| K2Error::other_src("parsing tx5 sig url", e))
+        tx5::SigUrl::parse(self).map_err(|e| {
+            K2Error::other_src(&format!("parsing tx5 sig url: {self}"), e)
+        })
     }
 }
 


### PR DESCRIPTION
I'm going to try integrating kitsune2 into a project as a standalone, with no Holochain. So far so good, but here is a change I found helpful.

`Kitsune2MemoryOpStore` is useful for testing other kitsune hosts, but it is written to be used with `MemoryOp` which is clearly for testing purposes -- its `OpId` implementation is intentionally not robust, making it unsuitable for real-world situations. Aside from that, host implementers will have written their own custom op types, and having to convert to `MemoryOp` isn't great. A better pattern is that any reusable OpStore implementation should be abstract over its op data.

I defined a trait that has the key elements necessary for working with your mem op store implementation: `created_at` timestamp, op id calculation, and serialization. This lets users more quickly get up and running with `Kitsune2MemoryOpStore`, which as far as I know is the *only* working OpStore implementation in the world aside from Holochain's. Without this, your first attempts at hooking up your own custom op type likely result in confusing deserialization errors, and in my case, discovering that I got the same OpId for every op due to the first 32 bytes being the same.

If you don't want to use this that's fine, but I will be using this in my branch.