### PR TITLE
fix: Close connections when marking a peer unresponsive

### DIFF
--- a/crates/transport_tx5/src/lib.rs
+++ b/crates/transport_tx5/src/lib.rs
@@ -337,6 +337,7 @@ impl TxImp for Tx5Transport {
                     .handler
                     .set_unresponsive(peer.clone(), Timestamp::now())
                     .await;
+                self.ep.close(&peer.to_peer_url()?);
                 return Err(K2Error::other_src(
                     format!("tx5 send error to peer at url {peer}"),
                     e,


### PR DESCRIPTION
I expected the transport to just deal with this but it seems that it can take a bit of time for the transport to notice that something is wrong even if you get an error that causes you to mark the peer as unresponsive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Ensure peer endpoints are closed after failed sends to unresponsive/nonexistent peers, preventing stale connections and improving stability and reported network stats.

- Tests
  - Enabled tracing for diagnostics, switched to dynamic test URLs, and added assertions to confirm no active connections remain after failure scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->