### PR TITLE
Improve flaky tests

### DIFF
--- a/crates/gossip/tests/initial_sync.rs
+++ b/crates/gossip/tests/initial_sync.rs
@@ -57,11 +57,11 @@ async fn two_new_agents_sync() {
         .await;
 
     // Then both agents should have reached full arc.
-    harness_1
-        .wait_for_full_arc_for_all(Duration::from_secs(5))
-        .await;
     harness_2
-        .wait_for_full_arc_for_all(Duration::from_secs(5))
+        .wait_for_full_arc_for_all(Duration::from_secs(10))
+        .await;
+    harness_1
+        .wait_for_full_arc_for_all(Duration::from_secs(10))
         .await;
 }
 

--- a/crates/kitsune2/tests/integration.rs
+++ b/crates/kitsune2/tests/integration.rs
@@ -171,7 +171,7 @@ async fn two_node_gossip() {
         .unwrap();
 
     // Wait for gossip to exchange all ops.
-    iter_check!(5000, 500, {
+    iter_check!(15000, 500, {
         let actual_ops_1 = space_1
             .op_store()
             .retrieve_ops(op_ids_2.clone())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Increased timeouts in sync tests to improve stability in slower environments.
  * Swapped the order of waiting for full synchronization between peers to reduce flakiness.
  * Extended the gossip wait window (from ~5s to ~15s) while keeping check intervals unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->