### PR TITLE
fix: Use default-features = false for transport dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ panic = "abort"
 [workspace.dependencies]
 # Self dependencies for workspace crates to depend on each other.
 # For example, most crates will depend on the api crate.
-kitsune2 = { version = "0.3.0-dev.1", path = "crates/kitsune2" }
+kitsune2 = { version = "0.3.0-dev.1", path = "crates/kitsune2", default-features = false }
 kitsune2_api = { version = "0.3.0-dev.1", path = "crates/api" }
 kitsune2_dht = { version = "0.3.0-dev.1", path = "crates/dht" }
 kitsune2_gossip = { version = "0.3.0-dev.1", path = "crates/gossip" }

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -36,16 +36,16 @@ args = ["test"]
 [tasks.test-go-pion]
 command = "cargo"
 args = [
-    "test",
-    "--package",
-    "kitsune2_transport_tx5",
-    "--package",
-    "kitsune2",
-    "--no-default-features",
-    "--features",
-    "backend-go-pion",
-    "--",
-    "--nocapture",
+  "test",
+  "--package",
+  "kitsune2_transport_tx5",
+  "--package",
+  "kitsune2",
+  "--no-default-features",
+  "--features",
+  "backend-go-pion",
+  "--",
+  "--nocapture",
 ]
 
 #
@@ -79,7 +79,7 @@ dependencies = ["format-toml-check", "format-check", "clippy", "doc-check"]
 
 [tasks.verify]
 description = "Run all static checks and tests"
-dependencies = ["static", "test"]
+dependencies = ["static", "test", "test-go-pion"]
 
 [tasks.fix]
 description = "Run all tasks to format, generate and tidy"

--- a/crates/kitsune2/Cargo.toml
+++ b/crates/kitsune2/Cargo.toml
@@ -20,7 +20,7 @@ bytes = { workspace = true }
 kitsune2_api = { workspace = true }
 kitsune2_core = { workspace = true }
 kitsune2_gossip = { workspace = true }
-kitsune2_transport_tx5 = { workspace = true }
+kitsune2_transport_tx5 = { workspace = true, default-features = false }
 serde = { workspace = true, features = ["derive"] }
 
 # Feature: schema

--- a/crates/kitsune2/Makefile.toml
+++ b/crates/kitsune2/Makefile.toml
@@ -1,1 +1,14 @@
 extend = "../../Makefile.toml"
+
+[tasks.clippy]
+args = [
+  "clippy",
+  "--all-targets",
+  "--features",
+  "datachannel-vendored",
+  "--",
+  "--deny=warnings",
+]
+
+[tasks.test]
+args = ["test", "--no-default-features", "--features", "datachannel-vendored"]

--- a/crates/kitsune2_showcase/Cargo.toml
+++ b/crates/kitsune2_showcase/Cargo.toml
@@ -18,7 +18,9 @@ clap = { workspace = true, features = ["derive", "wrap_help"] }
 kitsune2 = { workspace = true }
 kitsune2_api = { workspace = true }
 kitsune2_core = { workspace = true }
-kitsune2_transport_tx5 = { workspace = true }
+kitsune2_transport_tx5 = { workspace = true, features = [
+  "datachannel-vendored",
+] }
 rustls = { workspace = true }
 rustyline = { workspace = true, features = ["derive"] }
 serde = { workspace = true }

--- a/crates/transport_tx5/Cargo.toml
+++ b/crates/transport_tx5/Cargo.toml
@@ -36,7 +36,9 @@ tokio = { workspace = true, features = ["full"] }
 kitsune2_test_utils = { workspace = true }
 sbd-server = { workspace = true }
 kitsune2_core = { workspace = true }
-kitsune2_transport_tx5 = { path = ".", features = ["test-utils"] }
+kitsune2_transport_tx5 = { path = ".", default-features = false, features = [
+  "test-utils",
+] }
 
 [features]
 default = ["datachannel-vendored"]

--- a/crates/transport_tx5/Makefile.toml
+++ b/crates/transport_tx5/Makefile.toml
@@ -1,1 +1,15 @@
 extend = "../../Makefile.toml"
+
+[tasks.clippy]
+args = [
+  "clippy",
+  "--all-targets",
+  "--no-default-features",
+  "--features",
+  "datachannel-vendored",
+  "--",
+  "--deny=warnings",
+]
+
+[tasks.test]
+args = ["test", "--no-default-features", "--features", "datachannel-vendored"]

--- a/crates/transport_tx5/src/test.rs
+++ b/crates/transport_tx5/src/test.rs
@@ -454,7 +454,7 @@ async fn dump_network_stats() {
     assert_eq!(stats_1.backend, "BackendGoPion");
     #[cfg(all(
         feature = "backend-go-pion",
-        not(feature = "backend-libdatachannel")
+        feature = "backend-libdatachannel"
     ))]
     panic!("This test must be run with either libdatachannel or go-pion enabled, but not both.");
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Disabled default features for several workspace dependencies to standardize builds.
  * Added verification, linting, and test automation tasks across crates (including a go-pion test in verify).
  * Introduced vendored-datachannel lint/test tasks and enabled vendored datachannel for the showcase.
  * Made dev-dependency test configuration explicit to control test-time features.

* **Tests**
  * Adjusted a test's compilation condition — affects test builds only, no user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->