### PR TITLE
fix: Increase default re-insert delay for fetch requests

### DIFF
--- a/crates/core/src/factories/core_fetch.rs
+++ b/crates/core/src/factories/core_fetch.rs
@@ -34,7 +34,7 @@ mod config {
         pub parallel_request_count: u8,
         /// Delay before re-inserting ops to request back into the outgoing request queue.
         ///
-        /// Default: 2 s.
+        /// Default: 30 s.
         #[cfg_attr(feature = "schema", schemars(default))]
         pub re_insert_outgoing_request_delay_ms: u32,
     }
@@ -44,7 +44,7 @@ mod config {
         fn default() -> Self {
             Self {
                 parallel_request_count: 2,
-                re_insert_outgoing_request_delay_ms: 2000,
+                re_insert_outgoing_request_delay_ms: 30000,
             }
         }
     }


### PR DESCRIPTION
This should improve performance because the fast fetch retry could spam the target before they get a chance to respond

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Chores
  * Increased the default retry interval for outgoing requests from 2s to 30s to reduce network churn and improve stability. Users may observe fewer rapid retry attempts and longer waits before failed requests are re-queued; successful requests remain unaffected. No action required unless you rely on the previous short retry cadence—custom intervals still override the default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->