### PR TITLE
fix: are_all_blocked() returns false if an empty target list is provided

### DIFF
--- a/crates/core/src/factories/mem_blocks.rs
+++ b/crates/core/src/factories/mem_blocks.rs
@@ -78,6 +78,9 @@ impl Blocks for MemBlocks {
         &self,
         targets: Vec<BlockTarget>,
     ) -> BoxFut<'static, K2Result<bool>> {
+        if targets.is_empty() {
+            return Box::pin(async { Ok(false) });
+        }
         let inner = self.0.lock().expect("MemBlocks inner Mutex is poisoned");
         let are_all_blocked =
             targets.iter().all(|target| inner.contains(target));

--- a/crates/core/src/factories/mem_blocks/test.rs
+++ b/crates/core/src/factories/mem_blocks/test.rs
@@ -67,3 +67,9 @@ async fn all_targets_are_blocked_when_checking() {
         .await
         .unwrap());
 }
+
+#[tokio::test]
+async fn checking_empty_target_list_returns_false() {
+    let blocks = MemBlocks::default();
+    assert!(!blocks.are_all_blocked(vec![]).await.unwrap());
+}


### PR DESCRIPTION
Fixes a bug in the MemBlocks implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Corrected block evaluation for empty target lists: an empty input now returns “not blocked” instead of being treated as fully blocked, preventing unintended blocking in edge cases.

- Tests
  - Added an asynchronous test to verify the corrected behavior for empty target lists, ensuring this edge case remains covered.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->