### PR TITLE
refactor: make preflight handlers async

### DIFF
--- a/crates/api/src/kitsune.rs
+++ b/crates/api/src/kitsune.rs
@@ -25,9 +25,9 @@ pub trait KitsuneHandler: 'static + Send + Sync + std::fmt::Debug {
     fn preflight_gather_outgoing(
         &self,
         peer_url: Url,
-    ) -> K2Result<bytes::Bytes> {
+    ) -> BoxFut<'_, K2Result<bytes::Bytes>> {
         drop(peer_url);
-        Ok(bytes::Bytes::new())
+        Box::pin(async { Ok(bytes::Bytes::new()) })
     }
 
     /// Validate preflight data sent by a remote peer on a new connection.
@@ -39,10 +39,10 @@ pub trait KitsuneHandler: 'static + Send + Sync + std::fmt::Debug {
         &self,
         peer_url: Url,
         data: bytes::Bytes,
-    ) -> K2Result<()> {
+    ) -> BoxFut<'_, K2Result<()>> {
         drop(peer_url);
         drop(data);
-        Ok(())
+        Box::pin(async { Ok(()) })
     }
 
     /// Kitsune would like to construct a space. Provide a handler.

--- a/crates/core/src/factories/core_kitsune.rs
+++ b/crates/core/src/factories/core_kitsune.rs
@@ -55,7 +55,7 @@ impl TxHandler for TxHandlerTranslator {
     fn preflight_gather_outgoing(
         &self,
         peer_url: Url,
-    ) -> K2Result<bytes::Bytes> {
+    ) -> BoxFut<'_, K2Result<bytes::Bytes>> {
         self.0.preflight_gather_outgoing(peer_url)
     }
 
@@ -63,7 +63,7 @@ impl TxHandler for TxHandlerTranslator {
         &self,
         peer_url: Url,
         data: bytes::Bytes,
-    ) -> K2Result<()> {
+    ) -> BoxFut<'_, K2Result<()>> {
         self.0.preflight_validate_incoming(peer_url, data)
     }
 }

--- a/crates/core/src/factories/mem_transport.rs
+++ b/crates/core/src/factories/mem_transport.rs
@@ -319,7 +319,7 @@ async fn cmd_task(
     while let Some(cmd) = cmd_recv.recv().await {
         match cmd {
             Cmd::RegisterConnection(url, data_send, mut data_recv) => {
-                match handler.peer_connect(url.clone()) {
+                match handler.peer_connect(url.clone()).await {
                     Err(_) => continue,
                     Ok(preflight) => {
                         let (result_sender, _) =
@@ -366,7 +366,7 @@ async fn cmd_task(
                     r.recv_message_count += 1;
                     r.recv_bytes += data.len() as u64;
                 });
-                if let Err(err) = handler.recv_data(url.clone(), data) {
+                if let Err(err) = handler.recv_data(url.clone(), data).await {
                     if let Some(mut drop_send) = con_pool.remove(&url) {
                         drop_send.reason = Some(format!("{err:?}"));
                     }

--- a/crates/core/src/factories/mem_transport/test.rs
+++ b/crates/core/src/factories/mem_transport/test.rs
@@ -49,16 +49,16 @@ impl TxHandler for TrackHnd {
     fn preflight_gather_outgoing(
         &self,
         peer_url: Url,
-    ) -> K2Result<bytes::Bytes> {
-        (self.preflight_gather_outgoing)(peer_url)
+    ) -> BoxFut<'_, K2Result<bytes::Bytes>> {
+        Box::pin(async { (self.preflight_gather_outgoing)(peer_url) })
     }
 
     fn preflight_validate_incoming(
         &self,
         peer_url: Url,
         data: bytes::Bytes,
-    ) -> K2Result<()> {
-        (self.preflight_validate_incoming)(peer_url, data)
+    ) -> BoxFut<'_, K2Result<()>> {
+        Box::pin(async { (self.preflight_validate_incoming)(peer_url, data) })
     }
 }
 

--- a/crates/transport_tx5/src/harness.rs
+++ b/crates/transport_tx5/src/harness.rs
@@ -188,16 +188,16 @@ impl TxHandler for MockTxHandler {
     fn preflight_gather_outgoing(
         &self,
         peer_url: Url,
-    ) -> K2Result<bytes::Bytes> {
-        (self.pre_out)(peer_url)
+    ) -> BoxFut<'_, K2Result<bytes::Bytes>> {
+        Box::pin(async { (self.pre_out)(peer_url) })
     }
 
     fn preflight_validate_incoming(
         &self,
         peer_url: Url,
         data: bytes::Bytes,
-    ) -> K2Result<()> {
-        (self.pre_in)(peer_url, data)
+    ) -> BoxFut<'_, K2Result<()>> {
+        Box::pin(async { (self.pre_in)(peer_url, data) })
     }
 }
 


### PR DESCRIPTION
Makes the preflight handlers `preflight_validate_incoming()` and `preflight_gather_outgoing()` async on the `TxHandler` trait such that we can rely on peers sent via preflight to have been added to the peer store once the preflight has been handled and we handle further messages (that may depend on an up to date list of peers in the peer store).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Core transport and preflight processing converted to fully asynchronous flows for non-blocking, concurrent communication.

- Bug Fixes
  - Improved handling of incoming messages and disconnects to reduce errors and stale connections.

- Tests
  - Test harnesses and mocks updated to exercise the new async paths.

- Chores
  - Public handler interfaces adjusted to async futures; behavior preserved while enabling async integration and better diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->