### PR TITLE
Remove re insertion logic from fetching ops

### DIFF
--- a/crates/core/src/doc/core_fetch.rs
+++ b/crates/core/src/doc/core_fetch.rs
@@ -32,13 +32,9 @@
 //!     - In case the op to request has been received in the meantime and no longer needs to be
 //!       fetched, it will have been removed from the set. Do nothing.
 //!     - Otherwise proceed.
-//! - Check if the peer is on a back off list of unresponsive peers. If so, do not send a request.
+//! - Check if the peer is unresponsive. If so, do not send a request.
 //! - Dispatch request for op id from peer to transport module.
-//! - If the peer is unresponsive, put them on back off list. If maximum back off has been reached,
-//!   remove this and all other requests to the peer from the set.
-//! - Re-insert requested ([OpId], [Url]) into the queue. It will be removed
-//!   from the set of requests if it is received in the meantime, and thus prevent redundant
-//!   fetch requests.
+//! - If the request fails, remove this and all other requests to the peer from the set.
 //!
 //! #### Incoming requests
 //!

--- a/crates/core/src/factories/core_fetch.rs
+++ b/crates/core/src/factories/core_fetch.rs
@@ -192,11 +192,9 @@ impl Fetch for CoreFetch {
                         "could not insert fetch request into fetch queue"
                     );
                     // Remove request from state.
-                    self.state
-                        .lock()
-                        .unwrap()
-                        .requests
-                        .remove(&(op_id, source.clone()));
+                    let mut lock = self.state.lock().unwrap();
+                    lock.requests.remove(&(op_id, source.clone()));
+                    Self::notify_listeners_if_queue_drained(lock);
                 }
             }
 

--- a/crates/core/tests/fetch.rs
+++ b/crates/core/tests/fetch.rs
@@ -1,5 +1,5 @@
 use kitsune2_api::*;
-use kitsune2_core::factories::{CoreFetchConfig, CoreFetchModConfig};
+use kitsune2_core::factories::CoreFetchModConfig;
 use kitsune2_core::{default_test_builder, factories::MemoryOp};
 use kitsune2_test_utils::{
     enable_tracing, iter_check, random_bytes, space::TEST_SPACE_ID,
@@ -207,12 +207,7 @@ async fn two_peer_fetch() {
 #[tokio::test(flavor = "multi_thread")]
 async fn bob_comes_online_after_being_unresponsive() {
     enable_tracing();
-    let fetch_config_alice = CoreFetchModConfig {
-        core_fetch: CoreFetchConfig {
-            re_insert_outgoing_request_delay_ms: 10,
-            ..Default::default()
-        },
-    };
+    let fetch_config_alice = CoreFetchModConfig::default();
     let Peer {
         fetch: fetch_alice,
         op_store: op_store_alice,


### PR DESCRIPTION
Fetch requests for ops used to be re-inserted into the fetch request queue, until the incoming op would end these retries. This PR removes this re-insertion logic and simplifies the fetch request queue.

The flow used to be to add fetch requests to a state object, send the fetch requests and then re-insert these requests back into the fetch request queue after a delay. When the op would come in, all requests for this op still remaining in the state object were removed.

This is now simplified and every fetch request is sent once. Requests are not re-inserted into the queue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Immediately purge failed outgoing requests to unresponsive peers and ensure state updates occur before enqueueing to prevent stuck queues and race conditions.
  - Enhanced structured error logging for enqueue failures.

- **Refactor**
  - Removed delayed re-insert/backoff behavior and simplified outgoing-request ordering and handling; one configuration option was removed (breaking change).

- **Documentation**
  - Clarified outgoing fetch flow and failure handling to reflect immediate purge behavior.

- **Tests**
  - Tests moved to default configuration and rely on notification/drain-driven synchronization instead of timing sleeps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->