### PR TITLE
feat: include peer_unresponsive timestamp in GossipStateSummary

### DIFF
--- a/crates/api/src/gossip.rs
+++ b/crates/api/src/gossip.rs
@@ -92,6 +92,8 @@ pub struct PeerMeta {
     ///
     /// Note that termination is not necessarily an error.
     pub peer_terminated: Option<u32>,
+    /// The timestamp when the peer was marked unresponsive.
+    pub peer_unresponsive: Option<Timestamp>,
     /// The number of completed rounds.
     pub completed_rounds: Option<u32>,
     /// The number of peer timeouts.

--- a/crates/gossip/src/summary.rs
+++ b/crates/gossip/src/summary.rs
@@ -122,6 +122,10 @@ impl K2Gossip {
                         .peer_meta_store
                         .peer_terminated(url.clone())
                         .await?,
+                    peer_unresponsive: self
+                        .peer_meta_store
+                        .get_unresponsive(url.clone())
+                        .await?,
                     completed_rounds: self
                         .peer_meta_store
                         .completed_rounds(url.clone())


### PR DESCRIPTION
Adds `peer_unresponsive` to GossipStateSummary, which is exposed in holochain's `dump_network_metrics` call. This is helpful in diagnosing behavior with unresponsive peers.

Putting this field in `GossipStateSummary` isn't really the right place as it's not specifically related to gossip behavior. I'm not sure if that's worth addressing here.