### PR TITLE
refactor: convert Timestamp to bytes directly when storing in PeerMetaStore for set_unresponsive created timestamp

### DIFF
--- a/crates/api/src/peer_meta_store.rs
+++ b/crates/api/src/peer_meta_store.rs
@@ -52,7 +52,7 @@ pub trait PeerMetaStore: 'static + Send + Sync + std::fmt::Debug {
             self.put(
                 peer.clone(),
                 format!("{KEY_PREFIX_ROOT}:{META_KEY_UNRESPONSIVE}"),
-                serde_json::to_vec(&when).map_err(K2Error::other)?.into(),
+                when.into(),
                 Some(expiry),
             )
             .await?;
@@ -73,10 +73,7 @@ pub trait PeerMetaStore: 'static + Send + Sync + std::fmt::Debug {
             match maybe_value {
                 None => Ok(None),
                 Some(value) => {
-                    match serde_json::from_slice::<Timestamp>(&value) {
-                        Ok(when) => Ok(Some(when)),
-                        Err(err) => Err(K2Error::other(err)),
-                    }
+                    Ok(Some(value.try_into().map_err(K2Error::other)?))
                 }
             }
         })

--- a/crates/api/src/timestamp.rs
+++ b/crates/api/src/timestamp.rs
@@ -97,3 +97,18 @@ impl From<Timestamp> for std::time::SystemTime {
             + std::time::Duration::from_micros(t.0 as u64)
     }
 }
+
+impl TryFrom<bytes::Bytes> for Timestamp {
+    type Error = std::array::TryFromSliceError;
+
+    fn try_from(value: bytes::Bytes) -> Result<Self, Self::Error> {
+        let array: [u8; 8] = value.as_ref().try_into()?;
+        Ok(Self(i64::from_ne_bytes(array)))
+    }
+}
+
+impl From<Timestamp> for bytes::Bytes {
+    fn from(val: Timestamp) -> Self {
+        bytes::Bytes::copy_from_slice(&val.0.to_ne_bytes())
+    }
+}


### PR DESCRIPTION
Part of resolving https://github.com/holochain/holochain/issues/5376

Previously, `set_unresponsive` and `get_unresponsive` were using serde_json to convert a `Timestamp` to byte array and back.

This allowed for a bug downstream, where holochain attempted to decode the byte array using rmp_serde.

This PR implements `From` and `TryFrom` so there is a canonical way for Timestamp to be converted directly to `Bytes` and back. These are now used in `set_unresponsive` and `get_unresponsive`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal timestamp storage and conversion mechanisms for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->