### PR TITLE
feat: expose webrtc_connect_timeout to Tx5TransportConfig

### DIFF
--- a/crates/kitsune2/tests/integration.rs
+++ b/crates/kitsune2/tests/integration.rs
@@ -74,6 +74,7 @@ async fn make_kitsune_node(
                 server_url: signal_server_url.to_owned(),
                 signal_allow_plain_text: true,
                 timeout_s: 5,
+                webrtc_connect_timeout_s: 3,
                 ..Default::default()
             },
         })


### PR DESCRIPTION
Resolves #360 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WebRTC connection timeout is now separately configurable, defaulting to 45 seconds and applied during transport initialization.

* **Bug Fixes**
  * Validation enforces the WebRTC connect timeout to be strictly less than the overall timeout to prevent invalid configs.

* **Tests**
  * Added unit and integration tests validating timeout rules and ensuring the new setting behaves as expected.

* **Documentation**
  * Updated config docs and inline descriptions clarifying timeout behavior and defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->