### PR TITLE
fix: unable to build libdatachannel in nix devShell due to missing clang lib

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -67,6 +67,7 @@
                 cargo-make
                 taplo
                 perl
+                go
                 cmake
                 openssl
                 llvmPackages.clang


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added LLVM/Clang tooling to the development environment for improved build and analysis.
  * Reworked dev-shell declaration and structure for a cleaner, more consistent local setup.
  * Improved libclang path resolution and adjusted runtime toolchain invocation to make local tooling more reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->