### PR TITLE
build: prepare release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,56 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## \[[0.4.0](https://github.com/holochain/kitsune2/compare/v0.3.0...v0.4.0)\] - 2025-11-29
+
+### Features
+
+- Add iroh transport by @jost-s in [#382](https://github.com/holochain/kitsune2/pull/382)
+- Implement tracking peer access state as peers are added and removed in the peer store, so that the access check can be sync without needing to use `block_on` by @ThetaSinner
+- \[**BREAKING**\] Expose webrtc_connect_timeout to Tx5TransportConfig (#361) by @mattyg in [#361](https://github.com/holochain/kitsune2/pull/361)
+
+### Bug Fixes
+
+- Reduce log size of `ArcSet` with custom `Debug` implementation by @ThetaSinner in [#366](https://github.com/holochain/kitsune2/pull/366)
+- Drop locks as soon as possible when sending fetch queue drained notifications by @ThetaSinner
+- Unable to build libdatachannel in nix devShell due to missing clang lib (#363) by @mattyg in [#363](https://github.com/holochain/kitsune2/pull/363)
+- Reduce lock hold on `space_map` by @ThetaSinner in [#362](https://github.com/holochain/kitsune2/pull/362)
+
+### Miscellaneous Tasks
+
+- Describe error context when transcoding config by @jost-s
+- Upgrade rust to v1.91.1 by @jost-s in [#385](https://github.com/holochain/kitsune2/pull/385)
+- Stop printing on entry to `wait_ready` by @ThetaSinner in [#374](https://github.com/holochain/kitsune2/pull/374)
+- Bump tx5 to v0.8.1 & sbd to v0.4.0 by @jost-s in [#376](https://github.com/holochain/kitsune2/pull/376)
+
+### Build System
+
+- \[**BREAKING**\] Prefix tx5 and iroh features with transport by @jost-s in [#393](https://github.com/holochain/kitsune2/pull/393)
+- Add iroh feature by @jost-s
+- Upgrade sbd-server to 0.4.0, adds a cli arg 'otlp_endpoint' to kitsune2-bootstrap-server for configuring an opentelemetry endpoint for the sbd server (#375) by @mattyg in [#375](https://github.com/holochain/kitsune2/pull/375)
+
+### CI
+
+- Release from release branches by @ThetaSinner in [#367](https://github.com/holochain/kitsune2/pull/367)
+
+### Testing
+
+- Extract fn encode_frame_header and write unit tests in iroh transport by @jost-s in [#392](https://github.com/holochain/kitsune2/pull/392)
+- Add unit tests for decode_frame in iroh transport by @jost-s
+- Add iroh integration test harness and move tests by @jost-s
+- Improve error messaging in tests by @ThetaSinner
+- Add new `TestTxHandler` that can be used in tests that need a preflight implementation that shares agents by @ThetaSinner
+- Improve flaky gossip tests for sync by @ThetaSinner in [#365](https://github.com/holochain/kitsune2/pull/365)
+
+### Automated Changes
+
+- *(deps)* Bump actions/checkout from 5 to 6 by @dependabot[bot] in [#383](https://github.com/holochain/kitsune2/pull/383)
+  - Bumps [actions/checkout](https://github.com/actions/checkout) from 5 to 6. - [Release notes](https://github.com/actions/checkout/releases) - [Changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md) - [Commits](https://github.com/actions/checkout/compare/v5...v6)
+  - Updated-dependencies: - dependency-name: actions/checkout   dependency-version: '6'   dependency-type: direct:production   update-type: version-update:semver-major ...
+
+### First-time Contributors
+
+- @mattyg made their first contribution in [#375](https://github.com/holochain/kitsune2/pull/375)
 ## \[[0.3.0](https://github.com/holochain/kitsune2/compare/v0.2.11...v0.3.0)\] - 2025-11-04
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2539,7 +2539,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune2"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "jsonschema",
@@ -2559,7 +2559,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_api"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64",
  "bytes",
@@ -2578,7 +2578,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_bootstrap_client"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "axum",
  "axum-server",
@@ -2598,7 +2598,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_bootstrap_srv"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-channel",
  "axum",
@@ -2629,7 +2629,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "ed25519-dalek 2.2.0",
@@ -2650,7 +2650,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_dht"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "kitsune2_api",
@@ -2664,7 +2664,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_gossip"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64",
  "bytes",
@@ -2686,7 +2686,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_showcase"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -2709,7 +2709,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_test_utils"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "axum",
  "bytes",
@@ -2725,7 +2725,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_transport_iroh"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "bytes",
  "futures",
@@ -2743,7 +2743,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_transport_tx5"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64",
  "bytes",
@@ -5450,7 +5450,7 @@ dependencies = [
 
 [[package]]
 name = "tool_proto_build"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "prost-build",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 homepage = "https://www.holochain.org/"
 repository = "https://github.com/holochain/kitsune2"
@@ -35,13 +35,13 @@ panic = "abort"
 [workspace.dependencies]
 # Self dependencies for workspace crates to depend on each other.
 # For example, most crates will depend on the api crate.
-kitsune2 = { version = "0.3.0-dev.1", path = "crates/kitsune2", default-features = false }
-kitsune2_api = { version = "0.3.0-dev.1", path = "crates/api" }
-kitsune2_dht = { version = "0.3.0-dev.1", path = "crates/dht" }
-kitsune2_gossip = { version = "0.3.0-dev.1", path = "crates/gossip" }
-kitsune2_transport_tx5 = { version = "0.3.0-dev.1", path = "crates/transport_tx5", default-features = false }
-kitsune2_transport_iroh = { version = "0.3.0-dev.1", path = "crates/transport_iroh" }
-kitsune2_bootstrap_client = { version = "0.3.0-dev.1", path = "crates/bootstrap_client" }
+kitsune2 = { version = "0.4.0", path = "crates/kitsune2", default-features = false }
+kitsune2_api = { version = "0.4.0", path = "crates/api" }
+kitsune2_dht = { version = "0.4.0", path = "crates/dht" }
+kitsune2_gossip = { version = "0.4.0", path = "crates/gossip" }
+kitsune2_transport_tx5 = { version = "0.4.0", path = "crates/transport_tx5", default-features = false }
+kitsune2_transport_iroh = { version = "0.4.0", path = "crates/transport_iroh" }
+kitsune2_bootstrap_client = { version = "0.4.0", path = "crates/bootstrap_client" }
 
 # used by bootstrap_srv for mpmc worker queue pattern.
 async-channel = "2.3.1"
@@ -134,9 +134,9 @@ prost-build = "0.14"
 # Please be careful to only include them in dev dependencies or move them
 # above this section.
 # --- dev-dependencies ---
-kitsune2_bootstrap_srv = { version = "0.3.0-dev.1", path = "crates/bootstrap_srv" }
-kitsune2_core = { version = "0.3.0-dev.1", path = "crates/core" }
-kitsune2_test_utils = { version = "0.3.0-dev.1", path = "crates/test_utils" }
+kitsune2_bootstrap_srv = { version = "0.4.0", path = "crates/bootstrap_srv" }
+kitsune2_core = { version = "0.4.0", path = "crates/core" }
+kitsune2_test_utils = { version = "0.4.0", path = "crates/test_utils" }
 
 # used to test the bootstrap server with SBD enabled
 sbd-client = "0.3.2"


### PR DESCRIPTION
I needed to run a patched version of holochain_release_util locally because cargo-semver-checks could not recognize the breaking changes. See https://github.com/holochain/release-integration/issues/19#issuecomment-3591823673

If we prefer to wait to release the iroh work until all its tickets are completed, I can revise this to cherry pick only the changes needed for https://github.com/holochain/holochain/pull/5428

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Version 0.4.0 released with new features, bug fixes, and improvements
  
* **Documentation**
  * Updated changelog with comprehensive release notes for v0.4.0

* **Chores**
  * Updated internal dependencies to 0.4.0 across all packages

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->