### PR TITLE
chore: prepare release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## \[[0.4.0](https://github.com/holochain/kitsune2/compare/v0.3.0...v0.4.0)\] - 2025-11-29
+## \[[0.4.0-dev.0](https://github.com/holochain/kitsune2/compare/v0.3.0...v0.4.0-dev.0)\] - 2025-12-02
 
 ### Features
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2539,7 +2539,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune2"
-version = "0.4.0"
+version = "0.4.0-dev.0"
 dependencies = [
  "bytes",
  "jsonschema",
@@ -2559,7 +2559,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_api"
-version = "0.4.0"
+version = "0.4.0-dev.0"
 dependencies = [
  "base64",
  "bytes",
@@ -2578,7 +2578,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_bootstrap_client"
-version = "0.4.0"
+version = "0.4.0-dev.0"
 dependencies = [
  "axum",
  "axum-server",
@@ -2598,7 +2598,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_bootstrap_srv"
-version = "0.4.0"
+version = "0.4.0-dev.0"
 dependencies = [
  "async-channel",
  "axum",
@@ -2629,7 +2629,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_core"
-version = "0.4.0"
+version = "0.4.0-dev.0"
 dependencies = [
  "bytes",
  "ed25519-dalek 2.2.0",
@@ -2650,7 +2650,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_dht"
-version = "0.4.0"
+version = "0.4.0-dev.0"
 dependencies = [
  "bytes",
  "kitsune2_api",
@@ -2664,7 +2664,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_gossip"
-version = "0.4.0"
+version = "0.4.0-dev.0"
 dependencies = [
  "base64",
  "bytes",
@@ -2686,7 +2686,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_showcase"
-version = "0.4.0"
+version = "0.4.0-dev.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -2709,7 +2709,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_test_utils"
-version = "0.4.0"
+version = "0.4.0-dev.0"
 dependencies = [
  "axum",
  "bytes",
@@ -2725,7 +2725,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_transport_iroh"
-version = "0.4.0"
+version = "0.4.0-dev.0"
 dependencies = [
  "bytes",
  "futures",
@@ -2743,7 +2743,7 @@ dependencies = [
 
 [[package]]
 name = "kitsune2_transport_tx5"
-version = "0.4.0"
+version = "0.4.0-dev.0"
 dependencies = [
  "base64",
  "bytes",
@@ -5450,7 +5450,7 @@ dependencies = [
 
 [[package]]
 name = "tool_proto_build"
-version = "0.4.0"
+version = "0.4.0-dev.0"
 dependencies = [
  "prost-build",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.0-dev.0"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 homepage = "https://www.holochain.org/"
 repository = "https://github.com/holochain/kitsune2"
@@ -35,13 +35,13 @@ panic = "abort"
 [workspace.dependencies]
 # Self dependencies for workspace crates to depend on each other.
 # For example, most crates will depend on the api crate.
-kitsune2 = { version = "0.4.0", path = "crates/kitsune2", default-features = false }
-kitsune2_api = { version = "0.4.0", path = "crates/api" }
-kitsune2_dht = { version = "0.4.0", path = "crates/dht" }
-kitsune2_gossip = { version = "0.4.0", path = "crates/gossip" }
-kitsune2_transport_tx5 = { version = "0.4.0", path = "crates/transport_tx5", default-features = false }
-kitsune2_transport_iroh = { version = "0.4.0", path = "crates/transport_iroh" }
-kitsune2_bootstrap_client = { version = "0.4.0", path = "crates/bootstrap_client" }
+kitsune2 = { version = "0.4.0-dev.0", path = "crates/kitsune2", default-features = false }
+kitsune2_api = { version = "0.4.0-dev.0", path = "crates/api" }
+kitsune2_dht = { version = "0.4.0-dev.0", path = "crates/dht" }
+kitsune2_gossip = { version = "0.4.0-dev.0", path = "crates/gossip" }
+kitsune2_transport_tx5 = { version = "0.4.0-dev.0", path = "crates/transport_tx5", default-features = false }
+kitsune2_transport_iroh = { version = "0.4.0-dev.0", path = "crates/transport_iroh" }
+kitsune2_bootstrap_client = { version = "0.4.0-dev.0", path = "crates/bootstrap_client" }
 
 # used by bootstrap_srv for mpmc worker queue pattern.
 async-channel = "2.3.1"
@@ -134,9 +134,9 @@ prost-build = "0.14"
 # Please be careful to only include them in dev dependencies or move them
 # above this section.
 # --- dev-dependencies ---
-kitsune2_bootstrap_srv = { version = "0.4.0", path = "crates/bootstrap_srv" }
-kitsune2_core = { version = "0.4.0", path = "crates/core" }
-kitsune2_test_utils = { version = "0.4.0", path = "crates/test_utils" }
+kitsune2_bootstrap_srv = { version = "0.4.0-dev.0", path = "crates/bootstrap_srv" }
+kitsune2_core = { version = "0.4.0-dev.0", path = "crates/core" }
+kitsune2_test_utils = { version = "0.4.0-dev.0", path = "crates/test_utils" }
 
 # used to test the bootstrap server with SBD enabled
 sbd-client = "0.3.2"


### PR DESCRIPTION
I had to generate it manually due to cargo-semver-checks failing to build the cargo docs with mutually exclusive features. See https://github.com/holochain/release-integration/issues/22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.4.0-dev.0 development release
  * Changelog updated with new release date

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->