### PR TITLE
Combine url and preflight frames in iroh transport

### DIFF
--- a/crates/kitsune2/tests/blocks.rs
+++ b/crates/kitsune2/tests/blocks.rs
@@ -223,6 +223,7 @@ async fn builder_with_iroh() -> (Arc<Builder>, Server) {
         .set_module_config(&IrohTransportModConfig {
             iroh_transport: IrohTransportConfig {
                 relay_url: Some(relay_server_url.to_string()),
+                relay_allow_plain_text: true,
                 ..Default::default()
             },
         })

--- a/crates/transport_iroh/src/frame.rs
+++ b/crates/transport_iroh/src/frame.rs
@@ -1,15 +1,16 @@
 use crate::MAX_FRAME_BYTES;
 use bytes::Bytes;
 use iroh::endpoint::Connection;
-use kitsune2_api::{K2Error, K2Result};
+use kitsune2_api::{K2Error, K2Result, Url};
 use std::sync::Arc;
 
 pub(super) const FRAME_HEADER_LEN: usize = 5;
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(super) enum FrameType {
-    PeerUrl = 0,
-    Payload = 1,
+    // Preflight consists of peer URL and preflight
+    Preflight = 0,
+    Data = 1,
 }
 
 impl TryFrom<u8> for FrameType {
@@ -17,8 +18,8 @@ impl TryFrom<u8> for FrameType {
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
-            0 => Ok(FrameType::PeerUrl),
-            1 => Ok(FrameType::Payload),
+            0 => Ok(FrameType::Preflight),
+            1 => Ok(FrameType::Data),
             _ => {
                 Err(K2Error::other(format!("unknown iroh frame type: {value}")))
             }
@@ -26,16 +27,90 @@ impl TryFrom<u8> for FrameType {
     }
 }
 
-/// Decodes a frame from raw byte data into a frame type and payload.
+#[derive(Debug)]
+pub(super) enum Frame {
+    Preflight((Url, Bytes)),
+    Data(Bytes),
+}
+
+/// Encodes a frame header for the given frame type and payload length.
 ///
 /// The frame format consists of:
-/// - 1 byte for frame type (0 for PeerUrl, 1 for Payload)
+/// - 1 byte for frame type (0 for Preflight, 1 for Data)
+/// - 4 bytes for payload length (big-endian u32)
+///
+/// Returns an error if the total frame size exceeds [`MAX_FRAME_BYTES`].
+fn encode_frame_header(ty: FrameType, data_len: usize) -> K2Result<Vec<u8>> {
+    if data_len + FRAME_HEADER_LEN > MAX_FRAME_BYTES {
+        return Err(K2Error::other("frame too large"));
+    }
+    let mut header = Vec::with_capacity(FRAME_HEADER_LEN);
+    header.push(ty as u8);
+    header.extend_from_slice(&(data_len as u32).to_be_bytes());
+    Ok(header)
+}
+
+/// Encodes a given frame.
+///
+/// The frame format consists of:
+/// - 1 byte for frame type (0 for Preflight, 1 for Data)
 /// - 4 bytes for payload length (big-endian u32)
 /// - The payload data following the header
 ///
+/// Payload data can be either the preflight or a message.
+/// The preflight consists of:
+/// - 4 bytes for the URL length
+/// - The URL
+/// - The preflight bytes
+///
+/// Messages are just the bytes of the payload.
+///
+/// # Errors
+///
+/// Returns an error when max frame bytes is exceeded.
+pub(super) fn encode_frame(frame: Frame) -> K2Result<Bytes> {
+    match frame {
+        Frame::Preflight((url, preflight)) => {
+            let url_bytes = Bytes::copy_from_slice(url.as_str().as_bytes());
+            let mut data = vec![];
+            data.extend_from_slice(&(url_bytes.len() as u32).to_be_bytes());
+            data.extend_from_slice(&url_bytes);
+            data.extend_from_slice(&preflight);
+            let mut frame =
+                encode_frame_header(FrameType::Preflight, data.len())?;
+            frame.extend(&data);
+            Ok(Bytes::copy_from_slice(&frame))
+        }
+        Frame::Data(data) => {
+            let mut frame = encode_frame_header(FrameType::Data, data.len())?;
+            frame.extend(&data);
+            Ok(Bytes::copy_from_slice(&frame))
+        }
+    }
+}
+
+/// Decodes a frame from raw byte data into a frame type and payload.
+///
+/// The frame format consists of:
+/// - 1 byte for frame type (0 for Preflight, 1 for Data)
+/// - 4 bytes for payload length (big-endian u32)
+/// - The payload data following the header
+///
+/// Payload data can be either the preflight or a message.
+/// The preflight consists of:
+/// - 4 bytes for the URL length
+/// - The URL
+/// - The preflight bytes
+///
+/// Messages are just the bytes of the payload.
+///
+/// # Errors
+///
 /// Returns an error if the data is shorter than the header, contains an invalid frame type,
 /// or if the payload length doesn't match the actual data length.
-pub(super) fn decode_frame(data: Vec<u8>) -> K2Result<(FrameType, Bytes)> {
+///
+/// In case of preflight frames, an error is returned for invalid URLs.
+pub(super) fn decode_frame(data: Vec<u8>) -> K2Result<Frame> {
     if data.len() < FRAME_HEADER_LEN {
         return Err(K2Error::other(
             "iroh frame shorter than header".to_string(),
@@ -44,61 +119,64 @@ pub(super) fn decode_frame(data: Vec<u8>) -> K2Result<(FrameType, Bytes)> {
     // Parse frame type from header byte.
     let frame_type = FrameType::try_from(data[0])?;
     // Extract payload length from next 4 bytes.
-    let len = u32::from_be_bytes([data[1], data[2], data[3], data[4]]) as usize;
-    if data.len() - FRAME_HEADER_LEN != len {
+    let payload_len =
+        u32::from_be_bytes([data[1], data[2], data[3], data[4]]) as usize;
+    if payload_len != data.len() - FRAME_HEADER_LEN {
         return Err(K2Error::other(
             "iroh frame payload length mismatch".to_string(),
         ));
     }
     // Extract payload data after header.
     let payload = Bytes::copy_from_slice(&data[FRAME_HEADER_LEN..]);
-    Ok((frame_type, payload))
-}
-
-/// Encodes a frame header for the given frame type and payload length.
-///
-/// The frame format consists of:
-/// - 1 byte for frame type (0 for PeerUrl, 1 for Payload)
-/// - 4 bytes for payload length (big-endian u32)
-///
-/// Returns an error if the total frame size exceeds [`MAX_FRAME_BYTES`].
-pub(super) fn encode_frame_header(
-    ty: FrameType,
-    data_len: usize,
-) -> K2Result<[u8; FRAME_HEADER_LEN]> {
-    if data_len + FRAME_HEADER_LEN > MAX_FRAME_BYTES {
-        return Err(K2Error::other("frame too large"));
-    }
-    let mut header = [0u8; FRAME_HEADER_LEN];
-    header[0] = ty as u8;
-    header[1..5].copy_from_slice(&(data_len as u32).to_be_bytes());
-    Ok(header)
+    let frame = match frame_type {
+        FrameType::Preflight => {
+            if payload.len() < 4 {
+                return Err(K2Error::other(
+                    "preflight payload too short for URL length",
+                ));
+            }
+            // The first 4 bytes of the payload are the URL length...
+            let url_len = u32::from_be_bytes([
+                payload[0], payload[1], payload[2], payload[3],
+            ]) as usize;
+            // ...followed by the URL
+            if payload.len() < 4 + url_len {
+                return Err(K2Error::other(
+                    "preflight payload too short for actual URL",
+                ));
+            }
+            let url = Url::from_str(
+                std::str::from_utf8(&payload[4..4 + url_len]).map_err(
+                    |err| K2Error::other_src("invalid peer url", err),
+                )?,
+            )?;
+            // The preflight takes up the rest of the payload,
+            // after the URL length and the URL.
+            let preflight_bytes =
+                Bytes::copy_from_slice(&payload[4 + url_len..]);
+            Frame::Preflight((url, preflight_bytes))
+        }
+        FrameType::Data => Frame::Data(payload),
+    };
+    Ok(frame)
 }
 
 /// Sends a frame over the iroh connection.
 ///
-/// The frame format consists of:
-/// - 1 byte for frame type (0 for PeerUrl, 1 for Payload)
-/// - 4 bytes for payload length (big-endian u32)
-/// - The payload data following the header
-///
-/// Opens a unidirectional stream, writes the frame header and data,
-/// and finishes the stream. The frame size is limited to [`MAX_FRAME_BYTES`].
+/// Opens a unidirectional stream, writes the frame and finishes the stream.
+/// The frame size is limited to [`MAX_FRAME_BYTES`].
 pub(super) async fn send_frame(
     conn: &Arc<Connection>,
-    ty: FrameType,
-    data: Bytes,
+    frame: Frame,
 ) -> K2Result<()> {
+    let frame = encode_frame(frame)?;
     let mut stream = conn.open_uni().await.map_err(|err| {
         K2Error::other_src("failed to open iroh send stream", err)
     })?;
-    let header = encode_frame_header(ty, data.len())?;
-    stream.write_all(&header).await.map_err(|err| {
-        K2Error::other_src("failed to send frame header", err)
-    })?;
-    stream.write_all(&data).await.map_err(|err| {
-        K2Error::other_src("failed to send frame payload", err)
-    })?;
+    stream
+        .write_all(&frame)
+        .await
+        .map_err(|err| K2Error::other_src("failed to send frame", err))?;
     stream.finish().map_err(|err| {
         K2Error::other_src("failed to finish iroh stream", err)
     })?;

--- a/crates/transport_iroh/src/tests/frame.rs
+++ b/crates/transport_iroh/src/tests/frame.rs
@@ -1,119 +1,192 @@
-use super::{
-    decode_frame, encode_frame_header, FrameType, FRAME_HEADER_LEN,
-    MAX_FRAME_BYTES,
-};
+use crate::{encode_frame, Frame};
+
+use super::{decode_frame, FrameType, FRAME_HEADER_LEN, MAX_FRAME_BYTES};
 use bytes::Bytes;
+use kitsune2_api::Url;
 
 #[test]
-fn encode_frame_header_valid_peer_url() {
-    let ty = FrameType::PeerUrl;
-    let data_len = 100;
-    let header = encode_frame_header(ty, data_len).unwrap();
-    assert_eq!(header[0], ty as u8);
-    assert_eq!(
-        u32::from_be_bytes([header[1], header[2], header[3], header[4]]),
-        data_len as u32
-    );
-}
-
-#[test]
-fn encode_frame_header_valid_payload() {
-    let ty = FrameType::Payload;
-    let data_len = 0;
-    let header = encode_frame_header(ty, data_len).unwrap();
-    assert_eq!(header[0], ty as u8);
-    assert_eq!(
-        u32::from_be_bytes([header[1], header[2], header[3], header[4]]),
-        data_len as u32
-    );
-}
-
-#[test]
-fn encode_frame_header_too_large() {
-    let data_len = MAX_FRAME_BYTES - FRAME_HEADER_LEN + 1;
-    let err = encode_frame_header(FrameType::Payload, data_len).unwrap_err();
+fn encode_frame_too_large() {
+    let excessive_data_len = MAX_FRAME_BYTES - FRAME_HEADER_LEN + 1;
+    let frame =
+        Frame::Data(Bytes::copy_from_slice(&vec![0u8; excessive_data_len]));
+    let err = encode_frame(frame).unwrap_err();
     assert!(err.to_string().contains("frame too large"));
 }
 
 #[test]
-fn decode_frame_valid_peer_url() {
-    let ty = FrameType::PeerUrl;
-    let payload = Bytes::from("http://some.url:0/withendpointid");
-    let mut data = vec![ty as u8];
-    data.extend_from_slice(&(payload.len() as u32).to_be_bytes());
-    data.extend_from_slice(&payload);
+fn encode_frame_valid_preflight() {
+    let url = Url::from_str("http://some.url:0/withendpointid").unwrap();
+    let preflight_bytes = Bytes::from_static(b"the preflight");
+    let frame = Frame::Preflight((url.clone(), preflight_bytes.clone()));
+    let encoded_frame = encode_frame(frame).unwrap();
 
-    let result = decode_frame(data).unwrap();
-    assert_eq!(result.0, ty);
-    assert_eq!(result.1, payload);
+    let url_len = url.as_str().len();
+    // 4 bytes for the URL length + URL bytes + preflight bytes
+    let expected_payload_len = (4 + url_len + preflight_bytes.len()) as u32;
+
+    assert_eq!(encoded_frame[0], FrameType::Preflight as u8);
+    let actual_payload_len = u32::from_be_bytes([
+        encoded_frame[1],
+        encoded_frame[2],
+        encoded_frame[3],
+        encoded_frame[4],
+    ]);
+    assert_eq!(actual_payload_len, expected_payload_len);
+    let actual_url_len = u32::from_be_bytes([
+        encoded_frame[5],
+        encoded_frame[6],
+        encoded_frame[7],
+        encoded_frame[8],
+    ]);
+    assert_eq!(actual_url_len, url_len as u32);
+    let actual_url =
+        Url::from_str(str::from_utf8(&encoded_frame[9..9 + url_len]).unwrap())
+            .unwrap();
+    assert_eq!(actual_url, url);
+    let actual_preflight =
+        Bytes::copy_from_slice(&encoded_frame[9 + url_len..]);
+    assert_eq!(actual_preflight, preflight_bytes);
 }
 
 #[test]
-fn decode_frame_valid_payload() {
-    let ty = FrameType::Payload;
-    let payload = Bytes::from("test payload");
-    let mut data = vec![ty as u8];
-    data.extend_from_slice(&(payload.len() as u32).to_be_bytes());
-    data.extend_from_slice(&payload);
+fn encode_frame_valid_data() {
+    let data = Bytes::from_static(b"some message");
+    let frame = Frame::Data(data.clone());
+    let encoded_frame = encode_frame(frame).unwrap();
 
-    let result = decode_frame(data).unwrap();
-    assert_eq!(result.0, ty);
-    assert_eq!(result.1, payload);
+    assert_eq!(encoded_frame[0], FrameType::Data as u8);
+    let actual_payload_len = u32::from_be_bytes([
+        encoded_frame[1],
+        encoded_frame[2],
+        encoded_frame[3],
+        encoded_frame[4],
+    ]);
+    assert_eq!(actual_payload_len, data.len() as u32);
+    let actual_data = Bytes::copy_from_slice(&encoded_frame[5..]);
+    assert_eq!(actual_data, data);
+}
+
+#[test]
+fn decode_frame_valid_preflight() {
+    let ty = FrameType::Preflight;
+    let url = Url::from_str("http://some.url:0/withendpointid").unwrap();
+    let url_bytes = Bytes::from(url.clone());
+    let preflight_bytes = Bytes::from_static(b"the preflight");
+    let mut payload = vec![];
+    payload.extend_from_slice(&(url_bytes.len() as u32).to_be_bytes());
+    payload.extend_from_slice(&url_bytes);
+    payload.extend_from_slice(&preflight_bytes);
+
+    let mut encoded_frame = vec![ty as u8];
+    encoded_frame.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+    encoded_frame.extend_from_slice(&payload);
+
+    let frame = decode_frame(encoded_frame).unwrap();
+    match frame {
+        Frame::Preflight((actual_url, actual_preflight)) => {
+            assert_eq!(actual_url, url);
+            assert_eq!(actual_preflight, preflight_bytes);
+        }
+        other => panic!("unexpected frame type {other:?}"),
+    }
+}
+
+#[test]
+fn decode_frame_valid_data() {
+    let ty = FrameType::Data;
+    let message = Bytes::from_static(b"important notification");
+    let mut payload = vec![];
+    payload.extend_from_slice(&message);
+
+    let mut encoded_frame = vec![ty as u8];
+    encoded_frame.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+    encoded_frame.extend_from_slice(&payload);
+
+    let frame = decode_frame(encoded_frame).unwrap();
+    match frame {
+        Frame::Data(actual_message) => {
+            assert_eq!(actual_message, message);
+        }
+        other => panic!("unexpected frame type {other:?}"),
+    }
+}
+
+#[test]
+fn decode_frame_invalid_preflight_url_too_short() {
+    let ty = FrameType::Preflight;
+    let mut encoded_frame = vec![ty as u8];
+    // Too few payload length bytes
+    encoded_frame.extend_from_slice(&(2u32).to_be_bytes());
+    encoded_frame.extend_from_slice(&[0u8; 2]);
+
+    let err = decode_frame(encoded_frame).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("preflight payload too short for URL length"),
+        "unexpected error, got {err}"
+    );
+}
+
+#[test]
+fn decode_frame_invalid_preflight_payload_too_short_for_url() {
+    let ty = FrameType::Preflight;
+    let url = Url::from_str("http://some.url:0/withendpointid").unwrap();
+    let url_bytes = Bytes::from(url);
+    let mut payload = vec![];
+    // Too many URL length bytes
+    payload.extend_from_slice(&(200u32).to_be_bytes());
+    payload.extend_from_slice(&url_bytes);
+
+    let mut encoded_frame = vec![ty as u8];
+    encoded_frame.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+    encoded_frame.extend_from_slice(&payload);
+
+    let err = decode_frame(encoded_frame).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("preflight payload too short for actual URL"),
+        "unexpected error, got {err}"
+    );
 }
 
 #[test]
 fn decode_frame_too_short() {
-    let data = vec![0u8; FRAME_HEADER_LEN - 1];
-    let err = decode_frame(data).unwrap_err();
+    let encoded_frame = vec![0u8; FRAME_HEADER_LEN - 1];
+    let err = decode_frame(encoded_frame).unwrap_err();
     assert!(err.to_string().contains("iroh frame shorter than header"));
 }
 
 #[test]
 fn decode_frame_invalid_frame_type() {
-    let mut data = vec![2u8]; // Invalid type
-    data.extend_from_slice(&(0u32).to_be_bytes()); // Empty payload
-    let err = decode_frame(data).unwrap_err();
+    let mut encoded_frame = vec![2u8]; // Invalid type
+    encoded_frame.extend_from_slice(&(0u32).to_be_bytes()); // Empty payload
+    let err = decode_frame(encoded_frame).unwrap_err();
     assert!(err.to_string().contains("unknown iroh frame type"));
 }
 
 #[test]
 fn decode_frame_payload_length_mismatch() {
-    let ty = FrameType::Payload;
+    let ty = FrameType::Data;
     let payload_len = 10;
     let actual_len = 5;
-    let mut data = vec![ty as u8];
-    data.extend_from_slice(&(payload_len as u32).to_be_bytes()); // Claim 10 bytes
-    data.extend_from_slice(&vec![0u8; actual_len]); // Only 5 bytes
+    let mut encoded_frame = vec![ty as u8];
+    encoded_frame.extend_from_slice(&(payload_len as u32).to_be_bytes()); // Claim 10 bytes
+    encoded_frame.extend_from_slice(&vec![0u8; actual_len]); // Only 5 bytes
 
-    let err = decode_frame(data).unwrap_err();
+    let err = decode_frame(encoded_frame).unwrap_err();
     assert!(err
         .to_string()
         .contains("iroh frame payload length mismatch"));
 }
 
 #[test]
-fn decode_frame_zero_payload() {
-    let ty = FrameType::PeerUrl;
+fn decode_frame_zero_data() {
+    let ty = FrameType::Data;
     let payload = Bytes::new();
-    let mut data = vec![ty as u8];
-    data.extend_from_slice(&(payload.len() as u32).to_be_bytes());
-    data.extend_from_slice(&payload);
+    let mut encoded_frame = vec![ty as u8];
+    encoded_frame.extend_from_slice(&(payload.len() as u32).to_be_bytes());
+    encoded_frame.extend_from_slice(&payload);
 
-    let result = decode_frame(data).unwrap();
-    assert_eq!(result.0, ty);
-    assert_eq!(result.1, payload);
-}
-
-#[test]
-fn decode_frame_max_payload() {
-    let ty = FrameType::Payload;
-    let payload_len = MAX_FRAME_BYTES - FRAME_HEADER_LEN;
-    let payload = Bytes::from(vec![0u8; payload_len]);
-    let mut data = vec![ty as u8];
-    data.extend_from_slice(&(payload.len() as u32).to_be_bytes());
-    data.extend_from_slice(&payload);
-
-    let result = decode_frame(data).unwrap();
-    assert_eq!(result.0, ty);
-    assert_eq!(result.1, payload);
+    let frame = decode_frame(encoded_frame).unwrap();
+    assert!(matches!(frame, Frame::Data(data) if data == payload));
 }

--- a/crates/transport_iroh/tests/integration.rs
+++ b/crates/transport_iroh/tests/integration.rs
@@ -1,16 +1,19 @@
 use bytes::Bytes;
 use kitsune2_api::{K2Proto, K2WireType, Url};
-use kitsune2_test_utils::{retry_fn_until_timeout, space::TEST_SPACE_ID};
+use kitsune2_test_utils::{
+    enable_tracing, retry_fn_until_timeout, space::TEST_SPACE_ID,
+};
 use kitsune2_transport_iroh::test_utils::{
     dummy_url, IrohTransportTestHarness, MockTxHandler,
 };
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::{
     sync::Arc,
     time::{Duration, SystemTime},
 };
 
 #[tokio::test]
-async fn connect_two_endpoints() {
+async fn get_connected_peers() {
     let harness = IrohTransportTestHarness::new().await;
     let dummy_url = Url::from_str("http://url.not.set:0/0").unwrap();
 
@@ -73,20 +76,147 @@ async fn connect_two_endpoints() {
 }
 
 #[tokio::test]
-async fn preflight_only_called_once_per_peer() {
-    use std::sync::atomic::{AtomicUsize, Ordering};
-
+async fn send_and_receive_space_notify() {
     let harness = IrohTransportTestHarness::new().await;
-
     let dummy_url = Url::from_str("http://url.not.set:0/0").unwrap();
 
-    let preflight_count = Arc::new(AtomicUsize::new(0));
+    let handler_1 = Arc::new(MockTxHandler::default());
+    let ep_1 = harness.build_transport(handler_1.clone()).await;
+    ep_1.register_space_handler(TEST_SPACE_ID, handler_1.clone());
+
+    let (space_notify_sender, mut space_notify_receiver) =
+        tokio::sync::mpsc::unbounded_channel();
+    let recv_space_notify = Arc::new(move |_peer, _space_id, data| {
+        space_notify_sender.send(data).unwrap();
+        Ok(())
+    });
+    let handler_2 = Arc::new(MockTxHandler {
+        recv_space_notify,
+        ..Default::default()
+    });
+    let ep_2 = harness.build_transport(handler_2.clone()).await;
+    ep_2.register_space_handler(TEST_SPACE_ID, handler_2.clone());
+
+    // Wait for URLs to be updated
+    retry_fn_until_timeout(
+        || async {
+            let ep_1_url = handler_1.current_url.lock().unwrap().clone();
+            let ep_2_url = handler_2.current_url.lock().unwrap().clone();
+            ep_1_url != dummy_url && ep_2_url != dummy_url
+        },
+        Some(5000),
+        Some(500),
+    )
+    .await
+    .unwrap();
+
+    let message = b"hello";
+    let ep2_url = handler_2.current_url.lock().unwrap().clone();
+    ep_1.send_space_notify(ep2_url, TEST_SPACE_ID, Bytes::from_static(message))
+        .await
+        .unwrap();
+
+    tokio::time::timeout(Duration::from_secs(1), async {
+        let received_space_notification =
+            space_notify_receiver.recv().await.unwrap();
+        assert_eq!(*received_space_notification, *message);
+    })
+    .await
+    .expect("message was not received by ep_2");
+}
+
+#[tokio::test]
+async fn send_and_receive_module_message() {
+    enable_tracing();
+    let harness = IrohTransportTestHarness::new().await;
+    let dummy_url = Url::from_str("http://url.not.set:0/0").unwrap();
+    let module_id = "test-mod".to_string();
+
+    let handler_1 = Arc::new(MockTxHandler::default());
+    let ep_1 = harness.build_transport(handler_1.clone()).await;
+    ep_1.register_space_handler(TEST_SPACE_ID, handler_1.clone());
+    ep_1.register_module_handler(
+        TEST_SPACE_ID,
+        module_id.clone(),
+        handler_1.clone(),
+    );
+
+    let (module_message_sender, mut module_message_receiver) =
+        tokio::sync::mpsc::unbounded_channel();
+    let recv_module_msg =
+        Arc::new(move |_peer, _space_id, _module_id, data| {
+            module_message_sender.send(data).unwrap();
+            Ok(())
+        });
+    let handler_2 = Arc::new(MockTxHandler {
+        recv_module_msg,
+        ..Default::default()
+    });
+    let ep_2 = harness.build_transport(handler_2.clone()).await;
+    ep_2.register_space_handler(TEST_SPACE_ID, handler_2.clone());
+    ep_2.register_module_handler(
+        TEST_SPACE_ID,
+        module_id.clone(),
+        handler_2.clone(),
+    );
+
+    // Wait for URLs to be updated
+    retry_fn_until_timeout(
+        || async {
+            let ep_1_url = handler_1.current_url.lock().unwrap().clone();
+            let ep_2_url = handler_2.current_url.lock().unwrap().clone();
+            ep_1_url != dummy_url && ep_2_url != dummy_url
+        },
+        Some(5000),
+        Some(500),
+    )
+    .await
+    .unwrap();
+
+    let message = b"hello";
+    let ep2_url = handler_2.current_url.lock().unwrap().clone();
+    ep_1.send_module(
+        ep2_url,
+        TEST_SPACE_ID,
+        module_id,
+        Bytes::from_static(message),
+    )
+    .await
+    .unwrap();
+
+    tokio::time::timeout(Duration::from_secs(1), async {
+        let received_module_message =
+            module_message_receiver.recv().await.unwrap();
+        assert_eq!(*received_module_message, *message);
+    })
+    .await
+    .expect("message was not received by ep_2");
+}
+
+#[tokio::test]
+async fn preflight_sent_and_received_by_both_endpoints() {
+    // enable_tracing();
+    let harness = IrohTransportTestHarness::new().await;
+    let dummy_url = Url::from_str("http://url.not.set:0/0").unwrap();
+
+    let preflight_count_sent_1 = Arc::new(AtomicUsize::new(0));
+    let preflight_count_received_1 = Arc::new(AtomicUsize::new(0));
+    let preflight_count_sent_2 = Arc::new(AtomicUsize::new(0));
+    let preflight_count_received_2 = Arc::new(AtomicUsize::new(0));
+
     let handler_1 = Arc::new(MockTxHandler {
         preflight_gather_outgoing: Arc::new({
-            let preflight_count = preflight_count.clone();
+            let preflight_count_sent_1 = preflight_count_sent_1.clone();
             move |_| {
-                preflight_count.fetch_add(1, Ordering::SeqCst);
+                preflight_count_sent_1.fetch_add(1, Ordering::SeqCst);
                 Ok(Bytes::new())
+            }
+        }),
+        preflight_validate_incoming: Arc::new({
+            let preflight_count_received_1 = preflight_count_received_1.clone();
+            move |_, _| {
+                preflight_count_received_1.fetch_add(1, Ordering::SeqCst);
+                Ok(())
             }
         }),
         ..Default::default()
@@ -97,6 +227,20 @@ async fn preflight_only_called_once_per_peer() {
     let (space_notify_sender, mut space_notify_receiver) =
         tokio::sync::mpsc::unbounded_channel();
     let handler_2 = Arc::new(MockTxHandler {
+        preflight_gather_outgoing: Arc::new({
+            let preflight_count_sent_2 = preflight_count_sent_2.clone();
+            move |_| {
+                preflight_count_sent_2.fetch_add(1, Ordering::SeqCst);
+                Ok(Bytes::new())
+            }
+        }),
+        preflight_validate_incoming: Arc::new({
+            let preflight_count_received_2 = preflight_count_received_2.clone();
+            move |_, _| {
+                preflight_count_received_2.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+        }),
         recv_space_notify: Arc::new(move |_peer, _space_id, data| {
             space_notify_sender.send(data).unwrap();
             Ok(())
@@ -121,43 +265,20 @@ async fn preflight_only_called_once_per_peer() {
 
     let ep_2_url = handler_2.current_url.lock().unwrap().clone();
 
-    // Spawn two concurrent sends
-    let message_1 = Bytes::from_static(b"msg1");
-    let send_1 = tokio::spawn({
-        let ep_1 = ep_1.clone();
-        let ep_2_url = ep_2_url.clone();
-        let message_1 = message_1.clone();
-        async move {
-            ep_1.send_space_notify(ep_2_url, TEST_SPACE_ID, message_1)
-                .await
-        }
-    });
+    // Send a message to establish the connection.
+    let message = Bytes::from_static(b"msg1");
+    ep_1.send_space_notify(ep_2_url, TEST_SPACE_ID, message.clone())
+        .await
+        .unwrap();
 
-    let message_2 = Bytes::from_static(b"msg2");
-    let send_2 = tokio::spawn({
-        let ep_1 = ep_1.clone();
-        let ep_2_url = ep_2_url.clone();
-        let message_2 = message_2.clone();
-        async move {
-            ep_1.send_space_notify(ep_2_url, TEST_SPACE_ID, message_2)
-                .await
-        }
-    });
+    let message_received = space_notify_receiver.recv().await.unwrap();
+    assert_eq!(message_received, message);
 
-    let (result_1, result_2) = tokio::join!(send_1, send_2);
-    result_1.unwrap().unwrap();
-    result_2.unwrap().unwrap();
-
-    let response_1 = space_notify_receiver.recv().await.unwrap();
-    let response_2 = space_notify_receiver.recv().await.unwrap();
-    let mut expected = vec![message_1, message_2];
-    expected.sort();
-    let mut responses = vec![response_1, response_2];
-    responses.sort();
-    assert_eq!(responses, expected);
-
-    // Preflight should have been called exactly once.
-    assert_eq!(preflight_count.load(Ordering::SeqCst), 1);
+    // Preflights should have been sent and received exactly once per endpoint.
+    assert_eq!(preflight_count_sent_1.load(Ordering::SeqCst), 1);
+    assert_eq!(preflight_count_received_2.load(Ordering::SeqCst), 1);
+    assert_eq!(preflight_count_sent_2.load(Ordering::SeqCst), 1);
+    assert_eq!(preflight_count_received_1.load(Ordering::SeqCst), 1);
 }
 
 #[tokio::test]


### PR DESCRIPTION
resolves #399 and #384

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Framing redesigned to explicit Preflight and Data frames; preflight exchanged first and data processed only after handshake.
* **Bug Fixes**
  * Stronger frame validation, URL parsing, and clearer error/teardown paths for malformed frames and preflight failures.
* **New Features**
  * Public frame encode/decode surface and unified send API; per-connection preflight state accessors; transport config option to allow plaintext relay in tests.
* **Tests**
  * Updated and expanded unit/integration tests covering Preflight/Data flows and edge cases.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->