### PR TITLE
Use iroh test-utils for test relay server and remove relay_allow_plain_text option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -324,6 +324,7 @@ dependencies = [
  "axum-core",
  "base64",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http",
  "http-body",
@@ -339,6 +340,7 @@ dependencies = [
  "serde_core",
  "serde_json",
  "serde_path_to_error",
+ "serde_urlencoded",
  "sha1 0.10.6",
  "sync_wrapper",
  "tokio",
@@ -346,6 +348,7 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -364,6 +367,7 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2184,6 +2188,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2374ba3cdaac152dc6ada92d971f7328e6408286faab3b7350842b2ebbed4789"
 dependencies = [
  "aead",
+ "axum",
  "backon",
  "bytes",
  "cfg_aliases",
@@ -5405,6 +5410,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/kitsune2/tests/blocks.rs
+++ b/crates/kitsune2/tests/blocks.rs
@@ -206,9 +206,7 @@ async fn builder_with_tx5() -> (Arc<Builder>, SbdServer) {
 
 #[cfg(feature = "transport-iroh")]
 async fn builder_with_iroh() -> (Arc<Builder>, Server) {
-    let relay_server = spawn_iroh_relay_server().await;
-    let relay_server_url =
-        format!("http://{}", relay_server.http_addr().unwrap());
+    let (_, relay_server_url, relay_server) = spawn_iroh_relay_server().await;
     let builder = Builder {
         transport: IrohTransportFactory::create(),
         gossip: CoreGossipStubFactory::create(),
@@ -223,8 +221,6 @@ async fn builder_with_iroh() -> (Arc<Builder>, Server) {
         .set_module_config(&IrohTransportModConfig {
             iroh_transport: IrohTransportConfig {
                 relay_url: Some(relay_server_url.to_string()),
-                relay_allow_plain_text: true,
-                ..Default::default()
             },
         })
         .unwrap();

--- a/crates/kitsune2/tests/integration.rs
+++ b/crates/kitsune2/tests/integration.rs
@@ -119,7 +119,6 @@ async fn make_kitsune_node(
         .set_module_config(&IrohTransportModConfig {
             iroh_transport: IrohTransportConfig {
                 relay_url: Some(relay_server_url.to_string()),
-                relay_allow_plain_text: true,
             },
         })
         .unwrap();
@@ -165,10 +164,8 @@ async fn sbd_signal_server() -> (String, SbdServer) {
 
 #[cfg(feature = "transport-iroh")]
 async fn iroh_relay_server() -> (String, Server) {
-    let relay_server = spawn_iroh_relay_server().await;
-    let relay_server_url =
-        format!("http://{}", relay_server.http_addr().unwrap());
-    (relay_server_url, relay_server)
+    let (_, relay_server_url, relay_server) = spawn_iroh_relay_server().await;
+    (relay_server_url.to_string(), relay_server)
 }
 
 macro_rules! relay_server_with_url {

--- a/crates/transport_iroh/Cargo.toml
+++ b/crates/transport_iroh/Cargo.toml
@@ -36,7 +36,9 @@ n0-watcher = { workspace = true }
 kitsune2_transport_iroh = { workspace = true, features = ["test-utils"] }
 kitsune2_test_utils = { workspace = true }
 
+iroh = { workspace = true, features = ["test-utils"] }
+
 [features]
 schema = ["dep:schemars"]
 
-test-utils = ["dep:iroh-relay", "dep:kitsune2_core"]
+test-utils = ["dep:iroh-relay", "dep:kitsune2_core", "iroh/test-utils"]

--- a/crates/transport_iroh/src/test_utils/harness.rs
+++ b/crates/transport_iroh/src/test_utils/harness.rs
@@ -25,14 +25,12 @@ impl IrohTransportTestHarness {
         }
         .with_default_config()
         .unwrap();
-        let relay_server = spawn_iroh_relay_server().await;
-        let relay_url = format!("http://{}", relay_server.http_addr().unwrap());
+        let (_, relay_url, relay_server) = spawn_iroh_relay_server().await;
         builder
             .config
             .set_module_config(&IrohTransportModConfig {
                 iroh_transport: IrohTransportConfig {
-                    relay_url: Some(relay_url),
-                    relay_allow_plain_text: true,
+                    relay_url: Some(relay_url.to_string()),
                 },
             })
             .unwrap();

--- a/crates/transport_iroh/src/test_utils/relay_server.rs
+++ b/crates/transport_iroh/src/test_utils/relay_server.rs
@@ -1,26 +1,12 @@
 //! Test utilities associated with iroh relay servers.
 
-use iroh_relay::server::{AccessConfig, Limits, RelayConfig, ServerConfig};
-use std::net::{Ipv4Addr, SocketAddr, SocketAddrV4};
+use iroh::test_utils::run_relay_server;
+use iroh::RelayUrl;
+use iroh_relay::RelayMap;
 
 pub use iroh_relay::server::Server;
 
 /// Spawn an iroh relay server at 127.0.0.1.
-pub async fn spawn_iroh_relay_server() -> Server {
-    Server::spawn::<(), ()>(ServerConfig {
-        metrics_addr: None,
-        quic: None,
-        relay: Some(RelayConfig {
-            http_bind_addr: SocketAddr::V4(SocketAddrV4::new(
-                Ipv4Addr::new(127, 0, 0, 1),
-                0,
-            )),
-            tls: None,
-            limits: Limits::default(),
-            key_cache_capacity: None,
-            access: AccessConfig::Everyone,
-        }),
-    })
-    .await
-    .unwrap()
+pub async fn spawn_iroh_relay_server() -> (RelayMap, RelayUrl, Server) {
+    run_relay_server().await.unwrap()
 }

--- a/crates/transport_iroh/src/tests/mod.rs
+++ b/crates/transport_iroh/src/tests/mod.rs
@@ -17,7 +17,6 @@ fn validate_bad_relay_url() {
         .set_module_config(&IrohTransportModConfig {
             iroh_transport: IrohTransportConfig {
                 relay_url: Some("<bad-url>".into()),
-                ..Default::default()
             },
         })
         .unwrap();
@@ -37,7 +36,6 @@ fn validate_plain_relay_url() {
         .set_module_config(&IrohTransportModConfig {
             iroh_transport: IrohTransportConfig {
                 relay_url: Some("http://test.url".into()),
-                ..Default::default()
             },
         })
         .unwrap();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the option to allow plaintext HTTP relay URLs; relay connections now require HTTPS/TLS.

* **Tests**
  * Test harness and relay utilities updated to a new test-server return format and initialization.
  * When test-utility features are enabled, tests may skip relay certificate verification for test servers.

* **Chores**
  * Enabled and extended test-utility features for the transport package and added them as dev-dependencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->