### PR TITLE
Use persistent streams in iroh connections

### DIFF
--- a/crates/transport_iroh/src/connection_context.rs
+++ b/crates/transport_iroh/src/connection_context.rs
@@ -1,20 +1,31 @@
-use iroh::endpoint::{Connection, ConnectionType};
-use kitsune2_api::{TxImpHnd, Url};
+use crate::{
+    decode_frame_header, decode_frame_preflight,
+    frame::{encode_frame, Frame},
+    Connections, FrameType, FRAME_HEADER_LEN,
+};
+use bytes::Bytes;
+use iroh::endpoint::{Connection, ConnectionType, RecvStream, SendStream};
+use kitsune2_api::{K2Error, K2Result, TxImpHnd, Url};
 use n0_watcher::Watcher;
 use std::{
     fmt,
     sync::{
-        atomic::{AtomicU64, Ordering},
+        atomic::{AtomicBool, AtomicU64, Ordering},
         Arc, Mutex, RwLock,
     },
+    time::Duration,
 };
+use tokio::{sync::MutexGuard, task::AbortHandle};
+use tracing::{debug, error, info, trace};
 
 pub(super) struct ConnectionContext {
     handler: Arc<TxImpHnd>,
     connection: Arc<Connection>,
+    connection_reader_abort_handle: Mutex<Option<AbortHandle>>,
+    send_stream: tokio::sync::Mutex<Option<SendStream>>,
     remote_url: RwLock<Option<Url>>,
-    preflight_sent: RwLock<bool>,
-    preflight_received: RwLock<bool>,
+    preflight_sent: AtomicBool,
+    preflight_received: AtomicBool,
     send_message_count: AtomicU64,
     send_bytes: AtomicU64,
     recv_message_count: AtomicU64,
@@ -29,104 +40,132 @@ impl fmt::Debug for ConnectionContext {
     }
 }
 
+impl Drop for ConnectionContext {
+    fn drop(&mut self) {
+        // Abort connection reader task
+        if let Some(connection_reader_abort_handle) = self
+            .connection_reader_abort_handle
+            .lock()
+            .expect("poisoned")
+            .take()
+        {
+            connection_reader_abort_handle.abort();
+        }
+    }
+}
+
 impl ConnectionContext {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         handler: Arc<TxImpHnd>,
         connection: Arc<Connection>,
         remote_url: Option<Url>,
         preflight_sent: bool,
-        preflight_received: bool,
         opened_at_s: u64,
         connection_type_watcher: Option<n0_watcher::Direct<ConnectionType>>,
-    ) -> Self {
-        Self {
+        connections: Connections,
+        local_url: Arc<RwLock<Option<Url>>>,
+    ) -> Arc<Self> {
+        let ctx = Arc::new(Self {
             handler,
             connection,
+            connection_reader_abort_handle: Mutex::new(None),
+            send_stream: tokio::sync::Mutex::new(None),
             remote_url: RwLock::new(remote_url),
-            preflight_sent: RwLock::new(preflight_sent),
-            preflight_received: RwLock::new(preflight_received),
+            preflight_sent: AtomicBool::new(preflight_sent),
+            preflight_received: AtomicBool::new(false),
             send_message_count: AtomicU64::new(0),
             send_bytes: AtomicU64::new(0),
             recv_message_count: AtomicU64::new(0),
             recv_bytes: AtomicU64::new(0),
             opened_at_s,
             connection_type_watcher: Mutex::new(connection_type_watcher),
+        });
+
+        // Spawn connection reader to listen for incoming connections on the
+        // new connection.
+        let connection_reader_abort_handle =
+            Self::spawn_connection_reader(ctx.clone(), connections, local_url);
+        *ctx.connection_reader_abort_handle.lock().expect("poisoned") =
+            Some(connection_reader_abort_handle);
+
+        ctx
+    }
+
+    pub async fn send_preflight_frame(
+        &self,
+        url: Url,
+        preflight_bytes: Bytes,
+    ) -> K2Result<()> {
+        let frame =
+            encode_frame(Frame::Preflight((url.clone(), preflight_bytes)))?;
+
+        let mut stream_lock = self.ensure_send_stream().await?;
+        let stream = stream_lock.as_mut().expect("stream must exist");
+
+        info!(local_url = ?url, "sending preflight frame");
+        trace!(?frame, "sending preflight frame");
+        if let Err(err) = stream.write_all(&frame).await {
+            error!(?err, "failed to send preflight frame");
+            *stream_lock = None;
+            return Err(K2Error::other_src(
+                "failed to send preflight frame",
+                err,
+            ));
         }
+
+        Ok(())
     }
 
-    pub fn set_remote_url(&self, peer: Url) {
-        *self.remote_url.write().expect("poisoned") = Some(peer);
+    pub async fn send_data_frame(&self, data: Bytes) -> K2Result<()> {
+        let data_len = data.len() as u64;
+        let frame = encode_frame(Frame::Data(data))?;
+
+        let mut stream_lock = self.ensure_send_stream().await?;
+        let stream = stream_lock.as_mut().expect("stream must exist");
+
+        trace!(?frame, "sending data frame");
+        if let Err(err) = stream.write_all(&frame).await {
+            error!(?err, "failed to send data frame");
+            *stream_lock = None;
+            return Err(K2Error::other_src("failed to send data frame", err));
+        }
+
+        drop(stream_lock);
+
+        // Update stats
+        self.increment_send_message_count();
+        self.increment_send_bytes(data_len);
+
+        Ok(())
     }
 
-    pub fn remote(&self) -> Option<Url> {
+    pub fn remote_url(&self) -> Option<Url> {
         self.remote_url.read().expect("poisoned").clone()
-    }
-
-    pub fn preflight_sent(&self) -> bool {
-        *self.preflight_sent.read().expect("poisoned")
-    }
-
-    pub fn set_preflight_sent(&self) {
-        *self.preflight_sent.write().expect("poisoned") = true;
-    }
-
-    pub fn preflight_received(&self) -> bool {
-        *self.preflight_received.read().expect("poisoned")
-    }
-
-    pub fn set_preflight_received(&self) {
-        *self.preflight_received.write().expect("poisoned") = true;
-    }
-
-    pub fn handler(&self) -> Arc<TxImpHnd> {
-        self.handler.clone()
-    }
-
-    pub fn connection(&self) -> Arc<Connection> {
-        self.connection.clone()
-    }
-
-    pub fn notify_disconnect(&self) {
-        if let Some(peer) = self.remote() {
-            self.handler
-                .peer_disconnect(peer, Some("disconnected".to_string()));
-        }
     }
 
     pub fn get_send_message_count(&self) -> u64 {
         self.send_message_count.load(Ordering::SeqCst)
     }
 
-    pub fn increment_send_message_count(&self) {
-        self.send_message_count.fetch_add(1, Ordering::SeqCst);
-    }
-
     pub fn get_send_bytes(&self) -> u64 {
         self.send_bytes.load(Ordering::SeqCst)
-    }
-
-    pub fn increment_send_bytes(&self, len: u64) {
-        self.send_bytes.fetch_add(len, Ordering::SeqCst);
     }
 
     pub fn get_recv_message_count(&self) -> u64 {
         self.recv_message_count.load(Ordering::SeqCst)
     }
 
-    pub fn increment_recv_message_count(&self) {
-        self.recv_message_count.fetch_add(1, Ordering::SeqCst);
-    }
-
     pub fn get_recv_bytes(&self) -> u64 {
         self.recv_bytes.load(Ordering::SeqCst)
     }
 
-    pub fn increment_recv_bytes(&self, len: u64) {
-        self.recv_bytes.fetch_add(len, Ordering::SeqCst);
-    }
-
     pub fn get_opened_at_s(&self) -> u64 {
         self.opened_at_s
+    }
+
+    pub fn connection(&self) -> Arc<Connection> {
+        self.connection.clone()
     }
 
     pub fn get_connection_type(&self) -> ConnectionType {
@@ -140,4 +179,301 @@ impl ConnectionContext {
             None => ConnectionType::None,
         }
     }
+
+    pub fn disconnect(&self, reason: String) {
+        info!(reason, remote_url = ?self.remote_url(), "disconnecting from remote");
+        self.connection.close(0u8.into(), reason.as_bytes());
+        if let Some(peer) = self.remote_url() {
+            self.handler.peer_disconnect(peer, Some(reason));
+        }
+    }
+
+    // Spawns an asynchronous task to continuously read and handle incoming uni-directional
+    // streams from an iroh connection. There is only one stream at a time incoming from a
+    // remote. It's read from until the connection is closed or an error occurs.
+    //
+    // Errors when receiving the preflight frame lead to a break of the loop accepting
+    // incoming streams. The preflight must succeed for data frames to be accepted. The
+    // connection cannot recover from a failed preflight, and a new connection must be
+    // established.
+    //
+    // # Parameters
+    // - `ctx`: The connection context containing handler and remote URL state.
+    // - `connections`: Shared map of peer URLs to their connection contexts, updated when
+    //   the preflight succeeds.
+    // - `local_url`: The local URL for this endpoint, used to respond to preflight messages.
+    fn spawn_connection_reader(
+        ctx: Arc<Self>,
+        connections: Connections,
+        local_url: Arc<RwLock<Option<Url>>>,
+    ) -> AbortHandle {
+        tokio::spawn(async move {
+            let err = loop {
+                // Main loop to accept incoming unidirectional streams from the remote peer.
+                match ctx.connection().accept_uni().await {
+                    Ok(stream) => {
+                        info!(remote_id = ?ctx.connection().remote_id(), "accepted incoming stream");
+                        let connections = connections.clone();
+                        let local_url = local_url.clone();
+                        // Read frames from the stream. If an error is returned, it means the
+                        // preflight couldn't be received. The connection must be closed in that
+                        // case, because a successful preflight is the prerequisite for establishing
+                        // a connection.
+                        //
+                        // Errors while receiving data frames from the stream indicate a problem
+                        // with the stream and lead to closing it. An `Ok` value is returned, so
+                        // that the connection is kept open and the next incoming stream is
+                        // awaited.
+                        if let Err(err) = Self::handle_incoming_stream(
+                            ctx.clone(),
+                            stream,
+                            connections.clone(),
+                            local_url,
+                        )
+                        .await
+                        {
+                            break err.to_string();
+                        }
+                    }
+                    Err(err) => {
+                        error!(?err, remote = ?ctx.remote_url(), "connection closed by remote");
+                        break err.to_string();
+                    }
+                }
+            };
+
+            // An error has occurred, either while accepting incoming streams
+            // or while reading the preflight from a stream. The protocol can
+            // not recover from this error and the connection must be closed.
+            if let Some(remote_url) = ctx.remote_url() {
+                connections
+                    .write()
+                    .expect("poisoned")
+                    .remove(&remote_url);
+            }
+            ctx.disconnect(err);
+        }).abort_handle()
+    }
+
+    // Handle frames from an incoming stream.
+    //
+    // By convention, the first frame on a new connection is the
+    // preflight. After the preflight has been received, the flag is
+    // updated in the context.
+    //
+    // If the preflight has not been received yet, read the preflight
+    // from the stream. Time out if the preflight isn't received and
+    // return an error to close the stream.
+    //
+    // The protocol can't recover from a failed preflight frame.
+    // The stream must be closed with an error, which causes the
+    // connection to be closed. A new connection must be established
+    // and the preflight has to be sent again.
+    //
+    // Once the preflight frame has been successfully received, data
+    // frames can be read from the stream. No other frames are allowed
+    // after the preflight.
+    //
+    // Data frames will be read from the stream until an error of any
+    // kind occurs. Errors during data frame header or data reception
+    // or decoding will close the stream, but not the connection.
+    // The connection reader will await the next incoming stream.
+    async fn handle_incoming_stream(
+        ctx: Arc<Self>,
+        mut recv_stream: RecvStream,
+        connections: Connections,
+        local_url: Arc<RwLock<Option<Url>>>,
+    ) -> K2Result<()> {
+        if !ctx.preflight_received() {
+            let result = tokio::time::timeout(Duration::from_secs(10), async {
+                let (remote_url, preflight_bytes) = read_preflight_frame_from_stream(&mut recv_stream).await?;
+
+                ctx.set_remote_url(remote_url.clone());
+                ctx.handler()
+                    .recv_data(remote_url.clone(), preflight_bytes)
+                    .await?;
+                ctx.set_preflight_received();
+                info!(remote = ?remote_url.peer_id(),"preflight received successfully");
+
+                // If the preflight has not been sent yet, it must be the first message
+                // sent back to the remote.
+                if !ctx.preflight_sent() {
+                    let maybe_local_url =
+                        local_url.read().expect("poisoned").clone();
+                    if let Some(local_url) = maybe_local_url {
+                        let return_preflight =
+                            ctx.handler().peer_connect(remote_url.clone()).await?;
+                        ctx.send_preflight_frame(
+                            local_url.clone(),
+                            return_preflight,
+                        )
+                        .await?;
+                        info!(peer = ?ctx.connection().remote_id(),?local_url, "sent preflight to peer from url");
+                        ctx.set_preflight_sent();
+                    }
+                }
+
+                Ok(remote_url)
+            })
+        .await
+        .map_err(|err| {
+            K2Error::other_src("timed out waiting for preflight", err)
+        });
+            match result {
+                Ok(Ok(remote_url)) => {
+                    connections
+                        .write()
+                        .expect("poisoned")
+                        .insert(remote_url, ctx.clone());
+                }
+                Ok(Err(err)) | Err(err) => {
+                    error!(?err, "failed to receive preflight frame");
+                    return Err(err);
+                }
+            }
+        }
+
+        // Keep reading data frames from the stream until it is closed.
+        loop {
+            let (data, data_len) = match read_data_frame_from_stream(
+                &mut recv_stream,
+            )
+            .await
+            {
+                Ok(data) => data,
+                Err(err) => {
+                    error!(?err, remote = ?ctx.remote_url(), "error receiving data frame");
+                    // Frame header could not be read or decoded, wrong frame type
+                    // or data frame data could not be read.
+                    // Break the loop to close the stream, but not the connection.
+                    break;
+                }
+            };
+
+            // Handle data frame: forward data to handler if remote URL is set.
+            let peer = ctx.remote_url().ok_or_else(|| {
+                K2Error::other("received data before preflight")
+            })?;
+            if let Err(err) = ctx
+                .handler()
+                .recv_data(peer.clone(), Bytes::copy_from_slice(&data))
+                .await
+            {
+                error!(?err, remote = ?peer.peer_id(),"error in recv_data");
+            };
+
+            ctx.increment_recv_message_count();
+            ctx.increment_recv_bytes(data_len as u64);
+        }
+
+        Ok(())
+    }
+
+    async fn ensure_send_stream(
+        &'_ self,
+    ) -> K2Result<MutexGuard<'_, Option<SendStream>>> {
+        // Atomically open a new stream if none is present.
+        let mut stream_lock = self.send_stream.lock().await;
+        if stream_lock.is_none() {
+            let stream = self.connection.open_uni().await.map_err(|err| {
+                K2Error::other_src("failed to open uni-directional stream", err)
+            })?;
+            *stream_lock = Some(stream);
+        }
+        Ok(stream_lock)
+    }
+
+    fn set_remote_url(&self, peer: Url) {
+        *self.remote_url.write().expect("poisoned") = Some(peer);
+    }
+
+    fn preflight_sent(&self) -> bool {
+        self.preflight_sent.load(Ordering::SeqCst)
+    }
+
+    fn set_preflight_sent(&self) {
+        self.preflight_sent.store(true, Ordering::SeqCst)
+    }
+
+    fn preflight_received(&self) -> bool {
+        self.preflight_received.load(Ordering::SeqCst)
+    }
+
+    fn set_preflight_received(&self) {
+        self.preflight_received.store(true, Ordering::SeqCst);
+    }
+
+    fn handler(&self) -> Arc<TxImpHnd> {
+        self.handler.clone()
+    }
+
+    fn increment_send_message_count(&self) {
+        self.send_message_count.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn increment_send_bytes(&self, len: u64) {
+        self.send_bytes.fetch_add(len, Ordering::SeqCst);
+    }
+
+    fn increment_recv_message_count(&self) {
+        self.recv_message_count.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn increment_recv_bytes(&self, len: u64) {
+        self.recv_bytes.fetch_add(len, Ordering::SeqCst);
+    }
+}
+
+async fn read_preflight_frame_from_stream(
+    recv_stream: &mut RecvStream,
+) -> K2Result<(Url, Bytes)> {
+    let mut header_bytes = [0u8; FRAME_HEADER_LEN];
+    recv_stream
+        .read_exact(&mut header_bytes)
+        .await
+        .map_err(|err| {
+            K2Error::other_src("preflight header read failed", err)
+        })?;
+    let (frame_type, data_len) = decode_frame_header(&header_bytes)?;
+    debug!(?frame_type, ?data_len, "decoded preflight frame header");
+    if frame_type == FrameType::Data {
+        return Err(K2Error::other(
+            "preflight frame expected, received data frame",
+        ));
+    };
+    let mut preflight_bytes = vec![0u8; data_len];
+    recv_stream
+        .read_exact(&mut preflight_bytes)
+        .await
+        .map_err(|err| K2Error::other_src("preflight data read failed", err))?;
+    let (remote_url, preflight_bytes) =
+        decode_frame_preflight(&preflight_bytes)?;
+    debug!(remote = ?remote_url.peer_id(), "decoded preflight frame data");
+    Ok((remote_url, preflight_bytes))
+}
+
+async fn read_data_frame_from_stream(
+    recv_stream: &mut RecvStream,
+) -> K2Result<(Vec<u8>, usize)> {
+    // Read data frame header
+    let mut header = [0u8; FRAME_HEADER_LEN];
+    recv_stream.read_exact(&mut header).await.map_err(|err| {
+        K2Error::other_src("error reading data frame header", err)
+    })?;
+    let (frame_type, data_len) =
+        decode_frame_header(&header).map_err(|err| {
+            K2Error::other_src("failed to decode iroh frame header", err)
+        })?;
+    if frame_type == FrameType::Preflight {
+        return Err(K2Error::other(
+            "data frame expected, received preflight frame",
+        ));
+    }
+    // Read data frame data
+    let mut data = vec![0u8; data_len];
+    recv_stream.read_exact(&mut data).await.map_err(|err| {
+        K2Error::other_src("error reading data frame data", err)
+    })?;
+    trace!(?data, "incoming data frame");
+    Ok((data, data_len))
 }

--- a/crates/transport_iroh/src/frame.rs
+++ b/crates/transport_iroh/src/frame.rs
@@ -1,8 +1,6 @@
 use crate::MAX_FRAME_BYTES;
 use bytes::Bytes;
-use iroh::endpoint::Connection;
 use kitsune2_api::{K2Error, K2Result, Url};
-use std::sync::Arc;
 
 pub(super) const FRAME_HEADER_LEN: usize = 5;
 
@@ -57,17 +55,17 @@ fn encode_frame_header(ty: FrameType, data_len: usize) -> K2Result<Vec<u8>> {
 /// - 4 bytes for payload length (big-endian u32)
 /// - The payload data following the header
 ///
-/// Payload data can be either the preflight or a message.
+/// Payload data can be either the preflight or data.
 /// The preflight consists of:
 /// - 4 bytes for the URL length
 /// - The URL
 /// - The preflight bytes
 ///
-/// Messages are just the bytes of the payload.
+/// Data is just the bytes of the data.
 ///
 /// # Errors
 ///
-/// Returns an error when max frame bytes is exceeded.
+/// Returns an error when [`MAX_FRAME_BYTES`] are exceeded.
 pub(super) fn encode_frame(frame: Frame) -> K2Result<Bytes> {
     match frame {
         Frame::Preflight((url, preflight)) => {
@@ -89,28 +87,19 @@ pub(super) fn encode_frame(frame: Frame) -> K2Result<Bytes> {
     }
 }
 
-/// Decodes a frame from raw byte data into a frame type and payload.
+/// Decodes a frame header from raw byte data into a frame type and data length.
 ///
-/// The frame format consists of:
+/// The frame header consists of:
 /// - 1 byte for frame type (0 for Preflight, 1 for Data)
-/// - 4 bytes for payload length (big-endian u32)
-/// - The payload data following the header
+/// - 4 bytes for data length (big-endian u32)
 ///
-/// Payload data can be either the preflight or a message.
-/// The preflight consists of:
-/// - 4 bytes for the URL length
-/// - The URL
-/// - The preflight bytes
-///
-/// Messages are just the bytes of the payload.
+/// The frame type and data length are returned as separate values.
 ///
 /// # Errors
 ///
-/// Returns an error if the data is shorter than the header, contains an invalid frame type,
-/// or if the payload length doesn't match the actual data length.
-///
-/// In case of preflight frames, an error is returned for invalid URLs.
-pub(super) fn decode_frame(data: Vec<u8>) -> K2Result<Frame> {
+/// Returns an error if the data is shorter than the header, contains an invalid
+/// frame type, or the data length plus frame header length exceed the [`MAX_FRAME_BYTES`].
+pub(super) fn decode_frame_header(data: &[u8]) -> K2Result<(FrameType, usize)> {
     if data.len() < FRAME_HEADER_LEN {
         return Err(K2Error::other(
             "iroh frame shorter than header".to_string(),
@@ -118,67 +107,49 @@ pub(super) fn decode_frame(data: Vec<u8>) -> K2Result<Frame> {
     }
     // Parse frame type from header byte.
     let frame_type = FrameType::try_from(data[0])?;
-    // Extract payload length from next 4 bytes.
-    let payload_len =
+    // Extract data length from next 4 bytes.
+    let data_len =
         u32::from_be_bytes([data[1], data[2], data[3], data[4]]) as usize;
-    if payload_len != data.len() - FRAME_HEADER_LEN {
-        return Err(K2Error::other(
-            "iroh frame payload length mismatch".to_string(),
-        ));
+    if data_len + FRAME_HEADER_LEN > MAX_FRAME_BYTES {
+        return Err(K2Error::other("iroh frame too large".to_string()));
     }
-    // Extract payload data after header.
-    let payload = Bytes::copy_from_slice(&data[FRAME_HEADER_LEN..]);
-    let frame = match frame_type {
-        FrameType::Preflight => {
-            if payload.len() < 4 {
-                return Err(K2Error::other(
-                    "preflight payload too short for URL length",
-                ));
-            }
-            // The first 4 bytes of the payload are the URL length...
-            let url_len = u32::from_be_bytes([
-                payload[0], payload[1], payload[2], payload[3],
-            ]) as usize;
-            // ...followed by the URL
-            if payload.len() < 4 + url_len {
-                return Err(K2Error::other(
-                    "preflight payload too short for actual URL",
-                ));
-            }
-            let url = Url::from_str(
-                std::str::from_utf8(&payload[4..4 + url_len]).map_err(
-                    |err| K2Error::other_src("invalid peer url", err),
-                )?,
-            )?;
-            // The preflight takes up the rest of the payload,
-            // after the URL length and the URL.
-            let preflight_bytes =
-                Bytes::copy_from_slice(&payload[4 + url_len..]);
-            Frame::Preflight((url, preflight_bytes))
-        }
-        FrameType::Data => Frame::Data(payload),
-    };
-    Ok(frame)
+    Ok((frame_type, data_len))
 }
 
-/// Sends a frame over the iroh connection.
+/// Decodes a preflight frame from raw byte data.
 ///
-/// Opens a unidirectional stream, writes the frame and finishes the stream.
-/// The frame size is limited to [`MAX_FRAME_BYTES`].
-pub(super) async fn send_frame(
-    conn: &Arc<Connection>,
-    frame: Frame,
-) -> K2Result<()> {
-    let frame = encode_frame(frame)?;
-    let mut stream = conn.open_uni().await.map_err(|err| {
-        K2Error::other_src("failed to open iroh send stream", err)
-    })?;
-    stream
-        .write_all(&frame)
-        .await
-        .map_err(|err| K2Error::other_src("failed to send frame", err))?;
-    stream.finish().map_err(|err| {
-        K2Error::other_src("failed to finish iroh stream", err)
-    })?;
-    Ok(())
+/// The preflight consists of:
+/// - 4 bytes for the URL length
+/// - The URL
+/// - The preflight bytes
+///
+/// The URL and the preflight bytes are returned as separate values.
+///
+/// # Errors
+///
+/// Returns an error if the data is shorter than 4 bytes for the URL length, or shorter
+/// than 4 bytes for the URL length plus the bytes of the URL, and if the URL has an
+/// invalid format.
+pub(super) fn decode_frame_preflight(data: &[u8]) -> K2Result<(Url, Bytes)> {
+    // If there are less than 4 bytes that indicate the URL length, return an error.
+    if data.len() < 4 {
+        return Err(K2Error::other("preflight data too short for URL length"));
+    }
+    // The first 4 bytes of the data are the URL length...
+    let url_len =
+        u32::from_be_bytes([data[0], data[1], data[2], data[3]]) as usize;
+    // If the data length is shorter than 4 bytes for the URL length plus the bytes
+    // for the URL, return an error.
+    if data.len() < 4 + url_len {
+        return Err(K2Error::other("preflight data too short for actual URL"));
+    }
+    // ...followed by the URL
+    let url = Url::from_str(
+        std::str::from_utf8(&data[4..4 + url_len])
+            .map_err(|err| K2Error::other_src("invalid peer url", err))?,
+    )?;
+    // The preflight takes up the rest of the data,
+    // after the URL length and the URL.
+    let preflight_bytes = Bytes::copy_from_slice(&data[4 + url_len..]);
+    Ok((url, preflight_bytes))
 }

--- a/crates/transport_iroh/tests/integration.rs
+++ b/crates/transport_iroh/tests/integration.rs
@@ -77,6 +77,7 @@ async fn get_connected_peers() {
 
 #[tokio::test]
 async fn send_and_receive_space_notify() {
+    enable_tracing();
     let harness = IrohTransportTestHarness::new().await;
     let dummy_url = Url::from_str("http://url.not.set:0/0").unwrap();
 
@@ -194,6 +195,407 @@ async fn send_and_receive_module_message() {
 }
 
 #[tokio::test]
+async fn reconnect_succeeds_after_connection_lost() {
+    enable_tracing();
+    let harness = IrohTransportTestHarness::new().await;
+    let dummy_url = dummy_url();
+
+    let (space_notify_sender, mut space_notify_receiver) =
+        tokio::sync::mpsc::unbounded_channel();
+    let handler_1 = Arc::new(MockTxHandler {
+        recv_space_notify: Arc::new(move |_peer, _space_id, data| {
+            space_notify_sender.send(data).unwrap();
+            Ok(())
+        }),
+        ..Default::default()
+    });
+    let ep_1 = harness.build_transport(handler_1.clone()).await;
+    ep_1.register_space_handler(TEST_SPACE_ID, handler_1.clone());
+
+    let handler_2 = Arc::new(MockTxHandler::default());
+    let ep_2 = harness.build_transport(handler_2.clone()).await;
+    ep_2.register_space_handler(TEST_SPACE_ID, handler_2.clone());
+
+    // Wait for URLs to be updated
+    retry_fn_until_timeout(
+        || async {
+            handler_1.current_url.lock().unwrap().clone() != dummy_url
+                && handler_2.current_url.lock().unwrap().clone() != dummy_url
+        },
+        Some(6000),
+        Some(500),
+    )
+    .await
+    .unwrap();
+
+    let ep1_url = handler_1.current_url.lock().unwrap().clone();
+
+    // Establish connection by sending first message
+    let first_message = Bytes::from_static(b"first");
+    ep_2.send_space_notify(
+        ep1_url.clone(),
+        TEST_SPACE_ID,
+        first_message.clone(),
+    )
+    .await
+    .unwrap();
+
+    // Verify first message received
+    tokio::time::timeout(Duration::from_secs(2), async {
+        let received = space_notify_receiver.recv().await.unwrap();
+        assert_eq!(received, first_message);
+    })
+    .await
+    .expect("first message should be received");
+
+    // Verify connection exists
+    assert_eq!(
+        ep_2.get_connected_peers().await.unwrap().len(),
+        1,
+        "connection should exist"
+    );
+
+    // Force disconnect the connection
+    ep_2.disconnect(ep1_url.clone(), None).await;
+
+    // Verify connection is removed
+    retry_fn_until_timeout(
+        || async { ep_2.get_connected_peers().await.unwrap().is_empty() },
+        None,
+        None,
+    )
+    .await
+    .expect("connection should be removed after disconnect");
+
+    // Send second message - this should trigger automatic reconnection
+    let second_message = Bytes::from_static(b"second");
+    ep_2.send_space_notify(
+        ep1_url.clone(),
+        TEST_SPACE_ID,
+        second_message.clone(),
+    )
+    .await
+    .unwrap();
+
+    // Verify second message received (proves reconnection worked)
+    tokio::time::timeout(Duration::from_secs(2), async {
+        let received = space_notify_receiver.recv().await.unwrap();
+        assert_eq!(received, second_message);
+    })
+    .await
+    .expect("second message should be received after reconnection");
+
+    // Verify connection was reestablished
+    assert_eq!(
+        ep_2.get_connected_peers().await.unwrap().len(),
+        1,
+        "connection should be reestablished"
+    );
+}
+
+#[tokio::test]
+async fn reconnect_succeeds_after_stream_error() {
+    enable_tracing();
+    let harness = IrohTransportTestHarness::new().await;
+    let dummy_url = dummy_url();
+
+    // Use atomic to fail only the first message
+    let should_fail = Arc::new(std::sync::atomic::AtomicBool::new(true));
+    let (space_notify_sender, mut space_notify_receiver) =
+        tokio::sync::mpsc::unbounded_channel();
+    let handler_1 = Arc::new(MockTxHandler {
+        recv_space_notify: Arc::new({
+            let should_fail = should_fail.clone();
+            move |_peer, _space_id, data| {
+                if should_fail.swap(false, std::sync::atomic::Ordering::SeqCst)
+                {
+                    Err(kitsune2_api::K2Error::other("stream processing error"))
+                } else {
+                    space_notify_sender.send(data).unwrap();
+                    Ok(())
+                }
+            }
+        }),
+        ..Default::default()
+    });
+    let ep_1 = harness.build_transport(handler_1.clone()).await;
+    ep_1.register_space_handler(TEST_SPACE_ID, handler_1.clone());
+
+    let handler_2 = Arc::new(MockTxHandler::default());
+    let ep_2 = harness.build_transport(handler_2.clone()).await;
+    ep_2.register_space_handler(TEST_SPACE_ID, handler_2.clone());
+
+    // Wait for URLs to be updated
+    retry_fn_until_timeout(
+        || async {
+            handler_1.current_url.lock().unwrap().clone() != dummy_url
+                && handler_2.current_url.lock().unwrap().clone() != dummy_url
+        },
+        Some(6000),
+        Some(500),
+    )
+    .await
+    .unwrap();
+
+    let ep_1_url = handler_1.current_url.lock().unwrap().clone();
+
+    // First message - will fail with stream error
+    let first_message = Bytes::from_static(b"first");
+    ep_2.send_space_notify(ep_1_url.clone(), TEST_SPACE_ID, first_message)
+        .await
+        .unwrap();
+
+    // Wait for error to be processed
+    retry_fn_until_timeout(
+        || async {
+            !should_fail.load(std::sync::atomic::Ordering::SeqCst)
+                && ep_2
+                    .dump_network_stats()
+                    .await
+                    .unwrap()
+                    .transport_stats
+                    .connections[0]
+                    .send_message_count
+                    == 1
+        },
+        Some(1000),
+        Some(100),
+    )
+    .await
+    .expect("first message should have been sent and failed to be received");
+
+    // Connection should still exist after stream error
+    assert_eq!(
+        ep_2.get_connected_peers().await.unwrap().len(),
+        1,
+        "connection remains after stream error"
+    );
+
+    // Second message - should trigger reconnection and succeed
+    let second_message = Bytes::from_static(b"second");
+    ep_2.send_space_notify(
+        ep_1_url.clone(),
+        TEST_SPACE_ID,
+        second_message.clone(),
+    )
+    .await
+    .unwrap();
+
+    // Verify second message received (proves reconnection worked)
+    tokio::time::timeout(Duration::from_secs(2), async {
+        let received = space_notify_receiver.recv().await.unwrap();
+        assert_eq!(received, second_message);
+    })
+    .await
+    .expect("second message should be received after reconnection");
+
+    // Verify connection was reestablished
+    assert_eq!(
+        ep_2.get_connected_peers().await.unwrap().len(),
+        1,
+        "connection should be reestablished"
+    );
+}
+
+#[tokio::test]
+async fn reconnect_succeeds_after_preflight_validation_error() {
+    enable_tracing();
+    let harness = IrohTransportTestHarness::new().await;
+    let dummy_url = dummy_url();
+
+    // Use atomic to fail only the first preflight validation
+    let should_fail = Arc::new(std::sync::atomic::AtomicBool::new(true));
+    let (space_notify_sender, mut space_notify_receiver) =
+        tokio::sync::mpsc::unbounded_channel();
+    let handler_1 = Arc::new(MockTxHandler {
+        preflight_validate_incoming: Arc::new({
+            let should_fail = should_fail.clone();
+            move |_, _| {
+                if should_fail.swap(false, std::sync::atomic::Ordering::SeqCst)
+                {
+                    Err(kitsune2_api::K2Error::other(
+                        "preflight validation failed",
+                    ))
+                } else {
+                    Ok(())
+                }
+            }
+        }),
+        recv_space_notify: Arc::new(move |_peer, _space_id, data| {
+            space_notify_sender.send(data).unwrap();
+            Ok(())
+        }),
+        ..Default::default()
+    });
+    let ep_1 = harness.build_transport(handler_1.clone()).await;
+    ep_1.register_space_handler(TEST_SPACE_ID, handler_1.clone());
+
+    let handler_2 = Arc::new(MockTxHandler::default());
+    let ep_2 = harness.build_transport(handler_2.clone()).await;
+    ep_2.register_space_handler(TEST_SPACE_ID, handler_2.clone());
+
+    // Wait for URLs to be updated
+    retry_fn_until_timeout(
+        || async {
+            handler_1.current_url.lock().unwrap().clone() != dummy_url
+                && handler_2.current_url.lock().unwrap().clone() != dummy_url
+        },
+        Some(6000),
+        Some(500),
+    )
+    .await
+    .unwrap();
+
+    let ep_1_url = handler_1.current_url.lock().unwrap().clone();
+
+    // First message - will fail during preflight validation
+    let first_message = Bytes::from_static(b"first");
+    ep_2.send_space_notify(
+        ep_1_url.clone(),
+        TEST_SPACE_ID,
+        first_message.clone(),
+    )
+    .await
+    .unwrap();
+
+    // ep 1 will close the stream, which will lead to closing the connection.
+    // Wait until the closed connection shows in ep 2's stats.
+    retry_fn_until_timeout(
+        || async {
+            ep_2.dump_network_stats()
+                .await
+                .unwrap()
+                .transport_stats
+                .connections
+                .is_empty()
+        },
+        Some(100),
+        Some(10),
+    )
+    .await
+    .unwrap();
+
+    // Second message - should trigger reconnection with successful preflight
+    let second_message = Bytes::from_static(b"second");
+    ep_2.send_space_notify(
+        ep_1_url.clone(),
+        TEST_SPACE_ID,
+        second_message.clone(),
+    )
+    .await
+    .unwrap();
+
+    // Verify second message received (proves reconnection worked)
+    tokio::time::timeout(Duration::from_secs(2), async {
+        let received = space_notify_receiver.recv().await.unwrap();
+        assert_eq!(received, second_message);
+    })
+    .await
+    .expect("second message should be received after reconnection");
+
+    // Verify connection was reestablished
+    assert_eq!(
+        ep_2.get_connected_peers().await.unwrap().len(),
+        1,
+        "connection should be reestablished"
+    );
+}
+
+#[tokio::test]
+async fn reconnect_succeeds_after_preflight_gather_error() {
+    let harness = IrohTransportTestHarness::new().await;
+    let dummy_url = dummy_url();
+
+    let (space_notify_sender, mut space_notify_receiver) =
+        tokio::sync::mpsc::unbounded_channel();
+    let handler_1 = Arc::new(MockTxHandler {
+        recv_space_notify: Arc::new(move |_peer, _space_id, data| {
+            space_notify_sender.send(data).unwrap();
+            Ok(())
+        }),
+        ..Default::default()
+    });
+    let ep_1 = harness.build_transport(handler_1.clone()).await;
+    ep_1.register_space_handler(TEST_SPACE_ID, handler_1.clone());
+
+    // Use atomic to fail only the first preflight gather
+    let should_fail = Arc::new(std::sync::atomic::AtomicBool::new(true));
+    let handler_2 = Arc::new(MockTxHandler {
+        preflight_gather_outgoing: Arc::new({
+            let should_fail = should_fail.clone();
+            move |_| {
+                if should_fail.swap(false, std::sync::atomic::Ordering::SeqCst)
+                {
+                    Err(kitsune2_api::K2Error::other("preflight gather failed"))
+                } else {
+                    Ok(Bytes::new())
+                }
+            }
+        }),
+        ..Default::default()
+    });
+    let ep_2 = harness.build_transport(handler_2.clone()).await;
+    ep_2.register_space_handler(TEST_SPACE_ID, handler_2.clone());
+
+    // Wait for URLs to be updated
+    retry_fn_until_timeout(
+        || async {
+            handler_1.current_url.lock().unwrap().clone() != dummy_url
+                && handler_2.current_url.lock().unwrap().clone() != dummy_url
+        },
+        Some(6000),
+        Some(500),
+    )
+    .await
+    .unwrap();
+
+    let ep_1_url = handler_1.current_url.lock().unwrap().clone();
+
+    // First message - will fail during preflight gather
+    let first_message = Bytes::from_static(b"first");
+    let result = ep_2
+        .send_space_notify(ep_1_url.clone(), TEST_SPACE_ID, first_message)
+        .await;
+
+    // Preflight gather error should propagate as send error
+    assert!(
+        result.is_err(),
+        "send should fail when preflight gather fails"
+    );
+
+    // Connection should not exist since preflight failed before connection was added to map
+    assert!(
+        ep_2.get_connected_peers().await.unwrap().is_empty(),
+        "connection should not exist after preflight gather failure"
+    );
+
+    // Second message - should succeed with working preflight gather
+    let second_message = Bytes::from_static(b"second");
+    ep_2.send_space_notify(
+        ep_1_url.clone(),
+        TEST_SPACE_ID,
+        second_message.clone(),
+    )
+    .await
+    .unwrap();
+
+    // Verify second message received (proves connection worked)
+    tokio::time::timeout(Duration::from_secs(2), async {
+        let received = space_notify_receiver.recv().await.unwrap();
+        assert_eq!(received, second_message);
+    })
+    .await
+    .expect("second message should be received");
+
+    // Verify connection was established
+    assert_eq!(
+        ep_2.get_connected_peers().await.unwrap().len(),
+        1,
+        "connection should be established"
+    );
+}
+
+#[tokio::test]
 async fn preflight_sent_and_received_by_both_endpoints() {
     // enable_tracing();
     let harness = IrohTransportTestHarness::new().await;
@@ -277,8 +679,16 @@ async fn preflight_sent_and_received_by_both_endpoints() {
     // Preflights should have been sent and received exactly once per endpoint.
     assert_eq!(preflight_count_sent_1.load(Ordering::SeqCst), 1);
     assert_eq!(preflight_count_received_2.load(Ordering::SeqCst), 1);
-    assert_eq!(preflight_count_sent_2.load(Ordering::SeqCst), 1);
-    assert_eq!(preflight_count_received_1.load(Ordering::SeqCst), 1);
+    retry_fn_until_timeout(
+        || async {
+            preflight_count_sent_2.load(Ordering::SeqCst) == 1
+                && preflight_count_received_1.load(Ordering::SeqCst) == 1
+        },
+        Some(100),
+        Some(10),
+    )
+    .await
+    .expect("preflight should have been sent by peer 2 and received by peer 1");
 }
 
 #[tokio::test]
@@ -437,13 +847,12 @@ async fn network_stats() {
         stats_ep_2.recv_bytes
     );
     // opened_at_s might differ by some milliseconds, so assert the absolute
-    // difference is within less than a second.
+    // difference is within 1 seconds.
     assert!(
-        opened_at_s.abs_diff(stats_ep_2.opened_at_s) < 1,
-        "opened at s is more than a second off expected moment"
+        opened_at_s.abs_diff(stats_ep_2.opened_at_s) <= 1,
+        "opened at s is expected to be within one second difference, but is {}",
+        opened_at_s.abs_diff(stats_ep_2.opened_at_s)
     );
-    assert!(
-        stats_ep_2.is_direct,
-        "expected direct connection but got false"
-    );
+    // It's not guaranteed that by now the connection has been upgraded
+    // to a direct connection, so this isn't asserted.
 }


### PR DESCRIPTION
resolves #403 
resolves #384 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistent uni‑directional streams with on‑demand send streams, explicit preflight handshake, remote URL accessor, get_connected_peers, and disconnect notifications.
  * Connection context lifecycle with automatic reader teardown and connection exposure.

* **Bug Fixes**
  * Atomic preflight state, handshake timeouts, stronger header validation, safer send/receive cleanup, and improved reconnect/disconnect handling.

* **Tests**
  * Expanded unit and integration tests covering header/preflight decoding and many reconnection scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->