### PR TITLE
ci: temporary workaround to run prepare release

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -15,5 +15,6 @@ jobs:
     with:
       cliff_config: "https://raw.githubusercontent.com/holochain/release-integration/refs/heads/main/pre-1.0-cliff.toml"
       force_version: ${{ inputs.force_version }}
+      extra_release_util_args: "--i-am-so-sorry-but-my-features-clash"
     secrets:
       HRA2_GITHUB_TOKEN: ${{ secrets.HRA2_GITHUB_TOKEN }}


### PR DESCRIPTION
Currently this workflow fails because of features clash. Temporary fix to that is to add this nice flag

closes no

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated internal release workflow configuration.

---

**Note:** This release contains no user-facing changes. Updates are internal to the release infrastructure only.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->