### PR TITLE
Make iroh max frame size configurable

### DIFF
--- a/crates/kitsune2/tests/blocks.rs
+++ b/crates/kitsune2/tests/blocks.rs
@@ -231,6 +231,7 @@ async fn builder_with_iroh() -> (Arc<Builder>, Server) {
         .set_module_config(&IrohTransportModConfig {
             iroh_transport: IrohTransportConfig {
                 relay_url: Some(relay_server_url.to_string()),
+                ..Default::default()
             },
         })
         .unwrap();

--- a/crates/kitsune2/tests/integration.rs
+++ b/crates/kitsune2/tests/integration.rs
@@ -134,6 +134,7 @@ async fn make_kitsune_node(
         .set_module_config(&IrohTransportModConfig {
             iroh_transport: IrohTransportConfig {
                 relay_url: Some(relay_server_url.to_string()),
+                ..Default::default()
             },
         })
         .unwrap();

--- a/crates/transport_iroh/src/test_utils/harness.rs
+++ b/crates/transport_iroh/src/test_utils/harness.rs
@@ -31,6 +31,7 @@ impl IrohTransportTestHarness {
             .set_module_config(&IrohTransportModConfig {
                 iroh_transport: IrohTransportConfig {
                     relay_url: Some(relay_url.to_string()),
+                    ..Default::default()
                 },
             })
             .unwrap();

--- a/crates/transport_iroh/src/tests/mod.rs
+++ b/crates/transport_iroh/src/tests/mod.rs
@@ -17,6 +17,7 @@ fn validate_bad_relay_url() {
         .set_module_config(&IrohTransportModConfig {
             iroh_transport: IrohTransportConfig {
                 relay_url: Some("<bad-url>".into()),
+                ..Default::default()
             },
         })
         .unwrap();
@@ -36,6 +37,7 @@ fn validate_plain_relay_url() {
         .set_module_config(&IrohTransportModConfig {
             iroh_transport: IrohTransportConfig {
                 relay_url: Some("http://test.url".into()),
+                ..Default::default()
             },
         })
         .unwrap();


### PR DESCRIPTION
resolves #389 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Frame size limit for the Iroh transport is now configurable (defaults to 1 MiB).

* **Refactor**
  * Transport initialization now consistently propagates the configured frame-size limit across connection handling.

* **Tests**
  * Tests updated to validate frame encoding/decoding using the configurable frame-size and to derive the default value.

* **Chores**
  * Test and config initializations now explicitly apply default values for unspecified fields.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->