### PR TITLE
Feat: integrate iroh relay server in bootstrap pt. 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,7 +281,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "http",
  "log",
  "url",
@@ -322,7 +322,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b098575ebe77cb6d14fc7f32749631a6e44edbef6b796f89b020e99ba20d425"
 dependencies = [
  "axum-core",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -371,6 +371,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-reverse-proxy"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84bb2eec9f1a2c150ce1204d843d690db0da305f6f2848cbfd4a840c830b4f0b"
+dependencies = [
+ "axum",
+ "base64 0.21.7",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "rand 0.9.2",
+ "rustls",
+ "sha1 0.10.6",
+ "tokio",
+ "tokio-tungstenite 0.21.0",
+ "tower",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "axum-server"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -414,6 +440,12 @@ name = "base32"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "022dfe9eb35f19ebbcb51e0b40a5ab759f46ad60cadf7297e0bd085afb50e076"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -1738,6 +1770,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "hdrhistogram"
+version = "7.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
+dependencies = [
+ "byteorder",
+ "num-traits",
+]
+
+[[package]]
 name = "heapless"
 version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1924,7 +1966,9 @@ dependencies = [
  "http",
  "hyper",
  "hyper-util",
+ "log",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -1938,7 +1982,7 @@ version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -2481,7 +2525,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1b46a0365a611fbf1d2143104dcf910aada96fafd295bab16c60b802bf6fa1d"
 dependencies = [
  "ahash",
- "base64",
+ "base64 0.22.1",
  "bytecount",
  "email_address",
  "fancy-regex",
@@ -2525,7 +2569,7 @@ dependencies = [
 name = "kitsune2_api"
 version = "0.4.0-dev.1"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures",
  "kitsune2_api",
@@ -2546,7 +2590,7 @@ version = "0.4.0-dev.1"
 dependencies = [
  "axum",
  "axum-server",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "kitsune2_api",
  "kitsune2_bootstrap_srv",
@@ -2566,14 +2610,18 @@ version = "0.4.0-dev.1"
 dependencies = [
  "async-channel",
  "axum",
+ "axum-reverse-proxy",
  "axum-server",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "clap",
  "ctrlc",
  "ed25519-dalek 2.2.0",
  "futures",
  "http",
+ "iroh",
+ "iroh-relay",
+ "kitsune2_test_utils",
  "num_cpus",
  "opentelemetry",
  "rand 0.8.5",
@@ -2630,7 +2678,7 @@ dependencies = [
 name = "kitsune2_gossip"
 version = "0.4.0-dev.1"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures",
  "kitsune2_api",
@@ -2710,7 +2758,7 @@ dependencies = [
 name = "kitsune2_transport_tx5"
 version = "0.4.0-dev.1"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "kitsune2_api",
  "kitsune2_core",
@@ -3422,7 +3470,7 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e046fd7660710fe5a05e8748e70d9058dc15c94ba914e7c4faa7c728f0e8ddc"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "hex",
  "opentelemetry",
  "opentelemetry_sdk",
@@ -3534,7 +3582,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -3684,7 +3732,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b575f975dcf03e258b0c7ab3f81497d7124f508884c37da66a7314aa2a8d467"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "derive_more 2.1.0",
  "futures-lite",
@@ -4160,7 +4208,7 @@ version = "0.12.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
@@ -4451,7 +4499,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d00f41338c3f61eb424696882b76128052fa5dd3db5d015ead03c785e637aa6"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "ed25519-dalek 2.2.0",
  "futures",
  "rand 0.8.5",
@@ -4474,7 +4522,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53866d188d6267155d1730844ccfc952b73950f9d7c59e0154cfe5ff5276da62"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "ed25519-dalek 2.2.0",
  "futures",
  "rand 0.8.5",
@@ -4513,7 +4561,7 @@ dependencies = [
  "anstyle",
  "axum",
  "axum-server",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "clap",
  "ed25519-dalek 2.2.0",
@@ -5222,7 +5270,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfdba5ab34e36bb015bb2cdfc13a3ee3473bcba240162f96301a3eacef2f769d"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "futures",
  "log",
@@ -5253,6 +5301,18 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.21.0",
 ]
 
 [[package]]
@@ -5302,7 +5362,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1b6348ebfaaecd771cecb69e832961d277f59845d4220a584701f72728152b7"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-sink",
@@ -5376,7 +5436,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "http",
  "http-body",
@@ -5405,9 +5465,13 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
+ "hdrhistogram",
+ "indexmap 2.12.1",
  "pin-project-lite",
+ "slab",
  "sync_wrapper",
  "tokio",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -5538,6 +5602,25 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.8.5",
+ "sha1 0.10.6",
+ "thiserror 1.0.69",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
@@ -5578,7 +5661,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfd11c21bcb1160c38d97b0dd972dcdda12292436d023852f2dc756f994cb9ee"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "futures",
  "influxive-otel-atomic-obs",
  "serde",
@@ -5616,7 +5699,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17059ca45a5d2a2f588b9dd638840744256cf1073392c47124b4859740865009"
 dependencies = [
  "app_dirs2",
- "base64",
+ "base64 0.22.1",
  "once_cell",
  "rand 0.9.2",
  "serde",
@@ -5646,7 +5729,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f398e3aa9d32409363a74ec924c5f93511e65caa8bd3386fd4b188d27f5737f9"
 dependencies = [
  "Inflector",
- "base64",
+ "base64 0.22.1",
  "libc",
  "libloading",
  "once_cell",
@@ -5722,7 +5805,7 @@ version = "3.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d39cb1dbab692d82a977c0392ffac19e188bd9186a9f32806f0aaa859d75585a"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "flate2",
  "log",
  "percent-encoding",
@@ -5739,7 +5822,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d81f9efa9df032be5934a46a068815a10a042b494b6a58cb0a1a97bb5467ed6f"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "http",
  "httparse",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,8 @@ kitsune2_bootstrap_client = { version = "0.4.0-dev.0", path = "crates/bootstrap_
 async-channel = "2.3.1"
 # this is used by bootstrap_srv as the http server implementation.
 axum = { version = "0.8", default-features = false }
+# used to proxy requests to http server to iroh relay server
+axum-reverse-proxy = "1.0"
 # CORS support for axum
 tower-http = "0.6"
 # Used with tower-http for constants

--- a/crates/bootstrap_srv/Cargo.toml
+++ b/crates/bootstrap_srv/Cargo.toml
@@ -42,17 +42,29 @@ tokio = { workspace = true, features = [
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 
-sbd-server = { workspace = true, features = ["tungstenite"] }
+sbd-server = { workspace = true, features = ["tungstenite"], optional = true }
 opentelemetry = { workspace = true }
+# iroh relay server-related dependencies
+axum-reverse-proxy = { workspace = true, optional = true }
+iroh = { workspace = true, optional = true }
+iroh-relay = { workspace = true, features = ["server"], optional = true }
 
 [dev-dependencies]
 ureq = { workspace = true }
 rand = { workspace = true }
 rcgen = { workspace = true }
 sbd-client = { workspace = true }
+iroh = { workspace = true, features = ["test-utils"] }
+kitsune2_test_utils = { workspace = true }
 
 [features]
-default = []
+default = ["sbd"]
 
 # enable axum http2 support
 http2 = ["axum/http2"]
+
+# use sbd as signaling and relay server
+sbd = ["dep:sbd-server"]
+
+# use iroh relay server
+iroh-relay = ["dep:axum-reverse-proxy", "dep:iroh", "dep:iroh-relay"]

--- a/crates/bootstrap_srv/Makefile.toml
+++ b/crates/bootstrap_srv/Makefile.toml
@@ -1,1 +1,29 @@
 extend = "../../Makefile.toml"
+
+# clippy is run with default features which covers sbd.
+[tasks.clippy]
+workspace = false
+dependencies = ["clippy-iroh-relay"]
+
+[tasks.clippy-iroh-relay]
+workspace = false
+command = "cargo"
+args = [
+  "clippy",
+  "--all-targets",
+  "--no-default-features",
+  "--features",
+  "iroh-relay",
+  "--",
+  "--deny=warnings",
+]
+
+# sbd is tested by extending the root makefile which runs `cargo test`.
+[tasks.test]
+workspace = false
+dependencies = ["test-iroh-relay"]
+
+[tasks.test-iroh-relay]
+workspace = false
+command = "cargo"
+args = ["test", "--no-default-features", "--features", "iroh-relay"]

--- a/crates/bootstrap_srv/src/bin/kitsune2-bootstrap-srv.rs
+++ b/crates/bootstrap_srv/src/bin/kitsune2-bootstrap-srv.rs
@@ -165,30 +165,33 @@ fn main() {
         config.allowed_origins = Some(allowed_origins);
     }
 
-    // Apply SBD command line arguments
-    if let Some(header) = args.sbd_trusted_ip_header {
-        config.sbd.trusted_ip_header = Some(header);
+    #[cfg(feature = "sbd")]
+    {
+        // Apply SBD command line arguments
+        if let Some(header) = args.sbd_trusted_ip_header {
+            config.sbd.trusted_ip_header = Some(header);
+        }
+        if let Some(limit) = args.sbd_limit_clients {
+            config.sbd.limit_clients = limit;
+        }
+        if args.sbd_disable_rate_limiting {
+            config.sbd.disable_rate_limiting = true;
+        }
+        if let Some(kbps) = args.sbd_limit_ip_kbps {
+            config.sbd.limit_ip_kbps = kbps;
+        }
+        if let Some(byte_burst) = args.sbd_limit_ip_byte_burst {
+            config.sbd.limit_ip_byte_burst = byte_burst;
+        }
+        config.sbd.otlp_endpoint = args.otlp_endpoint;
+        config.sbd.authentication_hook_server = args.authentication_hook_server;
+
+        // Setup opentelemetry metrics
+        sbd_server::enable_otlp_metrics_if_configured(&config.sbd)
+            .expect("Failed to initialize OTLP metrics");
     }
-    if let Some(limit) = args.sbd_limit_clients {
-        config.sbd.limit_clients = limit;
-    }
-    if args.sbd_disable_rate_limiting {
-        config.sbd.disable_rate_limiting = true;
-    }
-    if let Some(kbps) = args.sbd_limit_ip_kbps {
-        config.sbd.limit_ip_kbps = kbps;
-    }
-    if let Some(byte_burst) = args.sbd_limit_ip_byte_burst {
-        config.sbd.limit_ip_byte_burst = byte_burst;
-    }
-    config.sbd.otlp_endpoint = args.otlp_endpoint;
-    config.sbd.authentication_hook_server = args.authentication_hook_server;
 
     tracing::info!(?config);
-
-    // Setup opentelemetry metrics
-    sbd_server::enable_otlp_metrics_if_configured(&config.sbd)
-        .expect("Failed to initialize OTLP metrics");
 
     let (send, recv) = std::sync::mpsc::channel();
 

--- a/crates/bootstrap_srv/src/config.rs
+++ b/crates/bootstrap_srv/src/config.rs
@@ -74,8 +74,8 @@ pub struct Config {
     /// - `None`
     pub tls_key: Option<std::path::PathBuf>,
 
-    /// Disable the SBD server.
-    pub no_sbd: bool,
+    /// Disable the relay server.
+    pub no_relay_server: bool,
 
     /// The allowed origins for CORS requests.
     ///
@@ -83,7 +83,12 @@ pub struct Config {
     pub allowed_origins: Option<Vec<String>>,
 
     /// The SBD server configuration.
+    #[cfg(feature = "sbd")]
     pub sbd: sbd_server::Config,
+
+    /// The iroh relay server configuration.
+    #[cfg(feature = "iroh-relay")]
+    pub iroh_relay: crate::iroh_relay::Config,
 }
 
 impl Config {
@@ -97,9 +102,12 @@ impl Config {
             prune_interval: std::time::Duration::from_secs(10),
             tls_cert: None,
             tls_key: None,
-            no_sbd: false,
+            no_relay_server: false,
             allowed_origins: None,
+            #[cfg(feature = "sbd")]
             sbd: sbd_server::Config::default(),
+            #[cfg(feature = "iroh-relay")]
+            iroh_relay: crate::iroh_relay::Config::default(),
         }
     }
 
@@ -116,9 +124,12 @@ impl Config {
             prune_interval: std::time::Duration::from_secs(60),
             tls_cert: None,
             tls_key: None,
-            no_sbd: false,
+            no_relay_server: false,
             allowed_origins: None,
+            #[cfg(feature = "sbd")]
             sbd: sbd_server::Config::default(),
+            #[cfg(feature = "iroh-relay")]
+            iroh_relay: crate::iroh_relay::Config::default(),
         }
     }
 }

--- a/crates/bootstrap_srv/src/iroh_relay.rs
+++ b/crates/bootstrap_srv/src/iroh_relay.rs
@@ -1,0 +1,47 @@
+use iroh_relay::server::{AccessConfig, RelayConfig, Server, ServerConfig};
+use std::num::NonZeroU32;
+
+pub use iroh_relay::server::{ClientRateLimit, Limits};
+
+/// Configuration for iroh relay server
+#[derive(Debug)]
+pub struct Config {
+    /// Rate limiting configuration for iroh relay server
+    pub limits: Limits,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            limits: Limits {
+                accept_conn_limit: Some(250.0),
+                accept_conn_burst: Some(100),
+                client_rx: Some(ClientRateLimit {
+                    bytes_per_second: NonZeroU32::new(2 * 1024 * 1024).unwrap(), // 2 MiB/s
+                    max_burst_bytes: Some(NonZeroU32::new(256 * 1024).unwrap()), // 256 KiB burst
+                }),
+            },
+        }
+    }
+}
+
+pub(super) async fn start_iroh_relay_server(limits: &Limits) -> Server {
+    Server::spawn(ServerConfig::<(), ()> {
+        relay: Some(RelayConfig {
+            // Secure because only bound to loopback on localhost
+            http_bind_addr: ([127, 0, 0, 1], 0).into(),
+            tls: None, // HTTP is fine for localhost
+            limits: Limits {
+                accept_conn_limit: limits.accept_conn_limit,
+                accept_conn_burst: limits.accept_conn_burst,
+                client_rx: limits.client_rx,
+            },
+            key_cache_capacity: None, // uses default
+            access: AccessConfig::Everyone,
+        }),
+        quic: None,         // Disable QUIC for internal proxy
+        metrics_addr: None, // Don't expose metrics port either
+    })
+    .await
+    .expect("Failed to start internal iroh relay server")
+}

--- a/crates/bootstrap_srv/src/lib.rs
+++ b/crates/bootstrap_srv/src/lib.rs
@@ -214,7 +214,11 @@ pub use server::*;
 mod tls;
 pub use tls::*;
 
+#[cfg(feature = "sbd")]
 mod sbd;
+
+#[cfg(feature = "iroh-relay")]
+mod iroh_relay;
 
 #[cfg(test)]
 mod test;

--- a/crates/bootstrap_srv/src/sbd.rs
+++ b/crates/bootstrap_srv/src/sbd.rs
@@ -9,9 +9,9 @@ use base64::Engine;
 use futures::future::BoxFuture;
 use futures::stream::{SplitSink, SplitStream};
 use futures::{SinkExt, StreamExt};
-use sbd_server::ws::{Payload, SbdWebsocket};
 use sbd_server::{
     handle_upgraded, preflight_ip_check, spawn_prune_task, to_canonical_ip,
+    ws::{Payload, SbdWebsocket},
     Config, IpRate, PubKey, WeakCSlot,
 };
 use std::io;

--- a/crates/bootstrap_srv/src/test/iroh_relay.rs
+++ b/crates/bootstrap_srv/src/test/iroh_relay.rs
@@ -1,0 +1,179 @@
+use super::*;
+use iroh::{EndpointAddr, RelayConfig, RelayMap, RelayUrl};
+use kitsune2_test_utils::enable_tracing;
+use std::{net::SocketAddr, str::FromStr, sync::Arc};
+
+const TEST_ALPN: &[u8] = b"alpn";
+
+#[test]
+fn use_bootstrap_and_iroh_relay() {
+    enable_tracing();
+    // We have mixed features between ring and aws_lc so the "lookup by crate features" doesn't
+    // return a default.
+    // If this is called twice due to parallel tests, ignore result, because it'll fail.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let s = BootstrapSrv::new(Config {
+        prune_interval: std::time::Duration::from_millis(5),
+        ..Config::testing()
+    })
+    .unwrap();
+    let addr = s.listen_addrs()[0];
+
+    PutInfo {
+        addr: s.listen_addrs()[0],
+        ..Default::default()
+    }
+    .call()
+    .unwrap();
+
+    let bootstrap_url = format!("http://{addr}/bootstrap/{S1}");
+    let res = ureq::get(&bootstrap_url)
+        .call()
+        .unwrap()
+        .into_body()
+        .read_to_string()
+        .unwrap();
+    let res: Vec<DecodeAgent> = serde_json::from_str(&res).unwrap();
+    assert_eq!(1, res.len());
+
+    create_two_endpoints_and_assert_message_is_received(false, addr);
+}
+
+#[test]
+fn use_bootstrap_and_iroh_relay_with_tls() {
+    enable_tracing();
+    // We have mixed features between ring and aws_lc so the "lookup by crate features" doesn't
+    // return a default.
+    // If this is called twice due to parallel tests, ignore result, because it'll fail.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let cert =
+        rcgen::generate_simple_self_signed(vec!["bootstrap.test".to_string()])
+            .unwrap();
+
+    let cert_dir = tempfile::tempdir().unwrap();
+
+    let cert_path = cert_dir.path().join("test_cert.pem");
+    File::create_new(&cert_path)
+        .unwrap()
+        .write_all(cert.cert.pem().as_bytes())
+        .unwrap();
+
+    let key_path = cert_dir.path().join("test_key.pem");
+    File::create_new(&key_path)
+        .unwrap()
+        .write_all(cert.key_pair.serialize_pem().as_bytes())
+        .unwrap();
+
+    let mut config = Config::testing();
+    config.tls_cert = Some(cert_path);
+    config.tls_key = Some(key_path);
+
+    let s = BootstrapSrv::new(Config {
+        prune_interval: std::time::Duration::from_millis(5),
+        ..config
+    })
+    .unwrap();
+    let addr = s.listen_addrs()[0];
+
+    PutInfo {
+        addr: s.listen_addrs()[0],
+        use_tls: true,
+        ..Default::default()
+    }
+    .call()
+    .unwrap();
+
+    let bootstrap_url = format!("https://{addr}/bootstrap/{S1}");
+    let res = ureq::get(&bootstrap_url)
+        .config()
+        .tls_config(
+            ureq::tls::TlsConfig::builder()
+                .disable_verification(true)
+                .build(),
+        )
+        .build()
+        .call()
+        .unwrap()
+        .into_body()
+        .read_to_string()
+        .unwrap();
+    let res: Vec<DecodeAgent> = serde_json::from_str(&res).unwrap();
+    assert_eq!(1, res.len());
+
+    create_two_endpoints_and_assert_message_is_received(true, addr);
+}
+
+fn create_two_endpoints_and_assert_message_is_received(
+    use_tls: bool,
+    addr: SocketAddr,
+) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .enable_time()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        // Relay URL uses https
+        let relay_url = RelayUrl::from_str(&format!(
+            "http{}://{addr:?}",
+            if use_tls { "s" } else { "" }
+        ))
+        .unwrap();
+        let relay_map = RelayMap::empty();
+        relay_map.insert(
+            relay_url.clone(),
+            Arc::new(RelayConfig {
+                quic: None,
+                url: relay_url.clone(),
+            }),
+        );
+
+        let ep_1 = iroh::Endpoint::empty_builder(iroh::RelayMode::Custom(
+            relay_map.clone(),
+        ))
+        .alpns(vec![TEST_ALPN.to_vec()])
+        .insecure_skip_relay_cert_verify(true)
+        .bind()
+        .await
+        .unwrap();
+        let ep_2 =
+            iroh::Endpoint::empty_builder(iroh::RelayMode::Custom(relay_map))
+                .alpns(vec![TEST_ALPN.to_vec()])
+                .insecure_skip_relay_cert_verify(true)
+                .bind()
+                .await
+                .unwrap();
+        // Endpoint address is composed of the endpoint ID and the relay URL.
+        let ep_2_addr =
+            EndpointAddr::new(ep_2.id()).with_relay_url(relay_url.clone());
+
+        let message = b"hello";
+
+        let message_received = tokio::spawn(async move {
+            let conn = ep_2.accept().await.unwrap().await.unwrap();
+            match conn.accept_uni().await {
+                Ok(mut recv_stream) => {
+                    let message_received =
+                        recv_stream.read_to_end(1_000).await.unwrap();
+                    conn.close(0u8.into(), b"");
+                    ep_2.close().await;
+                    message_received
+                }
+                Err(err) => {
+                    panic!("failed to accept incoming stream: {err}");
+                }
+            }
+        });
+
+        let conn = ep_1.connect(ep_2_addr, TEST_ALPN).await.unwrap();
+        let mut send_stream = conn.open_uni().await.unwrap();
+        send_stream.write_all(message).await.unwrap();
+        send_stream.finish().unwrap();
+
+        let received_message = message_received.await.unwrap();
+        assert_eq!(received_message, message);
+        ep_1.close().await;
+    });
+}

--- a/crates/bootstrap_srv/src/test/sbd.rs
+++ b/crates/bootstrap_srv/src/test/sbd.rs
@@ -1,0 +1,106 @@
+use super::*;
+
+#[test]
+fn invalid_auth() {
+    let s = BootstrapSrv::new(Config::testing()).unwrap();
+    let addr = format!("http://{}/bootstrap/{}", s.listen_addrs()[0], S1);
+    let res = ureq::Agent::config_builder()
+        .http_status_as_error(false)
+        .build()
+        .new_agent()
+        .get(&addr)
+        .header("Authorization", "Bearer bob")
+        .call()
+        .unwrap()
+        .into_body()
+        .read_to_string()
+        .unwrap();
+    assert!(format!("{res:?}").contains("Unauthorized"), "Got: {res:?}");
+}
+
+#[test]
+fn valid_auth() {
+    let s = BootstrapSrv::new(Config::testing()).unwrap();
+    let addr = format!("http://{}/authenticate", s.listen_addrs()[0]);
+    let token = ureq::put(&addr)
+        .send(&b"hello"[..])
+        .unwrap()
+        .into_body()
+        .read_to_string()
+        .unwrap();
+
+    let token = String::from_utf8_lossy(&token.as_bytes()[14..57]);
+
+    let addr = format!("http://{}/bootstrap/{}", s.listen_addrs()[0], S1);
+    let res = ureq::get(&addr)
+        .header("Authorization", &format!("Bearer {token}"))
+        .call()
+        .unwrap()
+        .into_body()
+        .read_to_string()
+        .unwrap();
+
+    assert_eq!("[]", res);
+}
+
+#[test]
+fn use_bootstrap_and_sbd() {
+    let s = BootstrapSrv::new(Config {
+        prune_interval: std::time::Duration::from_millis(5),
+        ..Config::testing()
+    })
+    .unwrap();
+    let addr = s.listen_addrs()[0];
+
+    PutInfo {
+        addr: s.listen_addrs()[0],
+        ..Default::default()
+    }
+    .call()
+    .unwrap();
+
+    let bootstrap_url = format!("http://{addr}/bootstrap/{S1}");
+    let res = ureq::get(&bootstrap_url)
+        .call()
+        .unwrap()
+        .into_body()
+        .read_to_string()
+        .unwrap();
+    let res: Vec<DecodeAgent> = serde_json::from_str(&res).unwrap();
+    assert_eq!(1, res.len());
+
+    async fn connect(
+        addr: std::net::SocketAddr,
+    ) -> (sbd_client::SbdClient, sbd_client::MsgRecv) {
+        sbd_client::SbdClient::connect_config(
+            &format!("ws://{addr}"),
+            &sbd_client::DefaultCrypto::default(),
+            sbd_client::SbdClientConfig {
+                allow_plain_text: true,
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap()
+    }
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .enable_time()
+        .build()
+        .unwrap();
+    rt.block_on(async move {
+        let (c1, _r1) = connect(addr).await;
+        let p1 = c1.pub_key().clone();
+        let (c2, mut r2) = connect(addr).await;
+        let p2 = c2.pub_key().clone();
+
+        c1.send(&p2, b"hello").await.unwrap();
+        let received = r2.recv().await.unwrap().0;
+        assert_eq!(p1.as_slice(), &received[0..32]);
+        assert_eq!(b"hello".as_slice(), &received[32..]);
+
+        c1.close().await;
+        c2.close().await;
+    });
+}

--- a/crates/transport_iroh/Makefile.toml
+++ b/crates/transport_iroh/Makefile.toml
@@ -1,0 +1,1 @@
+extend = "../../Makefile.toml"


### PR DESCRIPTION

relates to #391 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in internal HTTP relay for proxying routes when enabled.
  * Opt-in SBD mode adding authentication endpoints, token validation, rate limits and metrics.
  * New relay configuration with sensible defaults for connection and client limits.

* **Chores**
  * Workspace dependencies and feature-driven composition extended to support relay/SBD.
  * Server wiring and TLS handling modularized; config flag renamed to reflect relay disablement.
  * Build tasks added for relay-specific linting and testing.

* **Tests**
  * Added integration tests covering relay and SBD flows; adjusted tests for mixed-feature setups.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->