### PR TITLE
Chore: move feature tests to cargo make files

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -66,10 +66,7 @@ jobs:
       - name: Test
         env:
           RUST_LOG: info
-        run: |
-          cargo make test
-          cargo make test-transport-tx5-go-pion
-          cargo make test-transport-iroh
+        run: cargo make test
 
       - name: Examples
         run: cargo run --example schema --features schema
@@ -114,8 +111,6 @@ jobs:
         run: |-
           $env:SODIUM_LIB_DIR="$(pwd)\vcpkg\packages\libsodium_x64-windows-release\lib"
           cargo make test
-          cargo make test-transport-tx5-go-pion
-          cargo make test-transport-iroh
 
   nix-build:
     needs: static

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2726,7 +2726,6 @@ dependencies = [
  "axum",
  "bytes",
  "futures",
- "iroh-relay",
  "kitsune2_api",
  "rand 0.8.5",
  "serde_json",

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -33,36 +33,6 @@ install_crate = false
 command = "cargo"
 args = ["test"]
 
-[tasks.test-transport-tx5-go-pion]
-workspace = false
-command = "cargo"
-args = [
-  "test",
-  "--package",
-  "kitsune2_transport_tx5",
-  "--package",
-  "kitsune2",
-  "--no-default-features",
-  "--features",
-  "transport-tx5-backend-go-pion",
-  "--",
-  "--nocapture",
-]
-
-[tasks.test-transport-iroh]
-workspace = false
-command = "cargo"
-args = [
-  "test",
-  "--package",
-  "kitsune2",
-  "--no-default-features",
-  "--features",
-  "transport-iroh",
-  "--",
-  "--nocapture",
-]
-
 #
 # Tasks that modify content and are not run on CI
 #
@@ -90,7 +60,6 @@ args = ["format"]
 
 [tasks.static]
 description = "Run all static checks"
-workspace = false
 dependencies = ["format-toml-check", "format-check", "clippy", "doc-check"]
 
 [tasks.verify]

--- a/crates/kitsune2/Cargo.toml
+++ b/crates/kitsune2/Cargo.toml
@@ -72,5 +72,6 @@ schema = [
   "dep:serde_json",
   "kitsune2_core/schema",
   "kitsune2_gossip/schema",
-  "kitsune2_transport_tx5/schema",
+  "kitsune2_transport_tx5?/schema",
+  "kitsune2_transport_iroh?/schema",
 ]

--- a/crates/kitsune2/Makefile.toml
+++ b/crates/kitsune2/Makefile.toml
@@ -1,19 +1,61 @@
 extend = "../../Makefile.toml"
 
+# runs clippy with default features, which covers `transport-tx5-datachannel-vendored`
 [tasks.clippy]
+workspace = false
+dependencies = ["clippy-transport-tx5-backend-go-pion", "clippy-transport-iroh"]
+
+[tasks.clippy-transport-tx5-backend-go-pion]
+workspace = false
+command = "cargo"
 args = [
   "clippy",
   "--all-targets",
+  "--no-default-features",
   "--features",
-  "transport-tx5-datachannel-vendored",
+  "transport-tx5-backend-go-pion",
   "--",
   "--deny=warnings",
 ]
 
+[tasks.clippy-transport-iroh]
+workspace = false
+command = "cargo"
+args = [
+  "clippy",
+  "--all-targets",
+  "--no-default-features",
+  "--features",
+  "transport-iroh",
+  "--",
+  "--deny=warnings",
+]
+
+# runs test with default features, which covers `transport-tx5-datachannel-vendored`
 [tasks.test]
+workspace = false
+dependencies = ["test-transport-tx5-backend-go-pion", "test-transport-iroh"]
+
+[tasks.test-transport-tx5-backend-go-pion]
+workspace = false
+command = "cargo"
 args = [
   "test",
   "--no-default-features",
   "--features",
-  "transport-tx5-datachannel-vendored",
+  "transport-tx5-backend-go-pion",
+  "--",
+  "--nocapture",
+]
+
+[tasks.test-transport-iroh]
+workspace = false
+command = "cargo"
+args = [
+  "test",
+  "--no-default-features",
+  "--features",
+  "transport-iroh",
+  "--",
+  "--nocapture",
 ]

--- a/crates/kitsune2/examples/schema.rs
+++ b/crates/kitsune2/examples/schema.rs
@@ -3,6 +3,13 @@ use kitsune2_core::factories::{
     CoreSpaceModConfig, MemBootstrapModConfig, MemPeerStoreModConfig,
 };
 use kitsune2_gossip::K2GossipModConfig;
+#[cfg(feature = "transport-iroh")]
+use kitsune2_transport_iroh::IrohTransportModConfig;
+#[cfg(any(
+    feature = "transport-tx5-datachannel-vendored",
+    feature = "transport-tx5-backend-libdatachannel",
+    feature = "transport-tx5-backend-go-pion"
+))]
 use kitsune2_transport_tx5::Tx5TransportModConfig;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -23,10 +30,23 @@ struct K2Config {
     mem_peer_store: Option<MemPeerStoreModConfig>,
     #[serde(flatten)]
     k2_gossip: Option<K2GossipModConfig>,
+    #[cfg(any(
+        feature = "transport-tx5-datachannel-vendored",
+        feature = "transport-tx5-backend-libdatachannel",
+        feature = "transport-tx5-backend-go-pion"
+    ))]
     #[serde(flatten)]
     tx5_transport: Option<Tx5TransportModConfig>,
+    #[cfg(feature = "transport-iroh")]
+    #[serde(flatten)]
+    iroh_transport: Option<IrohTransportModConfig>,
 }
 
+#[cfg(any(
+    feature = "transport-tx5-datachannel-vendored",
+    feature = "transport-tx5-backend-libdatachannel",
+    feature = "transport-tx5-backend-go-pion"
+))]
 const CURRENT_VALUE: &str = r#"
 {
     "coreBootstrap": {
@@ -77,6 +97,53 @@ const CURRENT_VALUE: &str = r#"
                 }
             ]
         }
+    },
+    "extensionModule": {
+        "someField": "someValue"
+    }
+}
+"#;
+
+#[cfg(feature = "transport-iroh")]
+const CURRENT_VALUE: &str = r#"
+{
+    "coreBootstrap": {
+        "backoffMaxMs": 1000,
+        "backoffMinMs": 100,
+        "serverUrl": "https://test.com"
+    },
+    "coreFetch": {
+        "firstBackOffIntervalMs": 100,
+        "lastBackOffIntervalMs": 1000,
+        "numBackOffIntervals": 3,
+        "parallelRequestCount": 2,
+        "reInsertOutgoingRequestDelayMs": 10
+    },
+    "corePublish": {},
+    "coreSpace": {
+        "reSignExpireTimeMs": 15000,
+        "reSignFreqMs": 120000
+    },
+    "memBootstrap": {
+        "pollFreqMs": 100,
+        "testId": "hello-test"
+    },
+    "memPeerStore": {
+        "pruneIntervalS": 10
+    },
+    "k2Gossip": {
+        "initiateJitterMs": 10,
+        "initialInitiateIntervalMs": 100,
+        "initiateIntervalMs": 100,
+        "maxConcurrentAcceptedRounds": 20,
+        "maxGossipOpBytes": 1000,
+        "maxRequestGossipOpBytes": 1000,
+        "minInitiateIntervalMs": 100,
+        "roundTimeoutMs": 50
+    },
+    "irohTransport": {
+        "relayUrl": "https://test.com",
+        "maxFrameBytes": 1024
     },
     "extensionModule": {
         "someField": "someValue"

--- a/crates/test_utils/Cargo.toml
+++ b/crates/test_utils/Cargo.toml
@@ -18,7 +18,6 @@ axum = { workspace = true, default-features = false, features = [
 ] }
 bytes = { workspace = true }
 futures = { workspace = true }
-iroh-relay = { workspace = true, features = ["server"] }
 kitsune2_api = { workspace = true }
 rand = { workspace = true }
 tokio = { workspace = true }

--- a/crates/transport_tx5/Makefile.toml
+++ b/crates/transport_tx5/Makefile.toml
@@ -1,15 +1,36 @@
 extend = "../../Makefile.toml"
 
+# runs clippy with default features, which covers `datachannel-vendored`
 [tasks.clippy]
+workspace = false
+dependencies = ["clippy-transport-tx5-go-pion"]
+
+[tasks.clippy-transport-tx5-go-pion]
+workspace = false
+command = "cargo"
 args = [
   "clippy",
   "--all-targets",
   "--no-default-features",
   "--features",
-  "datachannel-vendored",
+  "backend-go-pion",
   "--",
   "--deny=warnings",
 ]
 
+# runs test with default features, which covers `datachannel-vendored`
 [tasks.test]
-args = ["test", "--no-default-features", "--features", "datachannel-vendored"]
+workspace = false
+dependencies = ["test-transport-tx5-go-pion"]
+
+[tasks.test-transport-tx5-go-pion]
+workspace = false
+command = "cargo"
+args = [
+  "test",
+  "--no-default-features",
+  "--features",
+  "backend-go-pion",
+  "--",
+  "--nocapture",
+]


### PR DESCRIPTION
Move tests with different features from the root makefile to their respective crates.

Another change is that previously `cargo clippy` was only run from the root. Now it's run for every crate as well, with different features as configured in the makefiles. That prolongs the static run by a few minutes. If that's not desired, I'll revert that change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated CI test steps into single test invocations per platform.
  * Added targeted lint and test variants for specific transport backends and delegated main tasks to focused sub-tasks.
  * Removed redundant test tasks and an unused dependency.

* **New Features**
  * Configuration examples/schema expanded to optionally include transport-specific settings guarded by feature flags.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->