### PR TITLE
refactor: allow plain text urls for iroh relay

### DIFF
--- a/crates/transport_iroh/src/tests/mod.rs
+++ b/crates/transport_iroh/src/tests/mod.rs
@@ -26,7 +26,7 @@ fn validate_bad_relay_url() {
 }
 
 #[test]
-fn validate_plain_relay_url() {
+fn validate_allowed_plain_text_relay_url() {
     let builder = Builder {
         transport: IrohTransportFactory::create(),
         ..kitsune2_core::default_test_builder()
@@ -37,6 +37,29 @@ fn validate_plain_relay_url() {
         .set_module_config(&IrohTransportModConfig {
             iroh_transport: IrohTransportConfig {
                 relay_url: Some("http://test.url".into()),
+                relay_allow_plain_text: true,
+                ..Default::default()
+            },
+        })
+        .unwrap();
+
+    let result = builder.validate_config();
+    assert!(result.is_ok());
+}
+
+#[test]
+fn validate_disallowed_plain_text_relay_url() {
+    let builder = Builder {
+        transport: IrohTransportFactory::create(),
+        ..kitsune2_core::default_test_builder()
+    };
+
+    builder
+        .config
+        .set_module_config(&IrohTransportModConfig {
+            iroh_transport: IrohTransportConfig {
+                relay_url: Some("http://test.url".into()),
+                relay_allow_plain_text: false,
                 ..Default::default()
             },
         })


### PR DESCRIPTION
This should be all that's required to integrate the iroh transport into Holochain. After this PR got merged, I'll trigger a release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added relay configuration option to control plaintext (HTTP) URL support. The option defaults to disabled for enhanced security. Users can explicitly enable plaintext relay URLs when necessary.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->