### PR TITLE
fix: Install crypto provider for iroh-relay

### DIFF
--- a/crates/bootstrap_srv/src/bin/kitsune2-bootstrap-srv.rs
+++ b/crates/bootstrap_srv/src/bin/kitsune2-bootstrap-srv.rs
@@ -136,7 +136,12 @@ fn main() {
         Config::testing()
     };
 
-    if args.tls_cert.is_some() || args.tls_key.is_some() {
+    // Install the crypto provider if TLS certs are provided, or if iroh-relay
+    // feature is enabled (iroh-relay uses rustls internally and needs the provider).
+    if args.tls_cert.is_some()
+        || args.tls_key.is_some()
+        || cfg!(feature = "iroh-relay")
+    {
         rustls::crypto::ring::default_provider()
             .install_default()
             .expect("Failed to configure default TLS provider");


### PR DESCRIPTION
Iroh needs a crypto engine, which did get initialized when a TLS certificate was given, but would fail like this without:
```
2026-01-13T19:27:39.979852Z  INFO sbd_server::metrics: /home/lucksus/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/sbd-server-0.4.0/src/metrics.rs:12: OTLP metrics export not configured
2026-01-13T19:27:39.979887Z  INFO kitsune2_bootstrap_srv: crates/bootstrap_srv/src/bin/kitsune2-bootstrap-srv.rs:194: config=Config { worker_thread_count: 2, max_entries_per_space: 32, request_listen_duration: 10ms, listen_address_list: [127.0.0.1:0], prune_interval: 10s, tls_cert: None, tls_key: None, no_relay_server: false, allowed_origins: None, sbd: Config { cert_pem_file: None, priv_key_pem_file: None, bind: [], trusted_ip_header: None, limit_clients: 32768, disable_rate_limiting: false, limit_ip_kbps: 1000, limit_ip_byte_burst: 262144, limit_idle_millis: 10000, authentication_hook_server: None, otlp_endpoint: None }, iroh_relay: Config { limits: Limits { accept_conn_limit: Some(250.0), accept_conn_burst: Some(100), client_rx: Some(ClientRateLimit { bytes_per_second: 2097152, max_burst_bytes: Some(262144) }) } } }
2026-01-13T19:27:39.981146Z DEBUG opentelemetry: /home/lucksus/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/opentelemetry-0.30.0/src/metrics/noop.rs:29:  name="NoopMeterProvider.MeterCreation" meter_name="sbd-server" Meter was obtained from a NoopMeterProvider. No metrics will be recorded. If global::meter_with_scope()/meter() was used, ensure that a valid MeterProvider is set globally before creating Meter.
2026-01-13T19:27:40.033940Z DEBUG iroh_relay::server: /home/lucksus/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iroh-relay-0.95.1/src/server.rs:358: Starting Relay server
2026-01-13T19:27:40.034531Z  INFO iroh_relay::server::http_server: /home/lucksus/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/iroh-relay-0.95.1/src/server/http_server.rs:342: [HTTP/WS] relay: serving on 127.0.0.1:38811
2026-01-13T19:27:40.034666Z  INFO kitsune2_bootstrap_srv::http: crates/bootstrap_srv/src/http.rs:262: Internal iroh relay server started at 127.0.0.1:38811

thread '<unnamed>' (2372314) panicked at /home/lucksus/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/rustls-0.23.35/src/crypto/mod.rs:249:14:

Could not automatically determine the process-level CryptoProvider from Rustls crate features.
Call CryptoProvider::install_default() before this point to select a provider manually, or make sure exactly one of the 'aws-lc-rs' and 'ring' features is enabled.
See the documentation of the CryptoProvider type for more information.
            
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TLS provider initialization to properly activate when the iroh-relay feature is enabled.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->