### PR TITLE
fix: Enforce blocking more strictly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /output-*
 .cargo
 logs
+
+# Rust Rover
+.idea/

--- a/crates/api/src/blocks.rs
+++ b/crates/api/src/blocks.rs
@@ -40,10 +40,10 @@ pub trait Blocks: 'static + Send + Sync + std::fmt::Debug {
         target: BlockTarget,
     ) -> BoxFut<'static, K2Result<bool>>;
 
-    /// Check a collection of targets and return `Ok(true)` if **all** targets are blocked.
+    /// Check a collection of targets and return `Ok(true)` if **any** target is blocked.
     ///
-    /// Note: If a single target is not blocked then return `Ok(false)`.
-    fn are_all_blocked(
+    /// Note: If no targets are blocked or targets is empty, then return `Ok(false)`.
+    fn is_any_blocked(
         &self,
         targets: Vec<BlockTarget>,
     ) -> BoxFut<'static, K2Result<bool>>;

--- a/crates/core/src/factories/core_access.rs
+++ b/crates/core/src/factories/core_access.rs
@@ -83,7 +83,7 @@ impl CorePeerAccessState {
                             .expect("poisoned")
                             .remove(&peer_url);
                     } else {
-                        let all_blocked = match blocks.are_all_blocked(agents_by_url).await {
+                        let any_blocked = match blocks.is_any_blocked(agents_by_url).await {
                             Ok(all_blocked) => all_blocked,
                             Err(e) => {
                                 tracing::error!(
@@ -95,7 +95,7 @@ impl CorePeerAccessState {
                             }
                         };
 
-                        let access = if all_blocked {
+                        let access = if any_blocked {
                             PeerAccess {
                                 decision: AccessDecision::Blocked,
                                 decided_at: Timestamp::now(),

--- a/crates/core/src/factories/mem_blocks.rs
+++ b/crates/core/src/factories/mem_blocks.rs
@@ -74,7 +74,7 @@ impl Blocks for MemBlocks {
         Box::pin(async move { Ok(is_blocked) })
     }
 
-    fn are_all_blocked(
+    fn is_any_blocked(
         &self,
         targets: Vec<BlockTarget>,
     ) -> BoxFut<'static, K2Result<bool>> {
@@ -82,10 +82,10 @@ impl Blocks for MemBlocks {
             return Box::pin(async { Ok(false) });
         }
         let inner = self.0.lock().expect("MemBlocks inner Mutex is poisoned");
-        let are_all_blocked =
-            targets.iter().all(|target| inner.contains(target));
+        let is_any_blocked =
+            targets.iter().any(|target| inner.contains(target));
 
-        Box::pin(async move { Ok(are_all_blocked) })
+        Box::pin(async move { Ok(is_any_blocked) })
     }
 }
 

--- a/crates/core/src/factories/mem_blocks/test.rs
+++ b/crates/core/src/factories/mem_blocks/test.rs
@@ -44,13 +44,23 @@ async fn targets_are_not_repeated_in_store() {
 }
 
 #[tokio::test]
+async fn no_target_is_blocked_when_checking() {
+    let blocks = MemBlocks::default();
+
+    assert!(!blocks
+        .is_any_blocked(vec![BLOCK_TARGET_AGENT_1, BLOCK_TARGET_AGENT_2])
+        .await
+        .unwrap());
+}
+
+#[tokio::test]
 async fn only_one_target_is_blocked_when_checking() {
     let blocks = MemBlocks::default();
 
     blocks.block(BLOCK_TARGET_AGENT_1).await.unwrap();
 
-    assert!(!blocks
-        .are_all_blocked(vec![BLOCK_TARGET_AGENT_1, BLOCK_TARGET_AGENT_2])
+    assert!(blocks
+        .is_any_blocked(vec![BLOCK_TARGET_AGENT_1, BLOCK_TARGET_AGENT_2])
         .await
         .unwrap());
 }
@@ -63,7 +73,7 @@ async fn all_targets_are_blocked_when_checking() {
     blocks.block(BLOCK_TARGET_AGENT_2).await.unwrap();
 
     assert!(blocks
-        .are_all_blocked(vec![BLOCK_TARGET_AGENT_1, BLOCK_TARGET_AGENT_2])
+        .is_any_blocked(vec![BLOCK_TARGET_AGENT_1, BLOCK_TARGET_AGENT_2])
         .await
         .unwrap());
 }
@@ -71,5 +81,5 @@ async fn all_targets_are_blocked_when_checking() {
 #[tokio::test]
 async fn checking_empty_target_list_returns_false() {
     let blocks = MemBlocks::default();
-    assert!(!blocks.are_all_blocked(vec![]).await.unwrap());
+    assert!(!blocks.is_any_blocked(vec![]).await.unwrap());
 }

--- a/crates/kitsune2/tests/blocks.rs
+++ b/crates/kitsune2/tests/blocks.rs
@@ -450,12 +450,12 @@ async fn block_agent_in_space(agent: AgentId, space: DynSpace) {
     let block_targets = vec![BlockTarget::Agent(agent.clone())];
 
     // Check that the Blocks module doesn't consider Bob's agent blocked prior to blocking
-    let all_blocked = space
+    let any_blocked = space
         .blocks()
-        .are_all_blocked(block_targets.clone())
+        .is_any_blocked(block_targets.clone())
         .await
         .unwrap();
-    assert!(!all_blocked);
+    assert!(!any_blocked);
 
     // Then block the agent
     space
@@ -467,9 +467,9 @@ async fn block_agent_in_space(agent: AgentId, space: DynSpace) {
     space.peer_store().remove(agent.clone()).await.unwrap();
 
     // Check that all agents are considered blocked now
-    let all_blocked =
-        space.blocks().are_all_blocked(block_targets).await.unwrap();
-    assert!(all_blocked);
+    let any_blocked =
+        space.blocks().is_any_blocked(block_targets).await.unwrap();
+    assert!(any_blocked);
 }
 
 /// A helper function that joins with a new local agent to the given space,


### PR DESCRIPTION
Now blocking checks if any agent for a peer is blocked, instead of all of them

closes #410


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated access control logic to deny access when any blocked agent is detected, instead of requiring all agents to be blocked.

* **Tests**
  * Updated and added tests to verify the corrected blocking behavior.

* **Chores**
  * Added .idea/ to gitignore for development environment files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->