### PR TITLE
ci: remove nix build run on macos-15

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -116,7 +116,7 @@ jobs:
     needs: static
     strategy:
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-15]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
       fail-fast: false
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
There wasn't a run on Intel-Macs at all. This was supposed to be run on Intel, but it's actually running on aarch64 with macos v15.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refined CI workflow for Nix builds: standardized supported platforms by keeping Ubuntu variants and the latest macOS while removing an older macOS variant to simplify and streamline the build matrix and reduce maintenance overhead.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->