### PR TITLE
fix: old Rust version in use for the `test_auth_hook_server` image

### DIFF
--- a/docker/kitsune2_test_auth_hook_server/Dockerfile
+++ b/docker/kitsune2_test_auth_hook_server/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.85-bookworm AS builder
+FROM rust:1.92-bookworm AS builder
 
 # Pick a directory to work in
 WORKDIR /usr/src/kitsune2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Rust compiler version from 1.85 to 1.92 in the build environment.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->