### PR TITLE
feat: DHT size sharing

### DIFF
--- a/crates/api/src/gossip.rs
+++ b/crates/api/src/gossip.rs
@@ -96,6 +96,8 @@ pub struct PeerMeta {
     pub completed_rounds: Option<u32>,
     /// The number of peer timeouts.
     pub peer_timeouts: Option<u32>,
+    /// The total DHT op count reported by this peer.
+    pub dht_op_count: Option<u64>,
     /// Whether this peer has declared itself as offline, and no longer reachable, with a tombstone.
     pub is_tombstone: bool,
     /// The storage arc that this peer is declaring.
@@ -120,4 +122,14 @@ pub struct GossipStateSummary {
     pub dht_summary: HashMap<String, DhtSegmentState>,
     /// Peer metadata dump for each agent in this space.
     pub peer_meta: HashMap<Url, PeerMeta>,
+    /// An estimate of the local node's op count.
+    ///
+    /// This is initialised from the op store on startup and incremented as
+    /// ops are stored.  It does **not** reflect cached data added after
+    /// startup.  The host application can query its own data store for
+    /// an up-to-date value.
+    ///
+    /// Compare against each peer's [`PeerMeta::dht_op_count`] to estimate
+    /// sync progress.
+    pub local_op_count: u64,
 }

--- a/crates/api/src/op_store.rs
+++ b/crates/api/src/op_store.rs
@@ -177,6 +177,9 @@ pub trait OpStore: 'static + Send + Sync + std::fmt::Debug {
         &self,
         arc: DhtArc,
     ) -> BoxFuture<'_, K2Result<Vec<(u64, Bytes)>>>;
+
+    /// Return the total count of locally held ops.
+    fn query_total_op_count(&self) -> BoxFuture<'_, K2Result<u64>>;
 }
 
 /// Trait-object [OpStore].

--- a/crates/core/src/factories/core_gossip.rs
+++ b/crates/core/src/factories/core_gossip.rs
@@ -71,6 +71,7 @@ impl Gossip for CoreGossipStub {
                 accepted_rounds: Vec::with_capacity(0),
                 dht_summary: HashMap::with_capacity(0),
                 peer_meta: HashMap::with_capacity(0),
+                local_op_count: 0,
             })
         })
     }

--- a/crates/core/src/factories/mem_op_store.rs
+++ b/crates/core/src/factories/mem_op_store.rs
@@ -420,4 +420,11 @@ impl OpStore for Kitsune2MemoryOpStore {
             Ok(self_lock.time_slice_hashes.get_all(&arc))
         })
     }
+
+    fn query_total_op_count(&self) -> BoxFuture<'_, K2Result<u64>> {
+        Box::pin(async move {
+            let lock = self.read().await;
+            Ok(lock.op_list.len() as u64)
+        })
+    }
 }

--- a/crates/core/src/factories/mem_op_store/test.rs
+++ b/crates/core/src/factories/mem_op_store/test.rs
@@ -145,3 +145,41 @@ async fn retrieve_op_ids_bounded_across_multiple_arcs() {
     // Gets the remaining op in the second arc.
     assert_eq!(1, ops_in_arc_2.0.len());
 }
+
+#[tokio::test]
+async fn query_total_op_count_reflects_stored_ops() {
+    let op_store: DynOpStore =
+        Arc::new(Kitsune2MemoryOpStore::new(TEST_SPACE_ID));
+
+    assert_eq!(0, op_store.query_total_op_count().await.unwrap());
+
+    op_store
+        .process_incoming_ops(vec![
+            MemoryOp::new(Timestamp::now(), vec![1; 32]).into(),
+            MemoryOp::new(Timestamp::now(), vec![2; 32]).into(),
+        ])
+        .await
+        .unwrap();
+
+    assert_eq!(2, op_store.query_total_op_count().await.unwrap());
+}
+
+#[tokio::test]
+async fn query_total_op_count_same_store() {
+    let op_store: DynOpStore =
+        Arc::new(Kitsune2MemoryOpStore::new(TEST_SPACE_ID));
+
+    let op = MemoryOp::new(Timestamp::now(), vec![1; 32]);
+    op_store
+        .process_incoming_ops(vec![op.clone().into()])
+        .await
+        .unwrap();
+    assert_eq!(1, op_store.query_total_op_count().await.unwrap());
+
+    // Storing the same op again should not increase the count.
+    op_store
+        .process_incoming_ops(vec![op.into()])
+        .await
+        .unwrap();
+    assert_eq!(1, op_store.query_total_op_count().await.unwrap());
+}

--- a/crates/dht/src/dht.rs
+++ b/crates/dht/src/dht.rs
@@ -36,12 +36,14 @@ mod tests;
 pub struct Dht {
     partition: HashPartition,
     store: DynOpStore,
+    op_count: u64,
 }
 
 impl std::fmt::Debug for Dht {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Dht")
             .field("partition", &self.partition)
+            .field("op_count", &self.op_count)
             .finish()
     }
 }
@@ -84,6 +86,13 @@ pub trait DhtApi: 'static + Send + Sync + std::fmt::Debug {
         &mut self,
         stored_ops: Vec<StoredOp>,
     ) -> BoxFut<'_, K2Result<()>>;
+
+    /// Get an estimate of the total number of ops known to this node.
+    ///
+    /// Initialised from the op store on startup and incremented on every
+    /// [`DhtApi::inform_ops_stored`] call.  This is an estimate because it
+    /// does not account for content evicted after startup.
+    fn op_count(&self) -> u64;
 
     /// Get a minimal snapshot of the DHT model.
     fn snapshot_minimal(
@@ -131,10 +140,17 @@ impl DhtApi for Dht {
         stored_ops: Vec<StoredOp>,
     ) -> BoxFut<'_, K2Result<()>> {
         Box::pin(async move {
+            let count = stored_ops.len() as u64;
             self.partition
                 .inform_ops_stored(self.store.clone(), stored_ops)
-                .await
+                .await?;
+            self.op_count += count;
+            Ok(())
         })
+    }
+
+    fn op_count(&self) -> u64 {
+        self.op_count
     }
 
     /// Get a minimal snapshot of the DHT model.
@@ -522,6 +538,7 @@ impl Dht {
         current_time: Timestamp,
         store: DynOpStore,
     ) -> K2Result<Dht> {
+        let op_count = store.query_total_op_count().await?;
         Ok(Dht {
             partition: HashPartition::try_from_store(
                 9,
@@ -530,6 +547,7 @@ impl Dht {
             )
             .await?,
             store,
+            op_count,
         })
     }
 

--- a/crates/dht/src/dht/tests.rs
+++ b/crates/dht/src/dht/tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::dht::tests::harness::SyncWithOutcome;
 use crate::test::test_store;
 use harness::DhtSyncHarness;
-use kitsune2_api::{DhtArc, UNIX_TIMESTAMP};
+use kitsune2_api::{DhtArc, DynOpStore, UNIX_TIMESTAMP};
 use kitsune2_core::factories::MemoryOp;
 use std::time::Duration;
 
@@ -523,4 +523,49 @@ async fn ring_sync_respects_arc() {
 
     // Now the DHTs should be in sync
     assert!(dht1.is_in_sync_with(&dht2).await.unwrap());
+}
+
+#[tokio::test]
+async fn op_count_starts_at_zero_for_empty_store() {
+    let dht = Dht::try_from_store(UNIX_TIMESTAMP, test_store().await)
+        .await
+        .unwrap();
+    assert_eq!(0, dht.op_count());
+}
+
+#[tokio::test]
+async fn op_count_incremented_by_inform_ops_stored() {
+    let current_time = Timestamp::now();
+    let mut harness = DhtSyncHarness::new(current_time, DhtArc::FULL).await;
+
+    harness
+        .inject_ops(vec![
+            MemoryOp::new(UNIX_TIMESTAMP, vec![7; 32]),
+            MemoryOp::new(UNIX_TIMESTAMP, vec![8; 32]),
+        ])
+        .await
+        .unwrap();
+    assert_eq!(2, harness.dht.op_count());
+
+    harness
+        .inject_ops(vec![MemoryOp::new(UNIX_TIMESTAMP, vec![9; 32])])
+        .await
+        .unwrap();
+    assert_eq!(3, harness.dht.op_count());
+}
+
+#[tokio::test]
+async fn op_count_loaded_from_store_on_startup() {
+    let store: DynOpStore = test_store().await;
+    store
+        .process_incoming_ops(vec![
+            MemoryOp::new(UNIX_TIMESTAMP, vec![1; 32]).into(),
+            MemoryOp::new(UNIX_TIMESTAMP, vec![2; 32]).into(),
+            MemoryOp::new(UNIX_TIMESTAMP, vec![3; 32]).into(),
+        ])
+        .await
+        .unwrap();
+
+    let dht = Dht::try_from_store(Timestamp::now(), store).await.unwrap();
+    assert_eq!(3, dht.op_count());
 }

--- a/crates/gossip/proto/gen/kitsune2.gossip.rs
+++ b/crates/gossip/proto/gen/kitsune2.gossip.rs
@@ -156,6 +156,8 @@ pub struct K2GossipInitiateMessage {
     /// op data, so you cannot rely on this being respected during gossip.
     #[prost(uint32, tag = "21")]
     pub max_op_data_bytes: u32,
+    #[prost(uint64, optional, tag = "22")]
+    pub dht_op_count: ::core::option::Option<u64>,
 }
 /// A Kitsune2 gossip acceptance protocol message.
 ///
@@ -192,6 +194,8 @@ pub struct K2GossipAcceptMessage {
     /// and the initiator should use this new timestamp in their `new_since` next time they gossip with us.
     #[prost(int64, tag = "23")]
     pub updated_new_since: i64,
+    #[prost(uint64, optional, tag = "24")]
+    pub dht_op_count: ::core::option::Option<u64>,
     /// The DHT snapshot of the acceptor.
     #[prost(message, optional, tag = "30")]
     pub snapshot: ::core::option::Option<

--- a/crates/gossip/proto/gossip.proto
+++ b/crates/gossip/proto/gossip.proto
@@ -102,6 +102,8 @@ message K2GossipInitiateMessage {
   // those op ids should point to. The other party can't check this until they have fetched and checked the
   // op data, so you cannot rely on this being respected during gossip.
   uint32 max_op_data_bytes = 21;
+
+  optional uint64 dht_op_count = 22;
 }
 
 // A Kitsune2 gossip acceptance protocol message.
@@ -144,6 +146,8 @@ message K2GossipAcceptMessage {
   // Provide a new bookmark for the initiator. Any new ops will have been returned in `new_ops`
   // and the initiator should use this new timestamp in their `new_since` next time they gossip with us.
   int64 updated_new_since = 23;
+
+  optional uint64 dht_op_count = 24;
 
   // The DHT snapshot of the acceptor.
   optional SnapshotMinimalMessage snapshot = 30;

--- a/crates/gossip/src/gossip.rs
+++ b/crates/gossip/src/gossip.rs
@@ -238,6 +238,7 @@ impl K2Gossip {
             our_agents.clone(),
             our_arc_set.clone(),
         );
+        let dht_op_count = self.dht.read().await.op_count();
         let initiate = K2GossipInitiateMessage {
             session_id: round_state.session_id.clone(),
             participating_agents: encode_agent_ids(our_agents),
@@ -246,6 +247,7 @@ impl K2Gossip {
             }),
             new_since: new_since.as_micros(),
             max_op_data_bytes: self.config.max_gossip_op_bytes,
+            dht_op_count: Some(dht_op_count),
             tie_breaker: match &round_state.stage {
                 RoundStage::Initiated(i) => i.tie_breaker,
                 _ => unreachable!(),
@@ -441,11 +443,11 @@ impl TxModuleHandler for K2Gossip {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::harness::K2GossipFunctionalTestFactory;
+    use crate::harness::{K2GossipFunctionalTestFactory, MemoryOpRecord};
     use kitsune2_core::factories::MemoryOp;
     use kitsune2_dht::UNIT_TIME;
     use kitsune2_test_utils::space::TEST_SPACE_ID;
-    use kitsune2_test_utils::{enable_tracing, iter_check};
+    use kitsune2_test_utils::{enable_tracing, iter_check, random_bytes};
 
     #[tokio::test]
     async fn two_way_agent_sync() {
@@ -855,5 +857,99 @@ mod test {
 
         // Note that the total time elapsed by this point must be less than the initiate
         // interval. So we must have force initiated after timeouts.
+    }
+
+    #[tokio::test]
+    async fn dht_op_count_shared_via_gossip() {
+        enable_tracing();
+
+        let space = TEST_SPACE_ID;
+        let factory =
+            K2GossipFunctionalTestFactory::create(space.clone(), true, None)
+                .await;
+
+        let harness_1 = factory.new_instance().await;
+        let agent_info_1 = harness_1.join_local_agent(DhtArc::FULL).await;
+
+        const NUM_OPS: usize = 5;
+        let mut ops = Vec::<MemoryOpRecord>::with_capacity(NUM_OPS);
+        for _ in 0..NUM_OPS {
+            let op = MemoryOp::new(Timestamp::now(), random_bytes(128));
+            ops.push(MemoryOpRecord {
+                op_id: op.compute_op_id(),
+                op_data: op.op_data,
+                created_at: op.created_at,
+                stored_at: Timestamp::now(),
+                processed: false,
+            });
+        }
+
+        harness_1
+            .op_store
+            .write()
+            .await
+            .op_list
+            .extend(ops.iter().map(|op| (op.op_id.clone(), op.clone())));
+
+        let harness_2 = factory.new_instance().await;
+        let agent_info_2 = harness_2.join_local_agent(DhtArc::FULL).await;
+
+        harness_1
+            .space
+            .peer_store()
+            .insert(vec![agent_info_2.clone()])
+            .await
+            .unwrap();
+
+        harness_1
+            .wait_for_sync_with(&harness_2, std::time::Duration::from_secs(60))
+            .await;
+
+        let summary_2 = harness_2
+            .gossip
+            .get_state_summary(GossipStateSummaryRequest {
+                include_dht_summary: false,
+            })
+            .await
+            .unwrap();
+
+        let h1_url = agent_info_1.url.clone().unwrap();
+        let meta_for_h1 = summary_2
+            .peer_meta
+            .get(&h1_url)
+            .expect("expected peer_meta entry for harness_1");
+        assert!(
+            meta_for_h1.dht_op_count.is_some(),
+            "dht_op_count should be reported for harness_1"
+        );
+        assert!(
+            meta_for_h1.dht_op_count.unwrap() >= NUM_OPS as u64,
+            "expected at least {NUM_OPS} ops, got {:?}",
+            meta_for_h1.dht_op_count
+        );
+
+        let summary_1 = harness_1
+            .gossip
+            .get_state_summary(GossipStateSummaryRequest {
+                include_dht_summary: false,
+            })
+            .await
+            .unwrap();
+
+        let h2_url = agent_info_2.url.clone().unwrap();
+        let meta_for_h2 = summary_1
+            .peer_meta
+            .get(&h2_url)
+            .expect("expected peer_meta entry for harness_2");
+        assert!(
+            meta_for_h2.dht_op_count.is_some(),
+            "dht_op_count should be reported for harness_2"
+        );
+
+        assert!(
+            summary_1.local_op_count >= NUM_OPS as u64,
+            "expected local_op_count >= {NUM_OPS}, got {}",
+            summary_1.local_op_count
+        );
     }
 }

--- a/crates/gossip/src/harness/op_store.rs
+++ b/crates/gossip/src/harness/op_store.rs
@@ -338,6 +338,13 @@ impl OpStore for K2GossipMemoryOpStore {
             Ok(self_lock.time_slice_hashes.get_all(&arc))
         })
     }
+
+    fn query_total_op_count(&self) -> BoxFut<'_, K2Result<u64>> {
+        Box::pin(async move {
+            let lock = self.read().await;
+            Ok(lock.op_list.len() as u64)
+        })
+    }
 }
 
 #[derive(Debug, Default)]

--- a/crates/gossip/src/peer_meta_store.rs
+++ b/crates/gossip/src/peer_meta_store.rs
@@ -71,6 +71,26 @@ impl K2PeerMetaStore {
         .await
     }
 
+    /// Get the DHT op count last reported by the given peer.
+    pub async fn peer_dht_op_count(&self, peer: Url) -> K2Result<Option<u64>> {
+        self.get(peer, "gossip:dht_op_count").await
+    }
+
+    /// Set the DHT op count reported by the given peer.
+    pub(crate) async fn set_peer_dht_op_count(
+        &self,
+        peer: Url,
+        count: u64,
+    ) -> K2Result<()> {
+        self.put(
+            peer,
+            "gossip:dht_op_count",
+            count,
+            Some(Timestamp::now() + Duration::from_secs(24 * 60 * 60)),
+        )
+        .await
+    }
+
     /// Get the number of peer behavior errors.
     ///
     /// These are gossip rounds that have failed for a reason that we consider to be a wrong
@@ -307,6 +327,27 @@ mod tests {
         assert_eq!(
             Some(timestamp),
             store.new_ops_bookmark(peer.clone()).await.unwrap()
+        );
+    }
+
+    #[tokio::test]
+    async fn round_trip_dht_op_count() {
+        let store = test_store().await;
+        let peer = Url::from_str("ws://test-host:80/1").unwrap();
+
+        store.set_peer_dht_op_count(peer.clone(), 42).await.unwrap();
+        assert_eq!(
+            Some(42),
+            store.peer_dht_op_count(peer.clone()).await.unwrap()
+        );
+
+        store
+            .set_peer_dht_op_count(peer.clone(), 100)
+            .await
+            .unwrap();
+        assert_eq!(
+            Some(100),
+            store.peer_dht_op_count(peer.clone()).await.unwrap()
         );
     }
 }

--- a/crates/gossip/src/respond/accept.rs
+++ b/crates/gossip/src/respond/accept.rs
@@ -40,6 +40,12 @@ impl K2Gossip {
         )
         .await?;
 
+        if let Some(op_count) = accept.dht_op_count {
+            self.peer_meta_store
+                .set_peer_dht_op_count(from_peer.clone(), op_count)
+                .await?;
+        }
+
         // Send discovered ops to the fetch queue
         self.fetch
             .request_ops(decode_ids(accept.new_ops), from_peer.clone())
@@ -328,6 +334,82 @@ mod tests {
     use kitsune2_test_utils::enable_tracing;
 
     #[tokio::test]
+    async fn dht_op_count_is_stored_from_accept() {
+        let harness = RespondTestHarness::create().await;
+
+        let local_agent = harness.create_agent(DhtArc::FULL).await;
+        harness
+            .gossip
+            .local_agent_store
+            .add(local_agent.local.clone())
+            .await
+            .unwrap();
+
+        let remote_agent = harness.create_agent(DhtArc::FULL).await;
+        let remote_url = remote_agent.url.clone().unwrap();
+
+        let session_id = harness
+            .insert_initiated_round_state(&local_agent, &remote_agent)
+            .await;
+
+        let disc_boundary = match harness
+            .gossip
+            .dht
+            .read()
+            .await
+            .snapshot_minimal(ArcSet::new(vec![DhtArc::FULL]).unwrap())
+            .await
+            .unwrap()
+        {
+            DhtSnapshot::Minimal { disc_boundary, .. } => disc_boundary,
+            _ => panic!("Expected a minimal snapshot"),
+        };
+
+        harness
+            .gossip
+            .respond_to_accept(
+                remote_url.clone(),
+                K2GossipAcceptMessage {
+                    session_id,
+                    participating_agents: encode_agent_ids([remote_agent
+                        .agent
+                        .clone()]),
+                    arc_set: Some(ArcSetMessage {
+                        value: ArcSet::new(vec![DhtArc::FULL])
+                            .unwrap()
+                            .encode(),
+                    }),
+                    missing_agents: vec![],
+                    new_since: UNIX_TIMESTAMP.as_micros(),
+                    max_op_data_bytes: harness
+                        .gossip
+                        .config
+                        .max_gossip_op_bytes,
+                    new_ops: vec![],
+                    updated_new_since: Timestamp::now().as_micros(),
+                    dht_op_count: Some(77),
+                    snapshot: Some(SnapshotMinimalMessage {
+                        disc_boundary: disc_boundary.as_micros(),
+                        disc_top_hash: Bytes::new(),
+                        ring_top_hashes: vec![],
+                    }),
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            Some(77),
+            harness
+                .gossip
+                .peer_meta_store
+                .peer_dht_op_count(remote_url)
+                .await
+                .unwrap()
+        );
+    }
+
+    #[tokio::test]
     async fn respect_size_limit_for_new_ops() {
         enable_tracing();
 
@@ -414,6 +496,7 @@ mod tests {
                         .max_gossip_op_bytes,
                     new_ops: vec![],
                     updated_new_since: Timestamp::now().as_micros(),
+                    dht_op_count: Some(0),
                     snapshot: Some(SnapshotMinimalMessage {
                         disc_boundary: disc_boundary.as_micros(),
                         disc_top_hash: Bytes::new(),

--- a/crates/gossip/src/respond/initiate.rs
+++ b/crates/gossip/src/respond/initiate.rs
@@ -24,6 +24,14 @@ impl K2Gossip {
             return Ok(None);
         }
 
+        // Persist the peer's reported DHT op count on every accepted initiate,
+        // even if we respond with Busy.
+        if let Some(op_count) = initiate.dht_op_count {
+            self.peer_meta_store
+                .set_peer_dht_op_count(from_peer.clone(), op_count)
+                .await?;
+        }
+
         // If we've already accepted the maximum number of rounds, we can't accept another.
         // Send back a busy message to let the peer know.
         if self.config.max_concurrent_accepted_rounds != 0
@@ -115,6 +123,8 @@ impl K2Gossip {
         );
         state.peer_max_op_data_bytes -= used_bytes as i32;
 
+        let dht_op_count = self.dht.read().await.op_count();
+
         Ok(Some(GossipMessage::Accept(K2GossipAcceptMessage {
             session_id: initiate.session_id,
             participating_agents: encode_agent_ids(our_agents),
@@ -126,6 +136,7 @@ impl K2Gossip {
             max_op_data_bytes: self.config.max_gossip_op_bytes,
             new_ops: encode_op_ids(new_ops),
             updated_new_since: new_bookmark.as_micros(),
+            dht_op_count: Some(dht_op_count),
             snapshot,
         })))
     }
@@ -243,6 +254,7 @@ mod tests {
                     tie_breaker: 0,
                     new_since: Timestamp::now().as_micros(),
                     max_op_data_bytes: 5_000,
+                    dht_op_count: Some(0),
                 },
             )
             .await
@@ -341,6 +353,7 @@ mod tests {
                     tie_breaker: 0,
                     new_since: Timestamp::now().as_micros(),
                     max_op_data_bytes: 0,
+                    dht_op_count: Some(0),
                 }),
             )
             .await
@@ -380,6 +393,7 @@ mod tests {
                         tie_breaker: 0,
                         new_since: Timestamp::now().as_micros(),
                         max_op_data_bytes: 0,
+                        dht_op_count: Some(0),
                     }),
                 )
                 .await
@@ -409,6 +423,7 @@ mod tests {
             tie_breaker: 0,
             new_since: Timestamp::now().as_micros(),
             max_op_data_bytes: 5_000,
+            dht_op_count: Some(0),
         });
 
         let terminate_message =
@@ -464,6 +479,7 @@ mod tests {
                     tie_breaker: 0,
                     new_since: Timestamp::now().as_micros(),
                     max_op_data_bytes: 5_000,
+                    dht_op_count: Some(0),
                 }),
             )
             .await
@@ -510,6 +526,7 @@ mod tests {
                     tie_breaker: 0,
                     new_since: 0,
                     max_op_data_bytes: 0,
+                    dht_op_count: Some(0),
                 }),
             )
             .await
@@ -570,6 +587,7 @@ mod tests {
                     tie_breaker: initiate.tie_breaker.saturating_add(1),
                     new_since: Timestamp::now().as_micros(),
                     max_op_data_bytes: 5_000,
+                    dht_op_count: Some(0),
                 }),
             )
             .await
@@ -632,6 +650,7 @@ mod tests {
                     tie_breaker: initiate.tie_breaker,
                     new_since: Timestamp::now().as_micros(),
                     max_op_data_bytes: 5_000,
+                    dht_op_count: Some(0),
                 }),
             )
             .await
@@ -674,6 +693,7 @@ mod tests {
                         .max_gossip_op_bytes,
                     new_ops: Vec::new(),
                     updated_new_since: UNIX_TIMESTAMP.as_micros(),
+                    dht_op_count: Some(0),
                     snapshot: None,
                 }),
             )
@@ -686,6 +706,65 @@ mod tests {
             ),
             "Expected 'Unsolicited Accept message', got: {response:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn dht_op_count_is_stored_from_initiate() {
+        let harness = RespondTestHarness::create().await;
+
+        let local_agent = harness.create_agent(DhtArc::FULL).await;
+        harness
+            .gossip
+            .local_agent_store
+            .add(local_agent.local.clone())
+            .await
+            .unwrap();
+
+        let remote_agent = harness.create_agent(DhtArc::FULL).await;
+        let remote_url = remote_agent.url.clone().unwrap();
+
+        let response = harness
+            .gossip
+            .respond_to_initiate(
+                remote_url.clone(),
+                K2GossipInitiateMessage {
+                    session_id: test_session_id(),
+                    participating_agents: encode_agent_ids([remote_agent
+                        .agent
+                        .clone()]),
+                    arc_set: Some(ArcSetMessage {
+                        value: ArcSet::new(vec![DhtArc::FULL])
+                            .unwrap()
+                            .encode(),
+                    }),
+                    tie_breaker: rand::thread_rng()
+                        .next_u32()
+                        .saturating_add(1),
+                    new_since: Timestamp::now().as_micros(),
+                    max_op_data_bytes: 5_000,
+                    dht_op_count: Some(99),
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            Some(99),
+            harness
+                .gossip
+                .peer_meta_store
+                .peer_dht_op_count(remote_url)
+                .await
+                .unwrap()
+        );
+
+        // The local store is empty, so the accept message should report 0 ops.
+        match response.unwrap() {
+            GossipMessage::Accept(accept) => {
+                assert_eq!(Some(0), accept.dht_op_count);
+            }
+            other => panic!("Expected Accept, got: {other:?}"),
+        }
     }
 
     #[tokio::test]
@@ -758,6 +837,7 @@ mod tests {
                         .gossip
                         .config
                         .max_gossip_op_bytes,
+                    dht_op_count: Some(0),
                 },
             )
             .await

--- a/crates/gossip/src/respond/terminate.rs
+++ b/crates/gossip/src/respond/terminate.rs
@@ -307,6 +307,7 @@ mod tests {
                     tie_breaker: 0,
                     new_since: 0,
                     max_op_data_bytes: 30_000,
+                    dht_op_count: Some(0),
                 }),
             )
             .await
@@ -395,6 +396,7 @@ mod tests {
                     tie_breaker: 0,
                     new_since: 0,
                     max_op_data_bytes: 30_000,
+                    dht_op_count: Some(0),
                 }),
             )
             .await

--- a/crates/gossip/src/respond/tests.rs
+++ b/crates/gossip/src/respond/tests.rs
@@ -103,6 +103,7 @@ async fn initiate_respect_size_limit_for_new_ops_and_disc() {
                 max_op_data_bytes: harness.gossip.config.max_gossip_op_bytes,
                 new_ops: vec![],
                 updated_new_since: Timestamp::now().as_micros(),
+                dht_op_count: Some(0),
                 snapshot: Some(SnapshotMinimalMessage {
                     disc_boundary: disc_boundary.as_micros(),
                     disc_top_hash: Bytes::new(),
@@ -321,6 +322,7 @@ async fn accept_respect_size_limit_for_new_ops_and_disc() {
                 tie_breaker: rand::thread_rng().next_u32().saturating_add(1),
                 new_since: UNIX_TIMESTAMP.as_micros(),
                 max_op_data_bytes: harness.gossip.config.max_gossip_op_bytes,
+                dht_op_count: Some(0),
             },
         )
         .await

--- a/crates/gossip/src/summary.rs
+++ b/crates/gossip/src/summary.rs
@@ -16,7 +16,10 @@ impl K2Gossip {
             accepted_rounds: Vec::new(),
             dht_summary: HashMap::new(),
             peer_meta: HashMap::new(),
+            local_op_count: 0,
         };
+
+        summary.local_op_count = self.dht.read().await.op_count();
 
         if let Some(current_round) =
             self.initiated_round_state.lock().await.as_ref()
@@ -129,6 +132,10 @@ impl K2Gossip {
                     peer_timeouts: self
                         .peer_meta_store
                         .peer_timeouts(url.clone())
+                        .await?,
+                    dht_op_count: self
+                        .peer_meta_store
+                        .peer_dht_op_count(url.clone())
                         .await?,
                     is_tombstone: agent.is_tombstone,
                     storage_arc: agent.storage_arc,

--- a/crates/kitsune2_showcase/src/app/file_op_store.rs
+++ b/crates/kitsune2_showcase/src/app/file_op_store.rs
@@ -164,4 +164,8 @@ impl OpStore for FileOpStore {
     ) -> BoxFut<'_, K2Result<Vec<(u64, Bytes)>>> {
         self.mem_op_store.retrieve_slice_hashes(arc)
     }
+
+    fn query_total_op_count(&self) -> BoxFut<'_, K2Result<u64>> {
+        self.mem_op_store.query_total_op_count()
+    }
 }


### PR DESCRIPTION
closes #438
closely following description of ticket.

## Adds `op_count` to DHT and wire protocol

- Peers track their own OP count in a monotonically-increasing `Dht::op_count` field and...
- ...exchange their number during gossip. 
- OP count of remote peers gets tracked in peer store
- shared with K2 user in `K2Gossip::summary`.

## Additionally (to issue description)
- Makes `local_op_count` available in summary so user can do something like:

```Rust
let summary = space.gossip().get_state_summary(request).await?;
let my_ops = summary.local_op_count;
for (peer_url, meta) in &summary.peer_meta {
    if let Some(peer_ops) = meta.dht_op_count {
        let progress = my_ops as f64 / peer_ops as f64;
        // ...
    }
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * DHT operation counting: local op totals can be queried and are included in state summaries; gossip messages now carry peers' reported op counts so sync progress can be estimated and peer counts are persisted.

* **Tests**
  * Added tests covering op count initialization, loading from store, increments, idempotence on duplicates, persistence per-peer, and propagation via gossip.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->