### PR TITLE
Iroh transport auth integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2742,6 +2742,7 @@ dependencies = [
  "iroh",
  "iroh-relay-holochain",
  "kitsune2_api",
+ "kitsune2_bootstrap_client",
  "kitsune2_core",
  "kitsune2_test_utils",
  "kitsune2_transport_iroh",

--- a/crates/bootstrap_client/src/lib.rs
+++ b/crates/bootstrap_client/src/lib.rs
@@ -183,6 +183,57 @@ pub fn blocking_put_auth(
     res.into()
 }
 
+/// Register an iroh endpoint public key with the relay on the bootstrap server.
+///
+/// After authenticating (which yields a bearer token), this function registers
+/// the 32-byte iroh public key with the server's relay allowlist so that the
+/// endpoint is permitted to connect to the relay.
+///
+/// This function should only be called when the server is configured with an
+/// auth hook server. Open relays do not expose the `relay/register` endpoint,
+/// and registration is not required when the relay has no access restrictions.
+///
+/// Note the `blocking_` prefix. This is a hint to the caller that if the
+/// function is used in an async context, it should be treated as a blocking
+/// operation.
+pub fn blocking_register_relay_key(
+    mut server_url: Url,
+    auth_material: &AuthMaterial,
+    key_bytes: &[u8; 32],
+) -> K2Result<()> {
+    server_url.set_path("authenticate");
+    let auth_url = server_url.as_str().to_string();
+    auth_material.priv_authenticate(&auth_url, AuthType::IfUninit)?;
+
+    server_url.set_path("relay/register");
+    let register_url = server_url.as_str().to_string();
+
+    fn priv_register(
+        register_url: &str,
+        key_bytes: &[u8; 32],
+        auth_material: &AuthMaterial,
+    ) -> Res<()> {
+        let token = auth_material.auth_token.lock().unwrap().clone().unwrap();
+        ureq::put(register_url)
+            .header("Content-Type", "application/octet-stream")
+            .header("Authorization", &format!("Bearer {token}"))
+            .send(key_bytes.as_ref())
+            .map(|_| ())
+            .into()
+    }
+
+    let mut res = priv_register(&register_url, key_bytes, auth_material);
+
+    if res.needs_auth() {
+        server_url.set_path("authenticate");
+        let auth_url = server_url.as_str().to_string();
+        auth_material.priv_authenticate(&auth_url, AuthType::Force)?;
+        res = priv_register(&register_url, key_bytes, auth_material);
+    }
+
+    res.into()
+}
+
 /// Get all agent infos from the bootstrap server for the given space.
 ///
 /// Note the `blocking_` prefix. This is a hint to the caller that if the

--- a/crates/bootstrap_srv/Cargo.toml
+++ b/crates/bootstrap_srv/Cargo.toml
@@ -48,6 +48,7 @@ sbd-server = { workspace = true, features = ["tungstenite"], optional = true }
 opentelemetry = { workspace = true }
 # iroh relay server-related dependencies
 iroh = { workspace = true, optional = true }
+iroh-base = { workspace = true, optional = true }
 iroh-relay-holochain = { workspace = true, features = [
   "server",
 ], optional = true }
@@ -71,4 +72,4 @@ http2 = ["axum/http2"]
 sbd = ["dep:sbd-server"]
 
 # use iroh relay server
-iroh-relay = ["dep:iroh", "dep:iroh-relay-holochain"]
+iroh-relay = ["dep:iroh", "dep:iroh-base", "dep:iroh-relay-holochain"]

--- a/crates/bootstrap_srv/src/auth.rs
+++ b/crates/bootstrap_srv/src/auth.rs
@@ -104,12 +104,22 @@ impl AuthTokenTracker {
     }
 
     /// Remove expired tokens from the tracker.
-    pub fn prune_expired(&self, config: &AuthConfig) {
+    ///
+    /// Returns the list of tokens that were pruned so that other subsystems
+    /// (e.g. `RelayAllowlist`) can clean up their own state accordingly.
+    pub fn prune_expired(&self, config: &AuthConfig) -> Vec<Arc<str>> {
         let mut tokens = self.tokens.lock().unwrap();
         let now = Instant::now();
-        tokens.retain(|_, last_used| {
-            now.duration_since(*last_used) < config.auth_token_idle_timeout
+        let mut expired = Vec::new();
+        tokens.retain(|token, last_used| {
+            if now.duration_since(*last_used) < config.auth_token_idle_timeout {
+                true
+            } else {
+                expired.push(token.clone());
+                false
+            }
         });
+        expired
     }
 }
 
@@ -312,7 +322,7 @@ mod tests {
         std::thread::sleep(std::time::Duration::from_millis(150));
 
         // Prune expired tokens
-        tracker.prune_expired(&config);
+        let _ = tracker.prune_expired(&config);
 
         // All tokens should be gone
         assert!(!tracker.is_valid(&Some(Arc::from("token1")), &config));

--- a/crates/bootstrap_srv/src/http.rs
+++ b/crates/bootstrap_srv/src/http.rs
@@ -62,6 +62,8 @@ pub struct Server {
     tls_reload_handle: Option<tokio::task::AbortHandle>,
     shutdown: Option<axum_server::Handle>,
     auth_tracker: crate::auth::AuthTokenTracker,
+    #[cfg(feature = "iroh-relay")]
+    relay_allowlist: Option<crate::RelayAllowlist>,
 }
 
 impl Drop for Server {
@@ -96,6 +98,8 @@ impl Server {
                 tls_reload_handle,
                 shutdown,
                 auth_tracker,
+                #[cfg(feature = "iroh-relay")]
+                relay_allowlist,
             })) => Ok(Self {
                 t_join: Some(t_join),
                 addrs,
@@ -104,6 +108,8 @@ impl Server {
                 tls_reload_handle,
                 shutdown: Some(shutdown),
                 auth_tracker,
+                #[cfg(feature = "iroh-relay")]
+                relay_allowlist,
             }),
             Ok(Err(err)) => Err(err),
             Err(_) => Err(std::io::Error::other("failed to bind server")),
@@ -121,6 +127,11 @@ impl Server {
     pub fn auth_tracker(&self) -> &crate::auth::AuthTokenTracker {
         &self.auth_tracker
     }
+
+    #[cfg(feature = "iroh-relay")]
+    pub fn relay_allowlist(&self) -> Option<&crate::RelayAllowlist> {
+        self.relay_allowlist.as_ref()
+    }
 }
 
 struct Ready {
@@ -130,6 +141,8 @@ struct Ready {
     tls_reload_handle: Option<tokio::task::AbortHandle>,
     shutdown: axum_server::Handle,
     auth_tracker: crate::auth::AuthTokenTracker,
+    #[cfg(feature = "iroh-relay")]
+    relay_allowlist: Option<crate::RelayAllowlist>,
 }
 
 #[derive(Clone)]
@@ -144,6 +157,10 @@ pub struct AppState {
     // SBD-specific (keep for SBD websockets)
     #[cfg(feature = "sbd")]
     pub sbd_state: Option<crate::sbd::SbdState>,
+
+    // Iroh relay allowlist: Some when authentication hook server is configured
+    #[cfg(feature = "iroh-relay")]
+    pub relay_allowlist: Option<crate::RelayAllowlist>,
 }
 
 type BoxFut<'a, T> =
@@ -237,23 +254,38 @@ fn tokio_thread(
             let auth_tracker = crate::auth::AuthTokenTracker::default();
             let auth_config = Arc::new(config.auth.clone());
 
-            // CORS credentials based on auth config
-            let allow_credentials = config.auth.authentication_hook_server.is_some();
+            // CORS credentials only when auth is enabled AND specific origins are configured.
+            // Access-Control-Allow-Credentials cannot be combined with Access-Control-Allow-Origin: *
+            let allow_credentials = config.auth.authentication_hook_server.is_some()
+                && config
+                    .allowed_origins
+                    .as_ref()
+                    .is_some_and(|o| !o.is_empty());
 
-            let mut app = Router::<AppState>::new()
+            let app = Router::<AppState>::new()
                 .route("/authenticate", routing::put(handle_auth))
                 .route("/health", routing::get(handle_health_get))
                 .route("/bootstrap/{space}", routing::get(handle_boot_get))
                 .route(
                     "/bootstrap/{space}/{agent}",
                     routing::put(handle_boot_put),
-                )
+                );
+
+            let mut app = app
                 .layer(tower_http::cors::CorsLayer::new()
                     .allow_methods(tower_http::cors::AllowMethods::list([Method::GET, Method::PUT, Method::OPTIONS]))
                     .allow_headers(allowed_headers)
                     .allow_origin(origin)
                     .allow_credentials(allow_credentials)
                 );
+
+            #[cfg(feature = "iroh-relay")]
+            let relay_allowlist: Option<crate::RelayAllowlist> =
+                if config.auth.authentication_hook_server.is_some() {
+                    Some(crate::RelayAllowlist::default())
+                } else {
+                    None
+                };
 
             if !config.no_relay_server {
                 #[cfg(feature = "sbd")]
@@ -262,7 +294,17 @@ fn tokio_thread(
                 }
                 #[cfg(feature = "iroh-relay")]
                 {
-                    let relay_state = crate::iroh_relay_axum::create_relay_state();
+                    app = app.route(
+                        "/relay/register",
+                        routing::put(handle_relay_register),
+                    );
+
+                    let relay_state =
+                        if let Some(allowlist) = relay_allowlist.clone() {
+                            crate::iroh_relay_axum::create_relay_state_with_allowlist(allowlist)
+                        } else {
+                            crate::iroh_relay_axum::create_relay_state()
+                        };
                     let relay_router = Router::new()
                         .route("/relay", routing::get(crate::iroh_relay_axum::relay_handler))
                         .route("/ping", routing::get(crate::iroh_relay_axum::relay_probe_handler))
@@ -274,6 +316,8 @@ fn tokio_thread(
 
             // Clone auth_tracker before moving it into AppState so we can return it
             let auth_tracker_for_ready = auth_tracker.clone();
+            #[cfg(feature = "iroh-relay")]
+            let relay_allowlist_for_ready = relay_allowlist.clone();
 
             let app: Router = app
                 .layer(extract::DefaultBodyLimit::max(1024))
@@ -294,6 +338,8 @@ fn tokio_thread(
                             })
                         }
                     },
+                    #[cfg(feature = "iroh-relay")]
+                    relay_allowlist,
                 });
 
             let receiver = HttpReceiver(h_recv);
@@ -380,6 +426,8 @@ fn tokio_thread(
                     tls_reload_handle,
                     shutdown: shutdown_handle,
                     auth_tracker: auth_tracker_for_ready,
+                    #[cfg(feature = "iroh-relay")]
+                    relay_allowlist: relay_allowlist_for_ready,
                 }))
                 .is_err()
             {
@@ -529,6 +577,66 @@ async fn handle_boot_put(
         HttpRequest::BootstrapPut { space, agent, body },
     )
     .await
+}
+
+#[cfg(feature = "iroh-relay")]
+async fn handle_relay_register(
+    extract::State(state): extract::State<AppState>,
+    headers: axum::http::HeaderMap,
+    body: bytes::Bytes,
+) -> response::Response {
+    // Validate bearer token
+    let token: Option<Arc<str>> = headers
+        .get("Authorization")
+        .and_then(|t| t.to_str().ok())
+        .and_then(|t| t.strip_prefix("Bearer "))
+        .map(<Arc<str>>::from);
+
+    if !state.auth_tracker.is_valid(&token, &state.auth_config) {
+        return axum::response::IntoResponse::into_response((
+            axum::http::StatusCode::UNAUTHORIZED,
+            "Unauthorized",
+        ));
+    }
+
+    // Expect exactly 32 bytes (iroh public key)
+    let key_bytes: &[u8; 32] = match body.as_ref().try_into() {
+        Ok(b) => b,
+        Err(_) => {
+            return axum::response::IntoResponse::into_response((
+                axum::http::StatusCode::BAD_REQUEST,
+                "Expected exactly 32 bytes (iroh public key)",
+            ));
+        }
+    };
+
+    let key = match iroh_base::PublicKey::from_bytes(key_bytes) {
+        Ok(k) => k,
+        Err(_) => {
+            return axum::response::IntoResponse::into_response((
+                axum::http::StatusCode::BAD_REQUEST,
+                "Invalid public key bytes",
+            ));
+        }
+    };
+
+    // Register the key in the allowlist (if auth is enabled).
+    // token must be Some here: is_valid returned true, and the allowlist is
+    // only present when an auth hook server is configured, which requires a
+    // bearer token for is_valid to succeed. Guard defensively anyway.
+    if let Some(allowlist) = &state.relay_allowlist {
+        let Some(token) = token else {
+            return axum::response::IntoResponse::into_response((
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                "Internal server error",
+            ));
+        };
+        allowlist.register(key, token);
+    }
+
+    axum::response::IntoResponse::into_response(axum::Json(serde_json::json!(
+        {}
+    )))
 }
 
 fn b64_to_bytes(

--- a/crates/bootstrap_srv/src/iroh_relay_axum.rs
+++ b/crates/bootstrap_srv/src/iroh_relay_axum.rs
@@ -20,13 +20,14 @@ use std::{
 };
 use tracing::{debug, trace, warn};
 
+use futures::FutureExt;
 use iroh_relay_holochain::{
     ExportKeyingMaterial, KeyCache,
     protos::{
         handshake, relay::PER_CLIENT_SEND_QUEUE_DEPTH, streams::StreamError,
     },
     server::{
-        AccessConfig, Metrics, client::Config, clients::Clients,
+        Access, AccessConfig, Metrics, client::Config, clients::Clients,
         streams::RelayedStream,
     },
 };
@@ -270,10 +271,36 @@ pub async fn relay_probe_handler() -> (
 /// Creates a RelayState instance for the axum relay handler.
 ///
 /// This creates the state needed for the relay handler which can be mounted
-/// as a standard axum route.
+/// as a standard axum route. All connections are permitted.
 pub fn create_relay_state() -> RelayState {
     let key_cache = KeyCache::new(1024);
     let access = Arc::new(AccessConfig::Everyone);
+    let metrics = Arc::new(Metrics::default());
+    RelayState::new(key_cache, access, metrics)
+}
+
+/// Creates a RelayState that restricts connections to endpoints registered
+/// in the provided allowlist.
+///
+/// Use this when the bootstrap server is configured with an authentication
+/// hook server. Clients must call `PUT /authenticate` and then
+/// `PUT /relay/register` before their relay connection will be accepted.
+pub fn create_relay_state_with_allowlist(
+    allowlist: crate::RelayAllowlist,
+) -> RelayState {
+    let key_cache = KeyCache::new(1024);
+    let access =
+        Arc::new(AccessConfig::Restricted(Box::new(move |endpoint_id| {
+            let allowlist = allowlist.clone();
+            async move {
+                if allowlist.is_allowed(&endpoint_id) {
+                    Access::Allow
+                } else {
+                    Access::Deny
+                }
+            }
+            .boxed()
+        })));
     let metrics = Arc::new(Metrics::default());
     RelayState::new(key_cache, access, metrics)
 }

--- a/crates/bootstrap_srv/src/lib.rs
+++ b/crates/bootstrap_srv/src/lib.rs
@@ -221,6 +221,11 @@ pub use auth::*;
 mod sbd;
 
 #[cfg(feature = "iroh-relay")]
+mod relay_allowlist;
+#[cfg(feature = "iroh-relay")]
+pub use relay_allowlist::*;
+
+#[cfg(feature = "iroh-relay")]
 pub mod iroh_relay_axum;
 
 #[cfg(test)]

--- a/crates/bootstrap_srv/src/relay_allowlist.rs
+++ b/crates/bootstrap_srv/src/relay_allowlist.rs
@@ -1,0 +1,40 @@
+use iroh_base::PublicKey;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+/// Allowlist mapping iroh endpoint public keys to the bearer token
+/// that was used to register them.
+///
+/// When the bootstrap server is configured with an authentication hook
+/// server, the relay endpoint uses this allowlist (via `AccessConfig::Restricted`)
+/// to gate relay connections. A client must first call `PUT /authenticate`
+/// to obtain a bearer token and then `PUT /relay/register` to register
+/// its iroh public key before it will be permitted to connect to the relay.
+#[derive(Clone, Default)]
+pub struct RelayAllowlist {
+    entries: Arc<Mutex<HashMap<PublicKey, Arc<str>>>>,
+}
+
+impl RelayAllowlist {
+    /// Register an iroh endpoint key with the given bearer token.
+    ///
+    /// If the key is already registered, the token is updated.
+    pub fn register(&self, key: PublicKey, token: Arc<str>) {
+        self.entries.lock().unwrap().insert(key, token);
+    }
+
+    /// Returns true if the given key is currently in the allowlist.
+    pub fn is_allowed(&self, key: &PublicKey) -> bool {
+        self.entries.lock().unwrap().contains_key(key)
+    }
+
+    /// Remove entries whose associated bearer token has been pruned from
+    /// the auth tracker (i.e. the token has expired).
+    pub fn prune_for_expired_tokens(&self, expired_tokens: &[Arc<str>]) {
+        if expired_tokens.is_empty() {
+            return;
+        }
+        let mut entries = self.entries.lock().unwrap();
+        entries.retain(|_, token| !expired_tokens.contains(token));
+    }
+}

--- a/crates/bootstrap_srv/src/server.rs
+++ b/crates/bootstrap_srv/src/server.rs
@@ -14,6 +14,8 @@ const CREATED_AT_CLOCK_SKEW_ALLOWED_MICROS: i64 =
 const EXPIRES_AT_DURATION_MAX_ALLOWED_MICROS: i64 =
     std::time::Duration::from_secs(60 * 30).as_micros() as i64;
 
+type OnTokensPruned = Option<Box<dyn Fn(&[Arc<str>]) + Send>>;
+
 /// Print out a message if this thread dies.
 struct ThreadGuard(&'static str);
 
@@ -96,12 +98,26 @@ impl BootstrapSrv {
         let prune_cont = cont.clone();
         let prune_space_map = space_map.clone();
         let prune_auth_tracker = server.auth_tracker().clone();
+
+        // When the iroh relay is enabled and auth is configured, also prune the relay allowlist
+        // when auth tokens expire so that endpoints can no longer use the relay.
+        #[cfg(feature = "iroh-relay")]
+        let on_tokens_pruned: OnTokensPruned =
+            server.relay_allowlist().cloned().map(|al| {
+                Box::new(move |tokens: &[Arc<str>]| {
+                    al.prune_for_expired_tokens(tokens);
+                }) as Box<dyn Fn(&[Arc<str>]) + Send>
+            });
+        #[cfg(not(feature = "iroh-relay"))]
+        let on_tokens_pruned: OnTokensPruned = None;
+
         workers.push(std::thread::spawn(move || {
             prune_worker(
                 config,
                 prune_cont,
                 prune_space_map,
                 prune_auth_tracker,
+                on_tokens_pruned,
             )
         }));
 
@@ -156,6 +172,7 @@ fn prune_worker(
     cont: Arc<std::sync::atomic::AtomicBool>,
     space_map: crate::SpaceMap,
     auth_tracker: crate::auth::AuthTokenTracker,
+    on_tokens_pruned: OnTokensPruned,
 ) -> std::io::Result<()> {
     let _g = ThreadGuard("prune_worker thread has ended");
 
@@ -170,8 +187,12 @@ fn prune_worker(
             // Prune expired space infos
             space_map.update_all(config.max_entries_per_space);
 
-            // Prune expired auth tokens
-            auth_tracker.prune_expired(&config.auth);
+            // Prune expired auth tokens, collecting the list of expired tokens
+            // so dependent subsystems (e.g. the relay allowlist) can clean up too.
+            let expired_tokens = auth_tracker.prune_expired(&config.auth);
+            if let Some(cb) = &on_tokens_pruned {
+                cb(&expired_tokens);
+            }
         }
     }
 

--- a/crates/bootstrap_srv/src/test/iroh_relay_axum.rs
+++ b/crates/bootstrap_srv/src/test/iroh_relay_axum.rs
@@ -1,7 +1,9 @@
 use super::*;
 use iroh::{EndpointAddr, RelayConfig, RelayMap, RelayUrl};
+use iroh_base::SecretKey;
 use kitsune2_test_utils::enable_tracing;
-use std::{net::SocketAddr, str::FromStr, sync::Arc};
+use rand_chacha::rand_core::SeedableRng;
+use std::{net::SocketAddr, str::FromStr, sync::Arc, time::Duration};
 
 const TEST_ALPN: &[u8] = b"alpn";
 
@@ -103,6 +105,339 @@ fn use_bootstrap_and_iroh_relay_with_tls() {
     assert_eq!(1, res.len());
 
     create_two_endpoints_and_assert_message_is_received(true, addr);
+}
+
+#[test]
+fn use_bootstrap_and_iroh_relay_with_auth() {
+    enable_tracing();
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    // Start a fake authentication hook server in its own thread and runtime.
+    // BootstrapSrv creates its own multi-thread tokio runtime internally, so
+    // we keep the fake hook server isolated in a separate runtime.
+    let (auth_addr_tx, auth_addr_rx) = std::sync::mpsc::channel();
+    let _auth_server = std::thread::spawn(move || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_io()
+            .enable_time()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let listener =
+                tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let addr = listener.local_addr().unwrap();
+            let _ = auth_addr_tx.send(addr);
+
+            let app = axum::Router::new().route(
+                "/authenticate",
+                axum::routing::put(|| async {
+                    axum::Json(
+                        serde_json::json!({"authToken": "iroh-relay-test-token"}),
+                    )
+                }),
+            );
+            let _ = axum::serve(listener, app).await;
+        });
+    });
+
+    let auth_addr = auth_addr_rx
+        .recv_timeout(std::time::Duration::from_secs(5))
+        .expect("auth hook server did not start in time");
+    let hook_url = format!("http://{auth_addr}");
+
+    let s = BootstrapSrv::new(Config {
+        prune_interval: std::time::Duration::from_millis(5),
+        auth: crate::auth::AuthConfig {
+            authentication_hook_server: Some(hook_url),
+            ..Default::default()
+        },
+        ..Config::testing()
+    })
+    .unwrap();
+    let addr = s.listen_addrs()[0];
+
+    create_two_authenticated_endpoints_and_assert_message_is_received(addr);
+}
+
+#[test]
+fn use_bootstrap_and_iroh_relay_auth_rejects_unregistered() {
+    enable_tracing();
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let (auth_addr_tx, auth_addr_rx) = std::sync::mpsc::channel();
+    let _auth_server = std::thread::spawn(move || {
+        let rt = tokio::runtime::Builder::new_current_thread()
+            .enable_io()
+            .enable_time()
+            .build()
+            .unwrap();
+        rt.block_on(async {
+            let listener =
+                tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+            let addr = listener.local_addr().unwrap();
+            let _ = auth_addr_tx.send(addr);
+
+            let app = axum::Router::new().route(
+                "/authenticate",
+                axum::routing::put(|| async {
+                    axum::Json(
+                        serde_json::json!({"authToken": "iroh-relay-test-token"}),
+                    )
+                }),
+            );
+            let _ = axum::serve(listener, app).await;
+        });
+    });
+
+    let auth_addr = auth_addr_rx
+        .recv_timeout(Duration::from_secs(5))
+        .expect("auth hook server did not start in time");
+    let hook_url = format!("http://{auth_addr}");
+
+    let s = BootstrapSrv::new(Config {
+        prune_interval: std::time::Duration::from_millis(5),
+        auth: crate::auth::AuthConfig {
+            authentication_hook_server: Some(hook_url),
+            ..Default::default()
+        },
+        ..Config::testing()
+    })
+    .unwrap();
+    let addr = s.listen_addrs()[0];
+
+    assert_authenticated_relay_rejects_unregistered(addr);
+}
+
+fn assert_authenticated_relay_rejects_unregistered(addr: SocketAddr) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .enable_time()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        let relay_url =
+            RelayUrl::from_str(&format!("http://{addr:?}")).unwrap();
+
+        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(42u64);
+        let ep_1_secret = SecretKey::generate(&mut rng);
+        let ep_2_secret = SecretKey::generate(&mut rng);
+        let ep_3_secret = SecretKey::generate(&mut rng);
+
+        let build_endpoint = |secret_key: SecretKey| {
+            iroh::Endpoint::empty_builder(iroh::RelayMode::Custom(
+                RelayMap::empty(),
+            ))
+            .secret_key(secret_key)
+            .alpns(vec![TEST_ALPN.to_vec()])
+            .insecure_skip_relay_cert_verify(true)
+        };
+
+        let ep_1 = build_endpoint(ep_1_secret).bind().await.unwrap();
+        let ep_2 = build_endpoint(ep_2_secret).bind().await.unwrap();
+        let ep_3 = build_endpoint(ep_3_secret).bind().await.unwrap();
+
+        let authenticate_and_register = |key_bytes: [u8; 32]| async move {
+            let token_resp = ureq::put(&format!("http://{addr}/authenticate"))
+                .send(b"test-auth-material".as_ref())
+                .unwrap()
+                .into_body()
+                .read_to_string()
+                .unwrap();
+            let token = serde_json::from_str::<serde_json::Value>(&token_resp)
+                .unwrap()["authToken"]
+                .as_str()
+                .unwrap()
+                .to_owned();
+            ureq::put(&format!("http://{addr}/relay/register"))
+                .header("Authorization", &format!("Bearer {token}"))
+                .send(key_bytes.as_ref())
+                .unwrap();
+        };
+
+        authenticate_and_register(*ep_1.id().as_bytes()).await;
+        authenticate_and_register(*ep_2.id().as_bytes()).await;
+
+        // ep_3 attempts registration with the correct key but an invalid bearer
+        // token. Assert the server rejects it with 401; ep_3 remains absent
+        // from the allowlist.
+        let err = ureq::put(&format!("http://{addr}/relay/register"))
+            .header("Authorization", "Bearer invalid-token")
+            .send(ep_3.id().as_bytes().as_ref())
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                ureq::Error::StatusCode(401)
+            ),
+            "expected 401 Unauthorized, got {err:?}"
+        );
+
+        let relay_cfg = Arc::new(RelayConfig {
+            url: relay_url.clone(),
+            quic: None,
+        });
+        ep_1.insert_relay(relay_url.clone(), relay_cfg.clone()).await;
+        ep_2.insert_relay(relay_url.clone(), relay_cfg.clone()).await;
+        ep_3.insert_relay(relay_url.clone(), relay_cfg.clone()).await;
+
+        let ep_1_addr =
+            EndpointAddr::new(ep_1.id()).with_relay_url(relay_url.clone());
+        let ep_2_addr =
+            EndpointAddr::new(ep_2.id()).with_relay_url(relay_url.clone());
+
+        // ep_3 has no registered key, so the relay denies its WebSocket
+        // connection, leaving it with no path to reach ep_1 or ep_2.
+        // iroh retries the denied relay connection with backoff rather than
+        // returning an explicit error from connect(), so the expected outcome
+        // is that the attempt does not succeed within the timeout window.
+        let ep_3_to_ep_1 = tokio::time::timeout(
+            Duration::from_secs(5),
+            ep_3.connect(ep_1_addr, TEST_ALPN),
+        )
+        .await;
+        assert!(
+            !matches!(ep_3_to_ep_1, Ok(Ok(_))),
+            "ep_3 (unregistered) must not connect to ep_1 via authenticated relay"
+        );
+
+        let ep_3_to_ep_2 = tokio::time::timeout(
+            Duration::from_secs(5),
+            ep_3.connect(ep_2_addr.clone(), TEST_ALPN),
+        )
+        .await;
+        assert!(
+            !matches!(ep_3_to_ep_2, Ok(Ok(_))),
+            "ep_3 (unregistered) must not connect to ep_2 via authenticated relay"
+        );
+
+        // ep_1 and ep_2 are both registered so they can reach each other.
+        let message = b"hello from ep1";
+        let accept_task = tokio::spawn(async move {
+            let conn = ep_2.accept().await.unwrap().await.unwrap();
+            let mut recv = conn.accept_uni().await.unwrap();
+            let data = recv.read_to_end(1_000).await.unwrap();
+            conn.close(0u8.into(), b"");
+            ep_2.close().await;
+            data
+        });
+
+        let conn = ep_1.connect(ep_2_addr, TEST_ALPN).await.unwrap();
+        let mut send_stream = conn.open_uni().await.unwrap();
+        send_stream.write_all(message).await.unwrap();
+        send_stream.finish().unwrap();
+
+        assert_eq!(accept_task.await.unwrap(), message);
+
+        ep_1.close().await;
+        ep_3.close().await;
+    });
+}
+
+fn create_two_authenticated_endpoints_and_assert_message_is_received(
+    addr: SocketAddr,
+) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .enable_time()
+        .build()
+        .unwrap();
+    rt.block_on(async {
+        let relay_url =
+            RelayUrl::from_str(&format!("http://{addr:?}")).unwrap();
+
+        // Create two iroh endpoints without relay initially.
+        // We must register each endpoint's public key with the server before
+        // connecting to the relay.
+        let mut rng = rand_chacha::ChaCha8Rng::seed_from_u64(99u64);
+        let ep_1_secret = SecretKey::generate(&mut rng);
+        let ep_2_secret = SecretKey::generate(&mut rng);
+
+        let build_endpoint_without_relay = |secret_key: SecretKey| {
+            // Start with an empty relay map so the endpoint binds without
+            // immediately connecting to the relay. The relay transport is
+            // kept so that insert_relay (called after registration) works.
+            iroh::Endpoint::empty_builder(iroh::RelayMode::Custom(
+                RelayMap::empty(),
+            ))
+            .secret_key(secret_key)
+            .alpns(vec![TEST_ALPN.to_vec()])
+            .insecure_skip_relay_cert_verify(true)
+        };
+
+        let ep_1 = build_endpoint_without_relay(ep_1_secret)
+            .bind()
+            .await
+            .unwrap();
+        let ep_2 = build_endpoint_without_relay(ep_2_secret)
+            .bind()
+            .await
+            .unwrap();
+
+        // Authenticate and register an endpoint's public key directly via HTTP.
+        let authenticate_and_register = |key_bytes: [u8; 32]| async move {
+            let auth_url = format!("http://{addr}/authenticate");
+            let token_resp = ureq::put(&auth_url)
+                .send(b"test-auth-material".as_ref())
+                .unwrap()
+                .into_body()
+                .read_to_string()
+                .unwrap();
+            let token = serde_json::from_str::<serde_json::Value>(&token_resp)
+                .unwrap()["authToken"]
+                .as_str()
+                .unwrap()
+                .to_owned();
+
+            let register_url = format!("http://{addr}/relay/register");
+            ureq::put(&register_url)
+                .header("Authorization", &format!("Bearer {token}"))
+                .send(key_bytes.as_ref())
+                .unwrap();
+        };
+
+        authenticate_and_register(*ep_1.id().as_bytes()).await;
+        authenticate_and_register(*ep_2.id().as_bytes()).await;
+
+        // Insert the relay into both endpoints. The relay WebSocket connection
+        // is established lazily when traffic is needed.
+        let relay_cfg = Arc::new(RelayConfig {
+            url: relay_url.clone(),
+            quic: None,
+        });
+        ep_1.insert_relay(relay_url.clone(), relay_cfg.clone())
+            .await;
+        ep_2.insert_relay(relay_url.clone(), relay_cfg.clone())
+            .await;
+
+        let ep_2_addr =
+            EndpointAddr::new(ep_2.id()).with_relay_url(relay_url.clone());
+
+        let message = b"hello from ep1";
+
+        let message_received = tokio::spawn(async move {
+            let conn = ep_2.accept().await.unwrap().await.unwrap();
+            match conn.accept_uni().await {
+                Ok(mut recv_stream) => {
+                    let data = recv_stream.read_to_end(1_000).await.unwrap();
+                    conn.close(0u8.into(), b"");
+                    ep_2.close().await;
+                    data
+                }
+                Err(err) => {
+                    panic!("failed to accept incoming stream: {err}");
+                }
+            }
+        });
+
+        let conn = ep_1.connect(ep_2_addr, TEST_ALPN).await.unwrap();
+        let mut send_stream = conn.open_uni().await.unwrap();
+        send_stream.write_all(message).await.unwrap();
+        send_stream.finish().unwrap();
+
+        let received = message_received.await.unwrap();
+        assert_eq!(received, message);
+        ep_1.close().await;
+    });
 }
 
 fn create_two_endpoints_and_assert_message_is_received(

--- a/crates/transport_iroh/Cargo.toml
+++ b/crates/transport_iroh/Cargo.toml
@@ -13,6 +13,7 @@ edition.workspace = true
 [dependencies]
 bytes = { workspace = true }
 iroh = { workspace = true }
+kitsune2_bootstrap_client = { workspace = true }
 # used for test-utils
 iroh-relay-holochain = { workspace = true, features = [
   "server",

--- a/crates/transport_iroh/src/lib.rs
+++ b/crates/transport_iroh/src/lib.rs
@@ -180,7 +180,9 @@
 
 use crate::endpoint::{DynIrohEndpoint, IrohEndpoint};
 use bytes::Bytes;
-use iroh::{Endpoint, EndpointAddr, RelayMap, RelayMode, RelayUrl};
+use iroh::{
+    Endpoint, EndpointAddr, RelayConfig, RelayMap, RelayMode, RelayUrl,
+};
 use kitsune2_api::*;
 use std::{
     collections::HashMap,
@@ -321,8 +323,13 @@ impl TransportFactory for IrohTransportFactory {
                     }
                 });
 
-            let imp = IrohTransport::create(transport_config, handler.clone())
-                .await?;
+            let auth_material = builder.auth_material.clone();
+            let imp = IrohTransport::create(
+                transport_config,
+                handler.clone(),
+                auth_material,
+            )
+            .await?;
             Ok(DefaultTransport::create(&handler, imp))
         })
     }
@@ -367,14 +374,30 @@ impl IrohTransport {
     async fn create(
         config: IrohTransportConfig,
         handler: Arc<TxImpHnd>,
+        auth_material: Option<Vec<u8>>,
     ) -> K2Result<DynTxImp> {
+        // Determine whether we need to register with the relay before connecting.
+        // Registration is required when both a relay URL and auth material are provided.
+        let needs_relay_registration =
+            config.relay_url.is_some() && auth_material.is_some();
+
         // If a relay server is configured, only use that.
         // Otherwise, use the default relay servers provided by n0.
         let mut builder = if let Some(relay_url) = &config.relay_url {
-            let relay_url = RelayUrl::from_str(relay_url)
-                .map_err(|err| K2Error::other_src("Invalid relay URL", err))?;
-            let relay_map = RelayMap::from_iter([relay_url]);
-            Endpoint::empty_builder(RelayMode::Custom(relay_map))
+            if needs_relay_registration {
+                // Start with an empty relay map so the endpoint binds without
+                // immediately connecting to the relay. The relay transport is
+                // kept intact so that insert_relay (called after registration)
+                // can establish the WebSocket connection.
+                Endpoint::empty_builder(RelayMode::Custom(RelayMap::empty()))
+            } else {
+                let relay_url =
+                    RelayUrl::from_str(relay_url).map_err(|err| {
+                        K2Error::other_src("Invalid relay URL", err)
+                    })?;
+                let relay_map = RelayMap::from_iter([relay_url]);
+                Endpoint::empty_builder(RelayMode::Custom(relay_map))
+            }
         } else {
             Endpoint::empty_builder(RelayMode::Default)
         };
@@ -391,6 +414,51 @@ impl IrohTransport {
             K2Error::other_src("Failed to bind iroh endpoint", err)
         })?;
 
+        // If we need relay registration, authenticate and register our public
+        // key with the server before inserting the relay into the endpoint.
+        // insert_relay is deferred until after the watcher task is spawned so
+        // that the address update it fires is guaranteed to be observed.
+        if needs_relay_registration {
+            let relay_url_str = config
+                .relay_url
+                .as_deref()
+                .expect("relay_url checked above");
+            let auth_bytes =
+                auth_material.expect("auth_material checked above");
+
+            // Derive the server base URL from the relay URL by removing the path.
+            // e.g. "http://addr/relay/" -> "http://addr/"
+            let server_url = ::url::Url::parse(relay_url_str).map_err(|e| {
+                K2Error::other_src("Invalid relay URL for registration", e)
+            })?;
+            let mut server_url = server_url;
+            server_url.set_path("/");
+
+            let key_bytes = *endpoint.id().as_bytes();
+            let auth_material =
+                kitsune2_bootstrap_client::AuthMaterial::new(auth_bytes);
+
+            // Perform the authentication and key registration synchronously.
+            tokio::task::spawn_blocking(move || {
+                kitsune2_bootstrap_client::blocking_register_relay_key(
+                    server_url,
+                    &auth_material,
+                    &key_bytes,
+                )
+            })
+            .await
+            .map_err(|e| K2Error::other_src("Registration task failed", e))??;
+        }
+
+        // Clone the raw endpoint before consuming it into IrohEndpoint so that
+        // insert_relay can be called after the watcher task is subscribed.
+        // iroh::Endpoint is Arc-backed so this is a cheap reference copy.
+        let raw_endpoint_for_relay = if needs_relay_registration {
+            Some(endpoint.clone())
+        } else {
+            None
+        };
+
         let endpoint = Arc::new(IrohEndpoint::new(endpoint));
         let local_url = Arc::new(RwLock::new(None));
         let connections = Arc::new(RwLock::new(HashMap::new()));
@@ -401,6 +469,27 @@ impl IrohTransport {
             handler.clone(),
             local_url.clone(),
         );
+
+        // The watcher is now subscribed. Insert the relay so that the address
+        // update it fires is captured by the running watcher task, ensuring
+        // local_url is populated before any outbound send can run.
+        if let Some(raw_ep) = raw_endpoint_for_relay {
+            let relay_url_str = config
+                .relay_url
+                .as_deref()
+                .expect("relay_url checked above");
+            let relay_url = RelayUrl::from_str(relay_url_str)
+                .map_err(|err| K2Error::other_src("Invalid relay URL", err))?;
+            raw_ep
+                .insert_relay(
+                    relay_url.clone(),
+                    Arc::new(RelayConfig {
+                        url: relay_url,
+                        quic: None,
+                    }),
+                )
+                .await;
+        }
 
         let accept_task = Self::spawn_accept_task(
             endpoint.clone(),


### PR DESCRIPTION
Closes https://github.com/holochain/kitsune2/issues/436

This was a missing piece, the Iroh transport wasn't set up to authenticate with the relay service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Authenticated relay key registration endpoint and server-side relay allowlist.
  * Transport now performs relay key registration at startup when credentials are provided.

* **Bug Fixes**
  * Token pruning returns pruned tokens to enable synchronized allowlist cleanup.
  * CORS handling improved to consider authentication and allowed origins.

* **Tests**
  * End-to-end tests for authenticated relay registration and messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->