### PR TITLE
feat: add connection up down counter metric

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2748,6 +2748,8 @@ dependencies = [
  "kitsune2_transport_iroh",
  "mockall",
  "n0-watcher",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "schemars",
  "serde",
  "tokio",
@@ -3588,6 +3590,8 @@ dependencies = [
  "rand 0.9.2",
  "serde_json",
  "thiserror 2.0.17",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,6 +149,8 @@ sbd-client = "0.3.2"
 # iroh relay for testing iroh transport
 iroh-relay-holochain = "0.96.1"
 iroh-base = "0.96.1"
+# used to test opentelemetry metrics
+opentelemetry_sdk = "0.30"
 
 # used to hash op data
 sha2 = "0.10.8"

--- a/crates/transport_iroh/Cargo.toml
+++ b/crates/transport_iroh/Cargo.toml
@@ -23,6 +23,11 @@ kitsune2_api = { workspace = true }
 kitsune2_core = { workspace = true, optional = true }
 # used for test-utils
 kitsune2_test_utils = { workspace = true, optional = true }
+opentelemetry = { workspace = true, optional = true }
+# used for testing
+opentelemetry_sdk = { workspace = true, features = [
+  "testing",
+], optional = true }
 serde = { workspace = true, features = ["derive"] }
 tokio = { workspace = true, features = [
   "macros",
@@ -55,3 +60,5 @@ test-utils = [
   "kitsune2_test_utils?/relay",
   "iroh/test-utils",
 ]
+
+metrics = ["dep:opentelemetry", "dep:opentelemetry_sdk"]

--- a/crates/transport_iroh/src/connection_context.rs
+++ b/crates/transport_iroh/src/connection_context.rs
@@ -1,4 +1,6 @@
 use crate::connection::DynConnection;
+#[cfg(feature = "metrics")]
+use crate::metrics::connection_counter_metric;
 use crate::stream::{DynIrohRecvStream, DynIrohSendStream};
 use crate::{
     Connections, FRAME_HEADER_LEN, FrameType, decode_frame_header,
@@ -174,6 +176,9 @@ impl ConnectionContext {
         self.connection.close(0u8, reason.as_bytes());
         if let Some(peer) = self.remote_url() {
             self.handler.peer_disconnect(peer, Some(reason));
+            // Record connection counter metric.
+            #[cfg(feature = "metrics")]
+            connection_counter_metric().add(-1, &[]);
         }
     }
 
@@ -224,7 +229,7 @@ impl ConnectionContext {
                             connections.clone(),
                             local_url,
                         )
-                        .await
+                            .await
                         {
                             error!(?err, "Stream closed by remote");
                             // Don't mark peer as unresponsive for NoLocalAgentsDuringPreflight
@@ -256,7 +261,7 @@ impl ConnectionContext {
                     .remove(&remote_url);
                 if !skip_unresponsive {
                     info!(?remote_url, "Setting peer unresponsive");
-                    if let Err(err) = ctx.handler.set_unresponsive(remote_url.clone(), Timestamp::now()).await{
+                    if let Err(err) = ctx.handler.set_unresponsive(remote_url.clone(), Timestamp::now()).await {
                         warn!(?err, ?remote_url, "Failed to set peer unresponsive");
                     }
                 } else {
@@ -298,7 +303,7 @@ impl ConnectionContext {
     ) -> K2Result<()> {
         if !ctx.preflight_received() {
             let result = tokio::time::timeout(Duration::from_secs(10), async {
-                let (remote_url, preflight_bytes) = read_preflight_frame_from_stream(&recv_stream,ctx.max_frame_bytes).await?;
+                let (remote_url, preflight_bytes) = read_preflight_frame_from_stream(&recv_stream, ctx.max_frame_bytes).await?;
 
                 ctx.set_remote_url(remote_url.clone());
                 ctx.handler
@@ -319,7 +324,7 @@ impl ConnectionContext {
                             local_url.clone(),
                             return_preflight,
                         )
-                        .await?;
+                            .await?;
                         info!(peer = ?ctx.connection.remote_id(),?local_url, "Sent preflight to peer from URL");
                         ctx.set_preflight_sent();
                     } else {
@@ -330,16 +335,19 @@ impl ConnectionContext {
 
                 Ok(remote_url)
             })
-        .await
-        .map_err(|err| {
-            K2Error::other_src("timed out waiting for preflight", err)
-        });
+                .await
+                .map_err(|err| {
+                    K2Error::other_src("timed out waiting for preflight", err)
+                });
             match result {
                 Ok(Ok(remote_url)) => {
                     connections
                         .write()
                         .expect("poisoned")
                         .insert(remote_url, ctx.clone());
+                    // Record connection counter metric.
+                    #[cfg(feature = "metrics")]
+                    connection_counter_metric().add(1, &[]);
                 }
                 Ok(Err(err)) | Err(err) => {
                     error!(?err, "failed to receive preflight frame");

--- a/crates/transport_iroh/src/lib.rs
+++ b/crates/transport_iroh/src/lib.rs
@@ -202,6 +202,8 @@ mod connection_context;
 mod endpoint;
 mod stream;
 use connection_context::*;
+#[cfg(feature = "metrics")]
+mod metrics;
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod test_utils;

--- a/crates/transport_iroh/src/metrics.rs
+++ b/crates/transport_iroh/src/metrics.rs
@@ -1,0 +1,16 @@
+use std::sync::OnceLock;
+
+static CONNECTION_COUNTER_METRIC: OnceLock<ConnectionCounterMetric> =
+    OnceLock::new();
+
+pub(crate) type ConnectionCounterMetric =
+    opentelemetry::metrics::UpDownCounter<i64>;
+
+pub(crate) fn connection_counter_metric() -> &'static ConnectionCounterMetric {
+    CONNECTION_COUNTER_METRIC.get_or_init(|| {
+        opentelemetry::global::meter("kitsune2")
+            .i64_up_down_counter("kitsune2.transport.connections")
+            .with_description("The number of open connections")
+            .build()
+    })
+}

--- a/crates/transport_iroh/tests/metrics.rs
+++ b/crates/transport_iroh/tests/metrics.rs
@@ -1,0 +1,165 @@
+#![cfg(feature = "metrics")]
+
+use bytes::Bytes;
+use kitsune2_api::Url;
+use kitsune2_test_utils::retry_fn_until_timeout;
+use kitsune2_test_utils::space::TEST_SPACE_ID;
+use kitsune2_transport_iroh::test_utils::{
+    IrohTransportTestHarness, MockTxHandler,
+};
+use opentelemetry_sdk::metrics::{
+    InMemoryMetricExporter, PeriodicReader, SdkMeterProvider,
+    data::{AggregatedMetrics, MetricData},
+};
+use std::sync::Arc;
+use std::time::Duration;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn connection_counter() {
+    let exporter = InMemoryMetricExporter::default();
+
+    // Create a PeriodicReader with a short interval
+    let reader = PeriodicReader::builder(exporter.clone())
+        .with_interval(Duration::from_millis(500))
+        .build();
+
+    // Build the meter provider
+    let meter_provider =
+        SdkMeterProvider::builder().with_reader(reader).build();
+    opentelemetry::global::set_meter_provider(meter_provider.clone());
+
+    // Set up two endpoints and establish a connection.
+    let harness = IrohTransportTestHarness::new().await;
+    let dummy_url = Url::from_str("http://url.not.set:0/0").unwrap();
+
+    let handler_1 = Arc::new(MockTxHandler::default());
+    let ep_1 = harness.build_transport(handler_1.clone()).await;
+    ep_1.register_space_handler(TEST_SPACE_ID, handler_1.clone());
+
+    assert!(
+        ep_1.get_connected_peers().await.unwrap().is_empty(),
+        "peers connected to ep_1 should be empty"
+    );
+    let handler_2 = Arc::new(MockTxHandler::default());
+    let ep_2 = harness.build_transport(handler_2.clone()).await;
+    ep_2.register_space_handler(TEST_SPACE_ID, handler_2.clone());
+
+    // Wait for URLs to be updated
+    retry_fn_until_timeout(
+        || async {
+            let ep_1_url = handler_1.current_url.lock().unwrap().clone();
+            let ep_2_url = handler_2.current_url.lock().unwrap().clone();
+            ep_1_url != dummy_url && ep_2_url != dummy_url
+        },
+        Some(5000),
+        Some(500),
+    )
+    .await
+    .unwrap();
+
+    // Flush metrics
+    meter_provider.force_flush().unwrap();
+
+    // Expect connection counter metric to not have recorded anything.
+    let resource_metrics = exporter.get_finished_metrics().unwrap();
+    assert!(resource_metrics.is_empty());
+
+    // Send a message from ep_1 to ep_2 to establish a connection.
+    let ep2_url = handler_2.current_url.lock().unwrap().clone();
+    ep_1.send_space_notify(
+        ep2_url,
+        TEST_SPACE_ID,
+        Bytes::from_static(b"hello"),
+    )
+    .await
+    .unwrap();
+
+    // Expect connection counter metric to have recorded the connection.
+    // Both endpoints are using the same process, therefore the same global
+    // metrics provider, so it should be 2 connections, one from each
+    // endpoint's perspective.
+    retry_fn_until_timeout(
+        || async {
+            let resource_metrics = exporter.get_finished_metrics().unwrap();
+            if resource_metrics.is_empty() {
+                return false;
+            }
+            let last_resource_metric = resource_metrics.last().unwrap();
+
+            // The resource metric contains exactly one scoped metric.
+            let scoped_metrics =
+                last_resource_metric.scope_metrics().collect::<Vec<_>>();
+            assert_eq!(scoped_metrics.len(), 1);
+            // Scoped metrics contain exactly one metric.
+            let metrics = scoped_metrics[0].metrics().collect::<Vec<_>>();
+            assert_eq!(metrics.len(), 1);
+            assert_eq!(metrics[0].name(), "kitsune2.transport.connections");
+            assert_eq!(
+                metrics[0].description(),
+                "The number of active connections"
+            );
+            if let AggregatedMetrics::I64(MetricData::Sum(sum)) =
+                metrics[0].data()
+            {
+                let data_points = sum.data_points().collect::<Vec<_>>();
+                assert_eq!(data_points.len(), 1);
+                assert_eq!(data_points[0].attributes().count(), 0);
+                // The count should be 2
+                data_points[0].value() == 2
+            } else {
+                panic!("expected an i64 metric");
+            }
+        },
+        Some(5000),
+        Some(500),
+    )
+    .await
+    .expect("timed out waiting for connection counter to go up to 2");
+
+    // ep 2 disconnects
+    drop(ep_2);
+
+    // Check that connection count has gone down to 1.
+    // 1 because ep_2 is just dropped, so doesn't record any metric, but ep_1
+    // records that ep_2 has disconnected.
+    retry_fn_until_timeout(
+        || async {
+            // A resource metric gets written at every periodic read.
+            let resource_metrics = exporter.get_finished_metrics().unwrap();
+            if resource_metrics.len() < 2 {
+                return false;
+            }
+            // Check last recorded metric.
+            let last_resource_metric = resource_metrics.last().unwrap();
+
+            // The resource metric contains exactly one scoped metric.
+            let scoped_metrics =
+                last_resource_metric.scope_metrics().collect::<Vec<_>>();
+            assert_eq!(scoped_metrics.len(), 1);
+
+            // The scoped metric contains exactly one metric.
+            let metrics = scoped_metrics[0].metrics().collect::<Vec<_>>();
+            assert_eq!(metrics.len(), 1);
+            assert_eq!(metrics[0].name(), "kitsune2.transport.connections");
+            assert_eq!(
+                metrics[0].description(),
+                "The number of active connections"
+            );
+            if let AggregatedMetrics::I64(MetricData::Sum(sum)) =
+                metrics[0].data()
+            {
+                let data_points = sum.data_points().collect::<Vec<_>>();
+                assert_eq!(data_points.len(), 1);
+                assert_eq!(data_points[0].attributes().count(), 0);
+                // The count should be 1
+                data_points[0].value() == 1
+            } else {
+                panic!("expected an i64 metric");
+            }
+        },
+        Some(5000),
+        Some(500),
+    )
+    .await
+    .expect("timed out waiting for connection counter to go down to 1");
+}


### PR DESCRIPTION
Count active connections in the iroh transport.

part of https://github.com/holochain/holochain/issues/5612

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional OpenTelemetry metrics integration for transport observability
  * Connection counter metric tracking active connections on connect/disconnect

* **Tests**
  * End-to-end test validating connection metrics and propagation using an in-memory exporter

* **Chores**
  * Added dev/test dependency and feature gate to enable metrics instrumentation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->