### PR TITLE
fix: separate known-peers index from peer store to fix blocking for shared URLs

### DIFF
--- a/crates/api/src/builder.rs
+++ b/crates/api/src/builder.rs
@@ -73,6 +73,10 @@ pub struct Builder {
 
     /// The [`BlocksFactory`] to be used for creating [`Blocks`] instances.
     pub blocks: DynBlocksFactory,
+
+    /// The [`KnownPeersFactory`] to be used for creating [`KnownPeers`]
+    /// instances.
+    pub known_peers: DynKnownPeersFactory,
 }
 
 impl Builder {
@@ -100,6 +104,7 @@ impl Builder {
                 local_agent_store,
                 publish,
                 blocks,
+                known_peers,
             } = &mut self;
 
             kitsune.default_config(config)?;
@@ -115,6 +120,7 @@ impl Builder {
             local_agent_store.default_config(config)?;
             publish.default_config(config)?;
             blocks.default_config(config)?;
+            known_peers.default_config(config)?;
 
             config.mark_defaults_set();
         }
@@ -137,6 +143,7 @@ impl Builder {
         self.local_agent_store.validate_config(&self.config)?;
         self.publish.validate_config(&self.config)?;
         self.blocks.validate_config(&self.config)?;
+        self.known_peers.validate_config(&self.config)?;
 
         self.config.mark_validated();
 

--- a/crates/api/src/known_peers.rs
+++ b/crates/api/src/known_peers.rs
@@ -1,0 +1,54 @@
+//! Known-peers index types.
+//!
+//! The [`KnownPeers`] trait provides an append-only index of all ever-seen
+//! agent infos, including those that are currently blocked.  It is used
+//! purely for URL → agent-ID resolution by the access control layer so that
+//! a blocked agent cannot slip through just because it shares a URL with a
+//! non-blocked agent.
+
+use crate::*;
+use std::sync::Arc;
+
+/// An append-only index of all ever-seen agent infos, including blocked ones.
+///
+/// Unlike [`PeerStore`] this store never removes entries on blocking – its
+/// only purpose is to let the access control layer answer the question
+/// "which agents have we ever seen at this URL?".
+pub trait KnownPeers: 'static + Send + Sync + std::fmt::Debug {
+    /// Record agent infos without any block filtering.
+    ///
+    /// This should be called with every batch of agent infos *before* any
+    /// block filter is applied, so that blocked agents remain discoverable
+    /// by URL.
+    fn record(
+        &self,
+        agent_infos: Vec<Arc<AgentInfoSigned>>,
+    ) -> BoxFut<'_, K2Result<()>>;
+
+    /// Look up all known agent IDs reachable at the given URL, regardless of
+    /// their current block status.
+    fn get_by_url(&self, url: Url) -> BoxFut<'_, K2Result<Vec<AgentId>>>;
+}
+
+/// Trait-object [`KnownPeers`].
+pub type DynKnownPeers = Arc<dyn KnownPeers>;
+
+/// A factory for constructing [`KnownPeers`] instances.
+pub trait KnownPeersFactory: 'static + Send + Sync + std::fmt::Debug {
+    /// Help the builder construct a default config from the chosen
+    /// module factories.
+    fn default_config(&self, config: &mut Config) -> K2Result<()>;
+
+    /// Validate configuration.
+    fn validate_config(&self, config: &Config) -> K2Result<()>;
+
+    /// Construct a [`KnownPeers`] instance.
+    fn create(
+        &self,
+        builder: Arc<Builder>,
+        space_id: SpaceId,
+    ) -> BoxFut<'static, K2Result<DynKnownPeers>>;
+}
+
+/// Trait-object [`KnownPeersFactory`].
+pub type DynKnownPeersFactory = Arc<dyn KnownPeersFactory>;

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -89,6 +89,9 @@ pub use peer_meta_store::*;
 mod gossip;
 pub use gossip::*;
 
+mod known_peers;
+pub use known_peers::*;
+
 mod local_agent_store;
 pub use local_agent_store::*;
 

--- a/crates/api/src/peer_store.rs
+++ b/crates/api/src/peer_store.rs
@@ -81,11 +81,18 @@ pub trait PeerStoreFactory: 'static + Send + Sync + std::fmt::Debug {
     fn validate_config(&self, config: &Config) -> K2Result<()>;
 
     /// Construct a peer store instance.
+    ///
+    /// Implementations **must** call [`KnownPeers::record`] with every
+    /// batch of agent infos *before* applying any block or expiry
+    /// filtering.  This ensures the access control layer can always
+    /// resolve a peer URL back to its agent IDs, even for agents that
+    /// have been blocked and removed from the peer store.
     fn create(
         &self,
         builder: Arc<Builder>,
         space_id: SpaceId,
         blocks: DynBlocks,
+        known_peers: DynKnownPeers,
     ) -> BoxFut<'static, K2Result<DynPeerStore>>;
 }
 

--- a/crates/api/src/space.rs
+++ b/crates/api/src/space.rs
@@ -60,6 +60,9 @@ pub trait Space: 'static + Send + Sync + std::fmt::Debug {
     /// Get a reference to the blocks module being used by this space.
     fn blocks(&self) -> &DynBlocks;
 
+    /// Get a reference to the known-peers index being used by this space.
+    fn known_peers(&self) -> &known_peers::DynKnownPeers;
+
     /// The URL that this space is currently reachable at, if any.
     fn current_url(&self) -> Option<Url>;
 

--- a/crates/core/src/common.rs
+++ b/crates/core/src/common.rs
@@ -174,9 +174,14 @@ mod tests {
             .create(builder.clone(), TEST_SPACE_ID)
             .await
             .unwrap();
+        let known_peers = builder
+            .known_peers
+            .create(builder.clone(), TEST_SPACE_ID)
+            .await
+            .unwrap();
         let peer_store = builder
             .peer_store
-            .create(builder.clone(), TEST_SPACE_ID, blocks)
+            .create(builder.clone(), TEST_SPACE_ID, blocks, known_peers)
             .await
             .unwrap();
         let local_agent_store = builder
@@ -229,10 +234,14 @@ mod tests {
             .create(builder.clone(), TEST_SPACE_ID)
             .await
             .unwrap();
-
+        let known_peers = builder
+            .known_peers
+            .create(builder.clone(), TEST_SPACE_ID)
+            .await
+            .unwrap();
         let peer_store = builder
             .peer_store
-            .create(builder.clone(), TEST_SPACE_ID, blocks)
+            .create(builder.clone(), TEST_SPACE_ID, blocks, known_peers)
             .await
             .unwrap();
         let local_agent_store = builder
@@ -292,10 +301,14 @@ mod tests {
             .create(builder.clone(), TEST_SPACE_ID)
             .await
             .unwrap();
-
+        let known_peers = builder
+            .known_peers
+            .create(builder.clone(), TEST_SPACE_ID)
+            .await
+            .unwrap();
         let peer_store = builder
             .peer_store
-            .create(builder.clone(), TEST_SPACE_ID, blocks)
+            .create(builder.clone(), TEST_SPACE_ID, blocks, known_peers)
             .await
             .unwrap();
         let local_agent_store = builder
@@ -355,10 +368,14 @@ mod tests {
             .create(builder.clone(), TEST_SPACE_ID)
             .await
             .unwrap();
-
+        let known_peers = builder
+            .known_peers
+            .create(builder.clone(), TEST_SPACE_ID)
+            .await
+            .unwrap();
         let peer_store = builder
             .peer_store
-            .create(builder.clone(), TEST_SPACE_ID, blocks)
+            .create(builder.clone(), TEST_SPACE_ID, blocks, known_peers)
             .await
             .unwrap();
         let local_agent_store = builder
@@ -436,10 +453,14 @@ mod tests {
             .create(builder.clone(), TEST_SPACE_ID)
             .await
             .unwrap();
-
+        let known_peers = builder
+            .known_peers
+            .create(builder.clone(), TEST_SPACE_ID)
+            .await
+            .unwrap();
         let peer_store = builder
             .peer_store
-            .create(builder.clone(), TEST_SPACE_ID, blocks)
+            .create(builder.clone(), TEST_SPACE_ID, blocks, known_peers)
             .await
             .unwrap();
         let local_agent_store = builder
@@ -524,10 +545,14 @@ mod tests {
             .create(builder.clone(), TEST_SPACE_ID)
             .await
             .unwrap();
-
+        let known_peers = builder
+            .known_peers
+            .create(builder.clone(), TEST_SPACE_ID)
+            .await
+            .unwrap();
         let peer_store = builder
             .peer_store
-            .create(builder.clone(), TEST_SPACE_ID, blocks)
+            .create(builder.clone(), TEST_SPACE_ID, blocks, known_peers)
             .await
             .unwrap();
         let local_agent_store = builder
@@ -594,7 +619,16 @@ mod tests {
 
         let peer_store = builder
             .peer_store
-            .create(builder.clone(), TEST_SPACE_ID, blocks.clone())
+            .create(
+                builder.clone(),
+                TEST_SPACE_ID,
+                blocks.clone(),
+                builder
+                    .known_peers
+                    .create(builder.clone(), TEST_SPACE_ID)
+                    .await
+                    .unwrap(),
+            )
             .await
             .unwrap();
 
@@ -623,7 +657,16 @@ mod tests {
 
         let peer_store = builder
             .peer_store
-            .create(builder.clone(), TEST_SPACE_ID, blocks.clone())
+            .create(
+                builder.clone(),
+                TEST_SPACE_ID,
+                blocks.clone(),
+                builder
+                    .known_peers
+                    .create(builder.clone(), TEST_SPACE_ID)
+                    .await
+                    .unwrap(),
+            )
             .await
             .unwrap();
 

--- a/crates/core/src/factories.rs
+++ b/crates/core/src/factories.rs
@@ -44,5 +44,8 @@ pub use mem_op_store::*;
 mod mem_blocks;
 pub use mem_blocks::*;
 
+mod core_known_peers;
+pub use core_known_peers::*;
+
 mod core_access;
 pub use core_access::*;

--- a/crates/core/src/factories/core_access.rs
+++ b/crates/core/src/factories/core_access.rs
@@ -1,6 +1,6 @@
 use kitsune2_api::{
-    AccessDecision, BlockTarget, DynBlocks, DynPeerStore, K2Result, PeerAccess,
-    PeerAccessState, Timestamp, Url,
+    AccessDecision, BlockTarget, DynBlocks, DynKnownPeers, K2Result,
+    PeerAccess, PeerAccessState, Timestamp, Url,
 };
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
@@ -23,21 +23,29 @@ impl Drop for CorePeerAccessState {
 
 impl CorePeerAccessState {
     /// Create a new instance of the [`CorePeerAccessState`].
-    pub fn new(peer_store: DynPeerStore, blocks: DynBlocks) -> K2Result<Self> {
+    ///
+    /// `known_peers` is used to resolve peer URLs to agent IDs regardless of
+    /// block status.  `peer_store` is used only to register a listener so
+    /// that access decisions are updated whenever the peer store is updated.
+    pub fn new(
+        known_peers: DynKnownPeers,
+        blocks: DynBlocks,
+        peer_store: &kitsune2_api::DynPeerStore,
+    ) -> K2Result<Self> {
         let decisions = Arc::new(RwLock::new(HashMap::new()));
         peer_store.register_peer_update_listener(Arc::new({
-            let peer_store = Arc::downgrade(&peer_store);
+            let known_peers = Arc::downgrade(&known_peers);
             let blocks = Arc::downgrade(&blocks);
             let decisions = decisions.clone();
 
             move |agent_info| {
-                let peer_store = peer_store.clone();
+                let known_peers = known_peers.clone();
                 let blocks = blocks.clone();
                 let decisions = decisions.clone();
 
                 Box::pin(async move {
-                    let Some(peer_store) = peer_store.upgrade() else {
-                        tracing::info!("PeerStore dropped, cannot make access decision");
+                    let Some(known_peers) = known_peers.upgrade() else {
+                        tracing::info!("KnownPeers dropped, cannot make access decision");
                         return;
                     };
                     let Some(blocks) = blocks.upgrade() else {
@@ -57,12 +65,12 @@ impl CorePeerAccessState {
 
                     tracing::debug!("Making access decision for peer URL: {:?}", peer_url);
 
-                    // fetch peers by url
-                    let agents_by_url: Vec<_> = match peer_store
+                    // Use known_peers (not peer_store) so we find blocked agents too.
+                    let agents_by_url: Vec<_> = match known_peers
                         .get_by_url(peer_url.clone())
                         .await {
-                        Ok(peers) => peers.into_iter()
-                        .map(|agent| BlockTarget::Agent(agent.agent.clone()))
+                        Ok(agents) => agents.into_iter()
+                        .map(BlockTarget::Agent)
                         .collect(),
                         Err(e) => {
                             tracing::error!(
@@ -165,5 +173,124 @@ impl PeerAccessState for CorePeerAccessState {
             .get(&peer_url)
             .cloned();
         Ok(decision)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::factories::{
+        CoreKnownPeers, MemBlocks, MemPeerStore, MemPeerStoreConfig,
+    };
+    use kitsune2_api::{AccessDecision, AgentId, BlockTarget, Blocks, Id};
+    use kitsune2_test_utils::agent::{AgentBuilder, TestLocalAgent};
+    use std::sync::Arc;
+
+    const AGENT_1: AgentId = AgentId(Id(bytes::Bytes::from_static(b"agent1")));
+    const AGENT_2: AgentId = AgentId(Id(bytes::Bytes::from_static(b"agent2")));
+
+    fn make_url(s: &str) -> Url {
+        Url::from_str(format!("ws://a.b:80/{s}")).unwrap()
+    }
+
+    fn make_peer_store(
+        blocks: Arc<MemBlocks>,
+        known_peers: Arc<CoreKnownPeers>,
+    ) -> kitsune2_api::DynPeerStore {
+        Arc::new(MemPeerStore::new(
+            MemPeerStoreConfig {
+                prune_interval_s: 10,
+            },
+            blocks,
+            known_peers,
+        ))
+    }
+
+    /// Blocking one agent at a URL must block the URL even when a
+    /// non-blocked agent also resides at that URL.
+    #[tokio::test]
+    async fn shared_url_blocked_agent_blocks_url() {
+        let url = make_url("shared");
+        let blocks = Arc::new(MemBlocks::default());
+        let known_peers = Arc::new(CoreKnownPeers::default());
+        let peer_store = make_peer_store(blocks.clone(), known_peers.clone());
+
+        let access_state = CorePeerAccessState::new(
+            known_peers.clone(),
+            blocks.clone(),
+            &peer_store,
+        )
+        .unwrap();
+
+        // Insert both agents at the same URL; this records them in KnownPeers
+        // and triggers the listener which makes access decisions.
+        let info1 = AgentBuilder {
+            agent: Some(AGENT_1),
+            url: Some(Some(url.clone())),
+            ..Default::default()
+        }
+        .build(TestLocalAgent::default());
+        let info2 = AgentBuilder {
+            agent: Some(AGENT_2),
+            url: Some(Some(url.clone())),
+            ..Default::default()
+        }
+        .build(TestLocalAgent::default());
+        peer_store.insert(vec![info1, info2]).await.unwrap();
+
+        // Allow async listener tasks to complete.
+        tokio::task::yield_now().await;
+
+        // Both agents present, neither blocked → Granted.
+        let decision = access_state.get_access_decision(url.clone()).unwrap();
+        assert_eq!(
+            decision.map(|d| d.decision),
+            Some(AccessDecision::Granted),
+            "expected Granted before any block"
+        );
+
+        // Block agent_1 and remove it from the peer store (as the Host must).
+        blocks.block(BlockTarget::Agent(AGENT_1)).await.unwrap();
+        peer_store.remove(AGENT_1).await.unwrap();
+
+        // Allow async listener tasks to complete.
+        tokio::task::yield_now().await;
+
+        // agent_1 is now blocked; even though agent_2 (non-blocked) is still
+        // at the same URL, the URL must be Blocked.
+        let decision = access_state.get_access_decision(url.clone()).unwrap();
+        assert_eq!(
+            decision.map(|d| d.decision),
+            Some(AccessDecision::Blocked),
+            "expected Blocked after agent_1 at the shared URL was blocked"
+        );
+    }
+
+    /// A URL with only non-blocked agents is Granted.
+    #[tokio::test]
+    async fn url_with_no_blocked_agents_stays_granted() {
+        let url = make_url("clean");
+        let blocks = Arc::new(MemBlocks::default());
+        let known_peers = Arc::new(CoreKnownPeers::default());
+        let peer_store = make_peer_store(blocks.clone(), known_peers.clone());
+
+        let access_state = CorePeerAccessState::new(
+            known_peers.clone(),
+            blocks.clone(),
+            &peer_store,
+        )
+        .unwrap();
+
+        let info = AgentBuilder {
+            agent: Some(AGENT_1),
+            url: Some(Some(url.clone())),
+            ..Default::default()
+        }
+        .build(TestLocalAgent::default());
+        peer_store.insert(vec![info]).await.unwrap();
+        tokio::task::yield_now().await;
+
+        let decision = access_state.get_access_decision(url.clone()).unwrap();
+        assert_eq!(decision.map(|d| d.decision), Some(AccessDecision::Granted));
     }
 }

--- a/crates/core/src/factories/core_bootstrap/test.rs
+++ b/crates/core/src/factories/core_bootstrap/test.rs
@@ -96,9 +96,15 @@ impl Test {
             .await
             .unwrap();
 
+        let known_peers = builder
+            .known_peers
+            .create(builder.clone(), S1.clone())
+            .await
+            .unwrap();
+
         let peer_store = builder
             .peer_store
-            .create(builder.clone(), S1.clone(), blocks)
+            .create(builder.clone(), S1.clone(), blocks, known_peers)
             .await
             .unwrap();
 

--- a/crates/core/src/factories/core_gossip/test.rs
+++ b/crates/core/src/factories/core_gossip/test.rs
@@ -47,6 +47,11 @@ async fn create_gossip_instance() {
                         .create(builder.clone(), space_id.clone())
                         .await
                         .unwrap(),
+                    builder
+                        .known_peers
+                        .create(builder.clone(), space_id.clone())
+                        .await
+                        .unwrap(),
                 )
                 .await
                 .unwrap(),

--- a/crates/core/src/factories/core_known_peers.rs
+++ b/crates/core/src/factories/core_known_peers.rs
@@ -1,0 +1,93 @@
+//! The core known-peers index implementation.
+
+use kitsune2_api::*;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+/// The core known-peers factory.
+///
+/// This stores agent ID → URL mappings in memory.  Entries are never
+/// removed – the whole point of this store is to retain the URL → agent
+/// mapping even after an agent has been blocked and removed from the
+/// peer store.
+#[derive(Debug)]
+pub struct CoreKnownPeersFactory {}
+
+impl CoreKnownPeersFactory {
+    /// Construct a new `CoreKnownPeersFactory`.
+    pub fn create() -> DynKnownPeersFactory {
+        let out: DynKnownPeersFactory = Arc::new(Self {});
+        out
+    }
+}
+
+impl KnownPeersFactory for CoreKnownPeersFactory {
+    fn default_config(&self, _config: &mut Config) -> K2Result<()> {
+        Ok(())
+    }
+
+    fn validate_config(&self, _config: &Config) -> K2Result<()> {
+        Ok(())
+    }
+
+    fn create(
+        &self,
+        _builder: Arc<Builder>,
+        _space_id: SpaceId,
+    ) -> BoxFut<'static, K2Result<DynKnownPeers>> {
+        Box::pin(async move {
+            let out: DynKnownPeers = Arc::new(CoreKnownPeers::default());
+            Ok(out)
+        })
+    }
+}
+
+/// The core implementation of the [`KnownPeers`] trait.
+#[derive(Default)]
+pub struct CoreKnownPeers(Mutex<Inner>);
+
+impl std::fmt::Debug for CoreKnownPeers {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CoreKnownPeers").finish()
+    }
+}
+
+impl KnownPeers for CoreKnownPeers {
+    fn record(
+        &self,
+        agent_infos: Vec<Arc<AgentInfoSigned>>,
+    ) -> BoxFut<'_, K2Result<()>> {
+        Box::pin(async move {
+            self.0.lock().await.record(agent_infos);
+            Ok(())
+        })
+    }
+
+    fn get_by_url(&self, url: Url) -> BoxFut<'_, K2Result<Vec<AgentId>>> {
+        Box::pin(async move { Ok(self.0.lock().await.get_by_url(&url)) })
+    }
+}
+
+#[derive(Default)]
+struct Inner {
+    /// Agent ID → most recently seen URL for that agent.
+    store: HashMap<AgentId, Option<Url>>,
+}
+
+impl Inner {
+    fn record(&mut self, agent_infos: Vec<Arc<AgentInfoSigned>>) {
+        for agent_info in agent_infos {
+            self.store
+                .insert(agent_info.agent.clone(), agent_info.url.clone());
+        }
+    }
+
+    fn get_by_url(&self, url: &Url) -> Vec<AgentId> {
+        self.store
+            .iter()
+            .filter(|(_, stored_url)| stored_url.as_ref() == Some(url))
+            .map(|(agent_id, _)| agent_id.clone())
+            .collect()
+    }
+}

--- a/crates/core/src/factories/core_publish/test.rs
+++ b/crates/core/src/factories/core_publish/test.rs
@@ -403,9 +403,14 @@ async fn create_publish(
         .create(builder.clone(), TEST_SPACE_ID)
         .await
         .unwrap();
+    let known_peers = builder
+        .known_peers
+        .create(builder.clone(), TEST_SPACE_ID)
+        .await
+        .unwrap();
     let peer_store = builder
         .peer_store
-        .create(builder.clone(), TEST_SPACE_ID, blocks)
+        .create(builder.clone(), TEST_SPACE_ID, blocks, known_peers)
         .await
         .unwrap();
     let publish = CorePublish::new(

--- a/crates/core/src/factories/core_space.rs
+++ b/crates/core/src/factories/core_space.rs
@@ -106,14 +106,24 @@ impl SpaceFactory for CoreSpaceFactory {
                 .blocks
                 .create(builder.clone(), space_id.clone())
                 .await?;
+            let known_peers = builder
+                .known_peers
+                .create(builder.clone(), space_id.clone())
+                .await?;
             let peer_store = builder
                 .peer_store
-                .create(builder.clone(), space_id.clone(), blocks.clone())
+                .create(
+                    builder.clone(),
+                    space_id.clone(),
+                    blocks.clone(),
+                    known_peers.clone(),
+                )
                 .await?;
 
             let peer_access_state = Arc::new(CorePeerAccessState::new(
-                peer_store.clone(),
+                known_peers.clone(),
                 blocks.clone(),
+                &peer_store,
             )?);
 
             let bootstrap = builder
@@ -188,6 +198,7 @@ impl SpaceFactory for CoreSpaceFactory {
                     publish,
                     gossip,
                     blocks,
+                    known_peers,
                     peer_access_state,
                 )
             });
@@ -321,6 +332,7 @@ struct CoreSpace {
     publish: DynPublish,
     gossip: DynGossip,
     blocks: DynBlocks,
+    known_peers: DynKnownPeers,
     peer_access_state: DynPeerAccessState,
     inner: Arc<RwLock<InnerData>>,
     task_check_agent_infos: tokio::task::JoinHandle<()>,
@@ -358,6 +370,7 @@ impl CoreSpace {
         publish: DynPublish,
         gossip: DynGossip,
         blocks: DynBlocks,
+        known_peers: DynKnownPeers,
         peer_access_state: DynPeerAccessState,
     ) -> Self {
         let task_check_agent_infos = tokio::task::spawn(check_agent_infos(
@@ -380,6 +393,7 @@ impl CoreSpace {
             publish,
             gossip,
             blocks,
+            known_peers,
         }
     }
 
@@ -428,6 +442,10 @@ impl Space for CoreSpace {
 
     fn blocks(&self) -> &DynBlocks {
         &self.blocks
+    }
+
+    fn known_peers(&self) -> &DynKnownPeers {
+        &self.known_peers
     }
 
     fn current_url(&self) -> Option<Url> {

--- a/crates/core/src/factories/mem_bootstrap/test.rs
+++ b/crates/core/src/factories/mem_bootstrap/test.rs
@@ -53,9 +53,15 @@ impl Test {
             .await
             .unwrap();
 
+        let known_peers = builder
+            .known_peers
+            .create(builder.clone(), space_id.clone())
+            .await
+            .unwrap();
+
         let peer_store = builder
             .peer_store
-            .create(builder.clone(), space_id.clone(), blocks)
+            .create(builder.clone(), space_id.clone(), blocks, known_peers)
             .await
             .unwrap();
 

--- a/crates/core/src/factories/mem_peer_store.rs
+++ b/crates/core/src/factories/mem_peer_store.rs
@@ -82,18 +82,23 @@ impl PeerStoreFactory for MemPeerStoreFactory {
         builder: Arc<Builder>,
         _space_id: SpaceId,
         blocks: DynBlocks,
+        known_peers: DynKnownPeers,
     ) -> BoxFut<'static, K2Result<DynPeerStore>> {
         Box::pin(async move {
             let config: MemPeerStoreModConfig =
                 builder.config.get_module_config()?;
-            let out: DynPeerStore =
-                Arc::new(MemPeerStore::new(config.mem_peer_store, blocks));
+            let out: DynPeerStore = Arc::new(MemPeerStore::new(
+                config.mem_peer_store,
+                blocks,
+                known_peers,
+            ));
             Ok(out)
         })
     }
 }
 
-struct MemPeerStore(Mutex<Inner>);
+/// A production-ready memory-based peer store.
+pub struct MemPeerStore(Mutex<Inner>);
 
 impl std::fmt::Debug for MemPeerStore {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -102,11 +107,17 @@ impl std::fmt::Debug for MemPeerStore {
 }
 
 impl MemPeerStore {
-    pub fn new(config: MemPeerStoreConfig, blocks: DynBlocks) -> Self {
+    /// Construct a new MemPeerStore.
+    pub fn new(
+        config: MemPeerStoreConfig,
+        blocks: DynBlocks,
+        known_peers: DynKnownPeers,
+    ) -> Self {
         Self(Mutex::new(Inner::new(
             config,
             std::time::Instant::now(),
             blocks,
+            known_peers,
         )))
     }
 }
@@ -213,6 +224,7 @@ struct Inner {
     no_prune_until: std::time::Instant,
     listeners: Vec<Listener>,
     blocks: DynBlocks,
+    known_peers: DynKnownPeers,
 }
 
 impl Inner {
@@ -220,6 +232,7 @@ impl Inner {
         config: MemPeerStoreConfig,
         now_inst: std::time::Instant,
         blocks: DynBlocks,
+        known_peers: DynKnownPeers,
     ) -> Self {
         let no_prune_until = now_inst + config.prune_interval();
         Self {
@@ -228,6 +241,7 @@ impl Inner {
             no_prune_until,
             listeners: Vec::new(),
             blocks,
+            known_peers,
         }
     }
 
@@ -262,6 +276,11 @@ impl Inner {
         agent_list: Vec<Arc<AgentInfoSigned>>,
     ) -> K2Result<Vec<Arc<AgentInfoSigned>>> {
         self.check_prune();
+
+        // Record all agent infos to the known-peers index *before* any block
+        // or expiry filtering so that the access control layer can still
+        // resolve URLs even for blocked agents.
+        self.known_peers.record(agent_list.clone()).await?;
 
         let now = Timestamp::now();
 

--- a/crates/core/src/factories/mem_peer_store/test.rs
+++ b/crates/core/src/factories/mem_peer_store/test.rs
@@ -1,4 +1,4 @@
-use crate::factories::MemBlocks;
+use crate::factories::{CoreKnownPeers, MemBlocks};
 
 use super::*;
 use kitsune2_test_utils::agent::*;
@@ -11,6 +11,7 @@ fn create() -> Inner {
         },
         std::time::Instant::now(),
         Arc::new(MemBlocks::default()),
+        Arc::new(CoreKnownPeers::default()),
     )
 }
 
@@ -269,6 +270,7 @@ async fn try_insert_blocked_agent() {
         },
         std::time::Instant::now(),
         blocks.clone(),
+        Arc::new(CoreKnownPeers::default()),
     );
 
     blocks.block(BlockTarget::Agent(AGENT_1)).await.unwrap();
@@ -297,6 +299,7 @@ async fn try_insert_multiple_agents_when_one_is_blocked() {
         },
         std::time::Instant::now(),
         blocks.clone(),
+        Arc::new(CoreKnownPeers::default()),
     );
 
     blocks.block(BlockTarget::Agent(AGENT_1)).await.unwrap();
@@ -333,6 +336,7 @@ async fn remove_blocked_agent() {
         },
         std::time::Instant::now(),
         blocks.clone(),
+        Arc::new(CoreKnownPeers::default()),
     );
 
     mem_store

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -153,6 +153,7 @@ impl LocalAgent for Ed25519LocalAgent {
 /// - `local_agent_store` - The default local agent store is [factories::CoreLocalAgentStoreFactory].
 /// - `publish` - The default publish module is [factories::CorePublishFactory].
 /// - `blocks` - The default blocks module is [factories::MemBlocksFactory].
+/// - `known_peers` - The default known-peers index is [factories::CoreKnownPeersFactory].
 pub fn default_test_builder() -> Builder {
     Builder {
         config: Config::default(),
@@ -172,6 +173,7 @@ pub fn default_test_builder() -> Builder {
         local_agent_store: factories::CoreLocalAgentStoreFactory::create(),
         publish: factories::CorePublishFactory::create(),
         blocks: factories::MemBlocksFactory::create(),
+        known_peers: factories::CoreKnownPeersFactory::create(),
     }
 }
 

--- a/crates/gossip/src/initiate.rs
+++ b/crates/gossip/src/initiate.rs
@@ -317,11 +317,16 @@ mod tests {
                 .create(builder.clone(), TEST_SPACE_ID)
                 .await
                 .unwrap();
+            let known_peers = builder
+                .known_peers
+                .create(builder.clone(), TEST_SPACE_ID)
+                .await
+                .unwrap();
 
             Harness {
                 peer_store: builder
                     .peer_store
-                    .create(builder.clone(), TEST_SPACE_ID, blocks)
+                    .create(builder.clone(), TEST_SPACE_ID, blocks, known_peers)
                     .await
                     .unwrap(),
                 local_agent_store: builder

--- a/crates/gossip/src/respond/harness.rs
+++ b/crates/gossip/src/respond/harness.rs
@@ -69,6 +69,11 @@ impl RespondTestHarness {
             .create(builder.clone(), TEST_SPACE_ID)
             .await
             .unwrap();
+        let known_peers = builder
+            .known_peers
+            .create(builder.clone(), TEST_SPACE_ID)
+            .await
+            .unwrap();
 
         let config = Arc::new(config);
         Self {
@@ -80,7 +85,7 @@ impl RespondTestHarness {
                 space_id: TEST_SPACE_ID,
                 peer_store: builder
                     .peer_store
-                    .create(builder.clone(), TEST_SPACE_ID, blocks)
+                    .create(builder.clone(), TEST_SPACE_ID, blocks, known_peers)
                     .await
                     .unwrap(),
                 local_agent_store: builder

--- a/crates/kitsune2/src/lib.rs
+++ b/crates/kitsune2/src/lib.rs
@@ -70,5 +70,6 @@ pub fn default_builder() -> Builder {
         local_agent_store: factories::CoreLocalAgentStoreFactory::create(),
         publish: factories::CorePublishFactory::create(),
         blocks: factories::MemBlocksFactory::create(),
+        known_peers: factories::CoreKnownPeersFactory::create(),
     }
 }

--- a/crates/kitsune2/tests/blocks.rs
+++ b/crates/kitsune2/tests/blocks.rs
@@ -1044,14 +1044,12 @@ async fn incoming_notify_messages_from_blocked_peers_are_dropped() {
         }
     });
 
-    // Now have Bob close the connection so that we can verify later that
-    // resending a message from Alice succeeds after she joins with a new
-    // agent.
-    transport_bob.disconnect(peer_url_alice, None).await;
+    // Close the connection to get a clean slate before verifying that the
+    // URL remains blocked even when a non-blocked agent joins at it.
+    transport_bob.disconnect(peer_url_alice.clone(), None).await;
 
-    // Wait for Alice to disconnect as well. Otherwise, Alice may send the next
-    // message over the old WebRTC connection still that Bob has already
-    // closed on his end and Bob won't ever receive it.
+    // Wait for Alice to see the disconnect so the next send opens a fresh
+    // connection (with a new preflight carrying the new agent info).
     iter_check!(500, {
         if let Ok(peer_url) = peer_disconnect_recv_alice.try_recv()
             && peer_url == peer_url_bob
@@ -1060,39 +1058,30 @@ async fn incoming_notify_messages_from_blocked_peers_are_dropped() {
         }
     });
 
-    // To double-check, verify additionally that no space message has been
-    // handled by Bob.
+    // Double-check that no space message slipped through to Bob.
     assert!(
         recv_notify_recv_bob
             .recv_timeout(std::time::Duration::from_millis(50))
             .is_err()
     );
 
-    // Now have Alice join the space with a second agent which Bob should then
-    // receive via the preflight and consequently let further messages through
-    // again.
+    // Alice joins the space with a second (non-blocked) agent. Bob will
+    // learn about it via the preflight on the next connection, but the URL
+    // must remain blocked because the original blocked agent is still in
+    // KnownPeers. See https://github.com/holochain/kitsune2/issues/450
     let alice_local_agent_2 = Arc::new(Ed25519LocalAgent::default());
     space_alice
         .local_agent_join(alice_local_agent_2.clone())
         .await
         .unwrap();
 
-    // TODO: This test needs to be fixed! If any agent at a peer url is blocked
-    // messages should keep being rejected. But currently, they are being let
-    // through again if there is at least one non-blocked agent communicating
-    // from the same peer url as well.
-    // See https://github.com/holochain/kitsune2/issues/450
-    let payload_unblocked = Bytes::from("Sending to unblocked");
-
-    // Sending too shortly after a disconnect can lead to a tx5 send error
-    // sporadically and would leave the test flaky. Therefore, we wrap the
-    // send into an iter_check in order to make sure it makes it through.
+    // Send another message from Alice — it should still be blocked by Bob.
     iter_check!(2_000, 500, {
         if transport_alice
             .send_space_notify(
                 peer_url_bob.clone(),
                 TEST_SPACE_ID,
-                payload_unblocked.clone(),
+                Bytes::from("Should still be blocked"),
             )
             .await
             .is_ok()
@@ -1101,11 +1090,24 @@ async fn incoming_notify_messages_from_blocked_peers_are_dropped() {
         }
     });
 
-    // Verify that the message is being received correctly by Bob
-    let payload_unblocked_received = recv_notify_recv_bob
-        .recv_timeout(std::time::Duration::from_secs(2))
-        .expect("timed out waiting for space message");
-    assert_eq!(payload_unblocked, payload_unblocked_received);
+    // Verify that Bob blocked this message too (incoming count increased).
+    iter_check!(500, {
+        let net_stats = transport_bob.dump_network_stats().await.unwrap();
+        if let Some(space_blocks) =
+            net_stats.blocked_message_counts.get(&peer_url_alice)
+            && let Some(c) = space_blocks.get(&TEST_SPACE_ID)
+            && c.incoming >= 2
+        {
+            break;
+        }
+    });
+
+    // Confirm that Bob did not receive the message.
+    assert!(
+        recv_notify_recv_bob
+            .recv_timeout(std::time::Duration::from_millis(200))
+            .is_err()
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -1202,14 +1204,12 @@ async fn incoming_module_messages_from_blocked_peers_are_dropped() {
         }
     });
 
-    // Now have Bob close the connection so that we can verify later that
-    // resending a message from Alice succeeds after she joins with a new
-    // agent.
-    transport_bob.disconnect(peer_url_alice, None).await;
+    // Close the connection to get a clean slate before verifying that the
+    // URL remains blocked even when a non-blocked agent joins at it.
+    transport_bob.disconnect(peer_url_alice.clone(), None).await;
 
-    // Wait for Alice to disconnect as well. Otherwise, Alice may send the next
-    // message over the old WebRTC connection still that Bob has already
-    // closed on his end and Bob won't ever receive it.
+    // Wait for Alice to see the disconnect so the next send opens a fresh
+    // connection (with a new preflight carrying the new agent info).
     iter_check!(500, {
         if let Ok(peer_url) = peer_disconnect_recv_alice.try_recv()
             && peer_url == peer_url_bob
@@ -1218,40 +1218,31 @@ async fn incoming_module_messages_from_blocked_peers_are_dropped() {
         }
     });
 
-    // To double-check, verify additionally that no module message has been
-    // handled by Bob.
+    // Double-check that no module message slipped through to Bob.
     assert!(
         recv_module_msg_recv_bob
             .recv_timeout(std::time::Duration::from_millis(50))
             .is_err()
     );
 
-    // Now have Alice join the space with a second agent which Bob should then
-    // receive via the preflight and consequently let further messages through
-    // again.
+    // Alice joins the space with a second (non-blocked) agent. Bob will
+    // learn about it via the preflight on the next connection, but the URL
+    // must remain blocked because the original blocked agent is still in
+    // KnownPeers. See https://github.com/holochain/kitsune2/issues/450
     let alice_local_agent_2 = Arc::new(Ed25519LocalAgent::default());
     space_alice
         .local_agent_join(alice_local_agent_2.clone())
         .await
         .unwrap();
 
-    // TODO: This test needs to be fixed! If any agent at a peer url is blocked
-    // messages should keep being rejected. But currently, they are being let
-    // through again if there is at least one non-blocked agent communicating
-    // from the same peer url as well.
-    // See https://github.com/holochain/kitsune2/issues/450
-    let payload_unblocked = Bytes::from("Sending to unblocked");
-
-    // Sending too shortly after a disconnect can lead to a tx5 send error
-    // sporadically and would leave the test flaky. Therefore, we wrap the
-    // send into an iter_check in order to make sure it makes it through.
+    // Send another module message from Alice — it should still be blocked.
     iter_check!(2_000, 500, {
         if transport_alice
             .send_module(
                 peer_url_bob.clone(),
                 TEST_SPACE_ID,
                 "test".into(),
-                payload_unblocked.clone(),
+                Bytes::from("Should still be blocked"),
             )
             .await
             .is_ok()
@@ -1260,10 +1251,24 @@ async fn incoming_module_messages_from_blocked_peers_are_dropped() {
         }
     });
 
-    let payload_unblocked_received = recv_module_msg_recv_bob
-        .recv_timeout(std::time::Duration::from_secs(2))
-        .expect("timed out waiting for module message");
-    assert_eq!(payload_unblocked, payload_unblocked_received);
+    // Verify that Bob blocked this message too (incoming count increased).
+    iter_check!(500, {
+        let net_stats = transport_bob.dump_network_stats().await.unwrap();
+        if let Some(space_blocks) =
+            net_stats.blocked_message_counts.get(&peer_url_alice)
+            && let Some(c) = space_blocks.get(&TEST_SPACE_ID)
+            && c.incoming >= 2
+        {
+            break;
+        }
+    });
+
+    // Confirm that Bob did not receive the message.
+    assert!(
+        recv_module_msg_recv_bob
+            .recv_timeout(std::time::Duration::from_millis(200))
+            .is_err()
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -1357,14 +1362,12 @@ async fn outgoing_notify_messages_to_blocked_peers_are_dropped() {
         }
     });
 
-    // Now have Bob close the connection so that we can verify later that
-    // resending a message from Alice succeeds after she joins with a new
-    // agent.
+    // Close the connection to get a clean slate before verifying that the
+    // URL remains blocked even when a non-blocked agent joins at it.
     transport_bob.disconnect(peer_url_alice.clone(), None).await;
 
-    // Wait for Alice to disconnect as well. Otherwise, Alice may send the next
-    // message over the old WebRTC connection still that Bob has already
-    // closed on his end and Bob won't ever receive it.
+    // Wait for Alice to see the disconnect so any subsequent send attempt
+    // starts from a clean connection state.
     iter_check!(500, {
         if let Ok(peer_url) = peer_disconnect_recv_alice.try_recv()
             && peer_url == peer_url_bob
@@ -1373,16 +1376,17 @@ async fn outgoing_notify_messages_to_blocked_peers_are_dropped() {
         }
     });
 
-    // To double-check, verify additionally that no space message has been
-    // handled by Bob in the meantime.
+    // Double-check that no space message slipped through to Bob.
     assert!(
         recv_notify_recv_bob
             .recv_timeout(std::time::Duration::from_millis(50))
             .is_err()
     );
 
-    // Now have Bob join the space with a second agent and insert it to Alice's
-    // peer store to simulate bootstrapping.
+    // Bob joins with a second (non-blocked) agent and Alice learns about it
+    // via peer store insertion (simulating bootstrapping). The URL must
+    // remain blocked because the original blocked agent is still in
+    // KnownPeers. See https://github.com/holochain/kitsune2/issues/450
     let agent_info_bob_2 =
         join_new_local_agent_and_wait_for_agent_info(space_bob).await;
 
@@ -1392,47 +1396,34 @@ async fn outgoing_notify_messages_to_blocked_peers_are_dropped() {
         .await
         .unwrap();
 
-    // TODO: This test needs to be fixed! If any agent at a peer url is blocked
-    // messages should keep being rejected. But currently, they are being let
-    // through again if there is at least one non-blocked agent communicating
-    // from the same peer url as well.
-    // See https://github.com/holochain/kitsune2/issues/450
-    let payload_unblocked = Bytes::from("Sending to unblocked");
+    // Alice tries to send again — her transport should still drop it.
+    transport_alice
+        .send_space_notify(
+            peer_url_bob.clone(),
+            TEST_SPACE_ID,
+            Bytes::from("Should still be blocked"),
+        )
+        .await
+        .unwrap();
 
-    // Sending too shortly after a disconnect can lead to a tx5 send error
-    // sporadically and would leave the test flaky. Therefore, we wrap the
-    // send into an iter_check in order to make sure it makes it through.
-    iter_check!(2_000, 500, {
-        if transport_alice
-            .send_space_notify(
-                peer_url_bob.clone(),
-                TEST_SPACE_ID,
-                payload_unblocked.clone(),
-            )
-            .await
-            .is_ok()
-        {
-            break;
-        }
-    });
-
-    // Verify that the message is being received correctly by Bob
-    let payload_unblocked_received = recv_notify_recv_bob
-        .recv_timeout(std::time::Duration::from_secs(2))
-        .expect("timed out waiting for space message");
-    assert_eq!(payload_unblocked, payload_unblocked_received);
-
-    // And that the message blocks count on Alice's side is still 1
+    // Verify that Alice's outgoing block count increased to 2.
     iter_check!(500, {
         let net_stats = transport_alice.dump_network_stats().await.unwrap();
         if let Some(space_blocks) =
             net_stats.blocked_message_counts.get(&peer_url_bob)
             && let Some(c) = space_blocks.get(&TEST_SPACE_ID)
-            && c.outgoing == 1
+            && c.outgoing == 2
         {
             break;
         }
     });
+
+    // Confirm that Bob did not receive the message.
+    assert!(
+        recv_notify_recv_bob
+            .recv_timeout(std::time::Duration::from_millis(200))
+            .is_err()
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -1528,14 +1519,12 @@ async fn outgoing_module_messages_to_blocked_peers_are_dropped() {
         }
     });
 
-    // Now have Bob close the connection so that we can verify later that
-    // re-sending a message from Alice succeeds after she joins with a new
-    // agent.
+    // Close the connection to get a clean slate before verifying that the
+    // URL remains blocked even when a non-blocked agent joins at it.
     transport_bob.disconnect(peer_url_alice, None).await;
 
-    // Wait for Alice to disconnect as well. Otherwise, Alice may send the next
-    // message over the old WebRTC connection still that Bob has already
-    // closed on his end and Bob won't ever receive it.
+    // Wait for Alice to see the disconnect so any subsequent send attempt
+    // starts from a clean connection state.
     iter_check!(500, {
         if let Ok(peer_url) = peer_disconnect_recv_alice.try_recv()
             && peer_url == peer_url_bob
@@ -1544,16 +1533,17 @@ async fn outgoing_module_messages_to_blocked_peers_are_dropped() {
         }
     });
 
-    // To double-check, verify additionally that no module message has been
-    // handled by Bob in the meantime.
+    // Double-check that no module message slipped through to Bob.
     assert!(
         recv_module_msg_recv_bob
             .recv_timeout(std::time::Duration::from_millis(50))
             .is_err()
     );
 
-    // Now have Bob join the space with a second agent and insert it to Alice's
-    // peer store to simulate bootstrapping.
+    // Bob joins with a second (non-blocked) agent and Alice learns about it
+    // via peer store insertion (simulating bootstrapping). The URL must
+    // remain blocked because the original blocked agent is still in
+    // KnownPeers. See https://github.com/holochain/kitsune2/issues/450
     let agent_info_bob_2 =
         join_new_local_agent_and_wait_for_agent_info(space_bob).await;
 
@@ -1563,48 +1553,35 @@ async fn outgoing_module_messages_to_blocked_peers_are_dropped() {
         .await
         .unwrap();
 
-    // TODO: This test needs to be fixed! If any agent at a peer url is blocked
-    // messages should keep being rejected. But currently, they are being let
-    // through again if there is at least one non-blocked agent communicating
-    // from the same peer url as well.
-    // See https://github.com/holochain/kitsune2/issues/450
-    let payload_unblocked = Bytes::from("Sending to unblocked");
+    // Alice tries to send again — her transport should still drop it.
+    transport_alice
+        .send_module(
+            peer_url_bob.clone(),
+            TEST_SPACE_ID,
+            "test".into(),
+            Bytes::from("Should still be blocked"),
+        )
+        .await
+        .unwrap();
 
-    // Sending too shortly after a disconnect can lead to a tx5 send error
-    // sporadically and would leave the test flaky. Therefore, we wrap the
-    // send into an iter_check in order to make sure it makes it through.
-    iter_check!(2_000, 500, {
-        if transport_alice
-            .send_module(
-                peer_url_bob.clone(),
-                TEST_SPACE_ID,
-                "test".into(),
-                payload_unblocked.clone(),
-            )
-            .await
-            .is_ok()
-        {
-            break;
-        }
-    });
-
-    // Verify that the message is being received correctly by Bob
-    let payload_unblocked_received = recv_module_msg_recv_bob
-        .recv_timeout(std::time::Duration::from_secs(2))
-        .expect("timed out waiting for module message");
-    assert_eq!(payload_unblocked, payload_unblocked_received);
-
-    // And that the message blocks count on Alice's side is still 1
+    // Verify that Alice's outgoing block count increased to 2.
     iter_check!(500, {
         let net_stats = transport_alice.dump_network_stats().await.unwrap();
         if let Some(space_blocks) =
             net_stats.blocked_message_counts.get(&peer_url_bob)
             && let Some(c) = space_blocks.get(&TEST_SPACE_ID)
-            && c.outgoing == 1
+            && c.outgoing == 2
         {
             break;
         }
     });
+
+    // Confirm that Bob did not receive the message.
+    assert!(
+        recv_module_msg_recv_bob
+            .recv_timeout(std::time::Duration::from_millis(200))
+            .is_err()
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
Closes #450

## Problem

The blocking implementation had a fundamental design contradiction:

- Blocked agents are excluded from the `PeerStore` (not inserted; removed on block) to prevent gossip with them
- `CorePeerAccessState` used `PeerStore::get_by_url` to map peer URLs → agent IDs in order to decide whether to block incoming connections

These assumptions are mutually incompatible. When a blocked agent is removed from the peer store, the URL lookup can no longer find them. If a non-blocked agent shares the same peer URL, the lookup finds the non-blocked agent, sees no block, and incorrectly grants access — allowing the blocked agent's traffic through.

**Net result:** blocking only worked when *all* agents at a peer URL were blocked, not when *any* were.

## Solution

Introduce a new `KnownPeers` trait in the `api` crate: an append-only index of all ever-seen agent infos, including blocked ones, used purely for URL → agent ID resolution by the access control layer.

- `KnownPeers::record` — records agent infos without any block filtering
- `KnownPeers::get_by_url` — returns all known agents at a URL regardless of block status

`CorePeerAccessState` now uses `DynKnownPeers` for URL lookups instead of `DynPeerStore`. Agent infos are recorded into `KnownPeers` before the block filter runs, so blocked agents remain findable for access control purposes even after being removed from the peer store.

A new integration test verifies the fixed behaviour: a blocked agent sharing a peer URL with a non-blocked agent is correctly blocked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a known-peers index for independent URL-to-agent-ID resolution that persists even when peers are blocked or filtered from the peer store, enabling more robust peer discovery and access control decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->