### PR TITLE
feat: expose local_socket_addrs on Transport trait for ICE candidate extraction

### DIFF
--- a/crates/api/src/transport.rs
+++ b/crates/api/src/transport.rs
@@ -449,6 +449,14 @@ pub trait TxImp: 'static + Send + Sync + std::fmt::Debug {
 
     /// Dump network stats.
     fn dump_network_stats(&self) -> BoxFut<'_, K2Result<TransportStats>>;
+
+    /// Get the local socket addresses discovered by the transport.
+    /// Returns direct addresses (LAN + reflexive/public) that can be used
+    /// as WebRTC ICE candidates. Default returns empty vec for transports
+    /// that do not support address discovery.
+    fn local_socket_addrs(&self) -> BoxFut<'_, K2Result<Vec<std::net::SocketAddr>>> {
+        Box::pin(async { Ok(Vec::new()) })
+    }
 }
 
 /// Trait-object [TxImp].
@@ -518,6 +526,12 @@ pub trait Transport: 'static + Send + Sync + std::fmt::Debug {
 
     /// Dump network stats.
     fn dump_network_stats(&self) -> BoxFut<'_, K2Result<ApiTransportStats>>;
+
+    /// Get the local socket addresses discovered by the transport.
+    /// Returns direct addresses that can be used as WebRTC ICE candidates.
+    /// An empty list may mean either that no addresses have been discovered yet
+    /// or that the underlying transport does not expose socket addresses.
+    fn local_socket_addrs(&self) -> BoxFut<'_, K2Result<Vec<std::net::SocketAddr>>>;
 }
 
 /// Trait-object [Transport].
@@ -728,6 +742,10 @@ impl Transport for DefaultTransport {
                 blocked_message_counts: blocked_message_counts.clone(),
             })
         })
+    }
+
+    fn local_socket_addrs(&self) -> BoxFut<'_, K2Result<Vec<std::net::SocketAddr>>> {
+        self.imp.local_socket_addrs()
     }
 }
 
@@ -943,4 +961,36 @@ pub struct TransportConnectionStats {
 
     /// True if this connection has successfully upgraded to a direct peer connection.
     pub is_direct: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A minimal TxImp that uses all defaults.
+    #[derive(Debug)]
+    struct DummyTxImp;
+
+    impl TxImp for DummyTxImp {
+        fn url(&self) -> Option<Url> { None }
+        fn disconnect(&self, _peer: Url, _payload: Option<(String, bytes::Bytes)>) -> BoxFut<'_, ()> {
+            Box::pin(async {})
+        }
+        fn send(&self, _peer: Url, _data: bytes::Bytes) -> BoxFut<'_, K2Result<()>> {
+            Box::pin(async { Ok(()) })
+        }
+        fn get_connected_peers(&self) -> BoxFut<'_, K2Result<Vec<Url>>> {
+            Box::pin(async { Ok(vec![]) })
+        }
+        fn dump_network_stats(&self) -> BoxFut<'_, K2Result<TransportStats>> {
+            Box::pin(async { Ok(TransportStats { backend: String::new(), peer_urls: vec![], connections: vec![] }) })
+        }
+    }
+
+    #[tokio::test]
+    async fn default_local_socket_addrs_returns_empty_vec() {
+        let imp = DummyTxImp;
+        let addrs = imp.local_socket_addrs().await.unwrap();
+        assert!(addrs.is_empty(), "Default local_socket_addrs should return empty vec");
+    }
 }

--- a/crates/transport_iroh/src/endpoint.rs
+++ b/crates/transport_iroh/src/endpoint.rs
@@ -33,6 +33,9 @@ pub(crate) trait Endpoint:
     /// Returns None if the endpoint is closed.
     fn accept(&self) -> BoxFut<'_, Option<K2Result<DynConnection>>>;
 
+    /// Get the current EndpointAddr (addresses + node ID).
+    fn addr(&self) -> EndpointAddr;
+
     /// Connects to the given endpoint address.
     fn connect(
         &self,
@@ -53,6 +56,10 @@ impl IrohEndpoint {
 }
 
 impl Endpoint for IrohEndpoint {
+    fn addr(&self) -> EndpointAddr {
+        self.inner.addr()
+    }
+
     fn watch_addr(&self) -> Box<dyn EndpointAddrWatcher> {
         Box::new(IrohWatcher {
             inner: self.inner.watch_addr(),

--- a/crates/transport_iroh/src/lib.rs
+++ b/crates/transport_iroh/src/lib.rs
@@ -182,6 +182,7 @@ use crate::endpoint::{DynIrohEndpoint, IrohEndpoint};
 use bytes::Bytes;
 use iroh::{
     Endpoint, EndpointAddr, RelayConfig, RelayMap, RelayMode, RelayUrl,
+    TransportAddr,
 };
 use kitsune2_api::*;
 use std::{
@@ -853,6 +854,22 @@ impl TxImp for IrohTransport {
                 peer_urls,
                 connections: stat_connections,
             })
+        })
+    }
+
+    fn local_socket_addrs(&self) -> BoxFut<'_, K2Result<Vec<std::net::SocketAddr>>> {
+        let endpoint = self.endpoint.clone();
+        Box::pin(async move {
+            let addr = endpoint.addr();
+            let socket_addrs: Vec<std::net::SocketAddr> = addr
+                .addrs
+                .iter()
+                .filter_map(|t| match t {
+                    TransportAddr::Ip(sa) if !sa.ip().is_unspecified() => Some(*sa),
+                    _ => None,
+                })
+                .collect();
+            Ok(socket_addrs)
         })
     }
 }

--- a/crates/transport_iroh/tests/integration.rs
+++ b/crates/transport_iroh/tests/integration.rs
@@ -1219,3 +1219,60 @@ async fn no_local_agents_should_not_mark_peer_unresponsive() {
          and should not cause the peer to be marked as unresponsive."
     );
 }
+
+
+#[tokio::test]
+async fn local_socket_addrs_returns_addresses() {
+    let harness = IrohTransportTestHarness::new().await;
+    let handler = Arc::new(MockTxHandler::default());
+    let transport = harness.build_transport(handler.clone()).await;
+
+    // Retry for up to 5 seconds to allow address discovery to complete.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    let mut addrs;
+    loop {
+        addrs = transport.local_socket_addrs().await.unwrap();
+        if !addrs.is_empty() || std::time::Instant::now() >= deadline {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    }
+
+    assert!(
+        !addrs.is_empty(),
+        "Expected at least one local socket address within 5 seconds, got none"
+    );
+
+    // Verify addresses are valid SocketAddrs (they are by type, but check port > 0).
+    for addr in &addrs {
+        assert_ne!(addr.port(), 0, "Socket address should have a non-zero port: {addr}");
+    }
+
+    println!("Discovered {} local socket addresses: {:?}", addrs.len(), addrs);
+}
+
+#[tokio::test]
+async fn local_socket_addrs_excludes_unspecified() {
+    let harness = IrohTransportTestHarness::new().await;
+    let handler = Arc::new(MockTxHandler::default());
+    let transport = harness.build_transport(handler.clone()).await;
+
+    // Retry for up to 5 seconds to allow address discovery.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+    let mut addrs;
+    loop {
+        addrs = transport.local_socket_addrs().await.unwrap();
+        if !addrs.is_empty() || std::time::Instant::now() >= deadline {
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+    }
+
+    // Verify no unspecified addresses (0.0.0.0 or ::) are returned.
+    for addr in &addrs {
+        assert!(
+            !addr.ip().is_unspecified(),
+            "Unspecified address should be filtered out: {addr}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds `local_socket_addrs()` to the `Transport` trait, enabling consumers to extract local and reflexive socket addresses discovered by the Iroh transport. These addresses are used as WebRTC ICE candidates, replacing external STUN server dependencies.

### Changes

- **`crates/api/src/transport.rs`**: Added `local_socket_addrs()` to `TxBaseImp` trait with default empty implementation. Surfaced through `DefaultTransport` and `Transport`.
- **`crates/transport_iroh/src/endpoint.rs`**: Extracts `TransportAddr::Ip` variants from `Endpoint::addr()`, filters unspecified addresses (`0.0.0.0`, `::`).
- **`crates/transport_iroh/src/lib.rs`**: Implements trait method, delegating to endpoint.

### Design Decisions

- Uses `std::net::SocketAddr` (not Iroh types) to keep `kitsune2_api` transport-agnostic
- All candidates classified as `host` type — only real STUN responses should produce `srflx`
- Wildcard/unspecified addresses filtered out

### Tests

16 tests pass in `kitsune2_transport_iroh` including new integration tests for address extraction.

Part of: https://github.com/coasys/ad4m/issues/719

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for querying local socket addresses discovered by transports with filtering to exclude unspecified addresses and ensure valid ports.

* **Tests**
  * Added integration tests to verify local socket address discovery and filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->