### PR TITLE
feat: export iroh relay metrics via OpenTelemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -441,7 +441,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
- "bit-vec",
+ "bit-vec 0.8.0",
 ]
 
 [[package]]
@@ -449,6 +449,15 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
+name = "bit-vec"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71798fca2c1fe1086445a7258a4bc81e6e49dcd24c8d0dd9a1e57395b603f51"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bit_field"
@@ -544,9 +553,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -942,7 +951,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e0b1fab2ae45819af2d0731d60f2afe17227ebb1a1538a236da84c93e9a60162"
 dependencies = [
  "dispatch2",
- "nix 0.31.2",
+ "nix 0.31.3",
  "windows-sys 0.61.2",
 ]
 
@@ -980,7 +989,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest 0.11.2",
+ "digest 0.11.3",
  "fiat-crypto 0.3.0",
  "rand_core 0.10.1",
  "rustc_version",
@@ -1208,9 +1217,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
@@ -1287,7 +1296,7 @@ checksum = "c6e914c7c52decb085cea910552e24c63ac019e3ab8bf001ff736da9a9d9d890"
 dependencies = [
  "pkcs8 0.11.0-rc.10",
  "serde",
- "signature 3.0.0-rc.10",
+ "signature 3.0.0",
 ]
 
 [[package]]
@@ -1316,7 +1325,7 @@ dependencies = [
  "rand_core 0.10.1",
  "serde",
  "sha2 0.11.0-rc.5",
- "signature 3.0.0-rc.10",
+ "signature 3.0.0",
  "subtle",
  "zeroize",
 ]
@@ -1450,13 +1459,12 @@ checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "2d5b2eef6fafbf69f877e55509ce5b11a760690ac9700a2921be067aa6afaef6"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -1761,9 +1769,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1832,9 +1840,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heapless"
@@ -2007,9 +2015,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
@@ -2259,7 +2267,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -2301,16 +2309,6 @@ version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 dependencies = [
- "serde",
-]
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
  "serde",
 ]
 
@@ -2380,7 +2378,7 @@ dependencies = [
  "data-encoding",
  "data-encoding-macro",
  "derive_more",
- "digest 0.11.2",
+ "digest 0.11.3",
  "ed25519-dalek 3.0.0-pre.6",
  "getrandom 0.4.2",
  "n0-error",
@@ -2471,7 +2469,7 @@ dependencies = [
  "pin-project",
  "postcard",
  "rand 0.10.1",
- "rcgen 0.14.7",
+ "rcgen 0.14.8",
  "reloadable-state",
  "reqwest 0.13.3",
  "rustls",
@@ -2626,9 +2624,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2743,6 +2741,8 @@ dependencies = [
  "kitsune2_test_utils",
  "num_cpus",
  "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry_sdk",
  "rand 0.8.6",
  "rand_chacha 0.9.0",
  "rcgen 0.13.2",
@@ -2956,18 +2956,6 @@ checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
 dependencies = [
  "cfg-if",
  "windows-link",
-]
-
-[[package]]
-name = "libredox"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
-dependencies = [
- "bitflags",
- "libc",
- "plain",
- "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -3357,9 +3345,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -3369,9 +3357,9 @@ dependencies = [
 
 [[package]]
 name = "no_std_io2"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b51ed7824b6e07d354605f4abb3d9d300350701299da96642ee084f5ce631550"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
 dependencies = [
  "memchr",
 ]
@@ -3838,7 +3826,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -3897,18 +3885,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3952,12 +3940,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "plist"
@@ -4128,9 +4110,9 @@ dependencies = [
 
 [[package]]
 name = "prefix-trie"
-version = "0.8.2"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23370be78b7e5bcbb0cab4a02047eb040279a693c78daad04c2c5f1c24a83503"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
 dependencies = [
  "either",
  "ipnet",
@@ -4254,9 +4236,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.39.2"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
 ]
@@ -4453,21 +4435,21 @@ dependencies = [
  "ring",
  "rustls-pki-types",
  "time",
- "yasna",
+ "yasna 0.5.2",
 ]
 
 [[package]]
 name = "rcgen"
-version = "0.14.7"
+version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b99e0098aa4082912d4c649628623db6aba77335e4f4569ff5083a6448b32e"
+checksum = "57f6d249aad744e274e682777a50283a225a32705394ee6d5fcc01efa25e4055"
 dependencies = [
  "pem",
  "ring",
  "rustls-pki-types",
  "time",
  "x509-parser",
- "yasna",
+ "yasna 0.6.0",
 ]
 
 [[package]]
@@ -4475,15 +4457,6 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags",
 ]
@@ -5201,7 +5174,7 @@ checksum = "3b167252f3c126be0d8926639c4c4706950f01445900c4b3db0fd7e89fcb750a"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -5229,7 +5202,7 @@ checksum = "7c5f3b1e2dc8aad28310d8410bd4d7e180eca65fca176c52ab00d364475d0024"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest 0.11.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -5268,9 +5241,9 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "3.0.0-rc.10"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f1880df446116126965eeec169136b2e0251dba37c6223bcc819569550edea3"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
 
 [[package]]
 name = "simd-adler32"
@@ -5678,9 +5651,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -5716,9 +5689,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls-acme"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31fcc374ec87d754358a5d0709ed1ab7671d51e0f70ddc3b17a11ac36604cfa"
+checksum = "1af8573b15fdad8d66da116198cd8fd8d87ff62a67c1c6c3df7f62da1170793f"
 dependencies = [
  "async-trait",
  "base64",
@@ -5728,8 +5701,8 @@ dependencies = [
  "num-bigint",
  "pem",
  "proc-macro2",
- "rcgen 0.14.7",
- "reqwest 0.12.28",
+ "rcgen 0.14.8",
+ "reqwest 0.13.3",
  "ring",
  "rustls",
  "serde",
@@ -5916,20 +5889,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
  "http",
  "http-body",
- "iri-string",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -6433,9 +6406,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6446,9 +6419,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6456,9 +6429,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6466,9 +6439,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -6479,9 +6452,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -6535,9 +6508,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7168,6 +7141,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "yasna"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5f6765e852b9b4dc8e2a76843e4d64d1cea8e79bcde0b6901aea8e7c7f08282"
+dependencies = [
+ "bit-vec 0.9.1",
+ "time",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7212,9 +7195,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,8 +125,10 @@ schemars = { version = "0.9", features = ["preserve_order"] }
 rustyline = { version = "17.0" }
 # Used in showcase app for the commands
 strum = { version = "0.27.1", features = ["derive", "strum_macros"] }
-# Used for telemetry in sbd server
+# Used for telemetry in sbd server and bootstrap relay metrics
 opentelemetry = "0.30"
+opentelemetry_sdk = "0.30"
+opentelemetry-otlp = { version = "0.30", features = ["http-proto"] }
 # --- tool-dependencies ---
 # The following workspace dependencies are thus-far only used in unpublished
 # tools and so are not needed in any true dependency trees.
@@ -150,8 +152,6 @@ sbd-client = "0.3.2"
 # iroh relay for testing iroh transport
 iroh-relay = "0.98"
 iroh-base = "0.98"
-# used to test opentelemetry metrics
-opentelemetry_sdk = "0.30"
 
 # used to hash op data
 sha2 = "0.10.8"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,39 @@
 # kitsune2
 
 p2p / dht communication framework
+
+## Testing the bootstrap server metrics exporter
+
+Create a new file called `otel-config.yml`:
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+
+exporters:
+  debug:
+    verbosity: detailed
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      exporters: [debug]
+```
+
+Then start the metrics service with:
+
+```shell
+docker run --rm -p 4318:4318  -v "$PWD/otel-config.yaml:/etc/otelcol/config.yaml" otel/opentelemetry-collector:latest
+```
+
+The bootstrap server can then be configured to report metrics to the OTLP endpoint:
+
+```shell
+cargo run -- --listen 0.0.0.0:9000 --otlp-endpoint http://localhost:4318/v1/metrics
+```
+
+You will see metrics in the Docker log as they are reported.

--- a/crates/bootstrap_client/tests/integration.rs
+++ b/crates/bootstrap_client/tests/integration.rs
@@ -141,11 +141,12 @@ async fn auth_with_real_token_provider() {
 
     let mut config = Config::testing();
     let auth_hook_url = format!("http://{hook_addr:?}");
-    // Set auth on both config.auth (feature-independent) and config.sbd (for SBD websockets)
     config.auth.authentication_hook_server = Some(auth_hook_url.clone());
+
     // Note: sbd config still expects full URL with /authenticate path
     config.sbd.authentication_hook_server =
         Some(format!("{auth_hook_url}/authenticate"));
+
     config.allowed_origins = Some(vec!["http://localhost".into()]);
 
     let s =

--- a/crates/bootstrap_srv/Cargo.toml
+++ b/crates/bootstrap_srv/Cargo.toml
@@ -46,6 +46,8 @@ tracing-subscriber = { workspace = true, features = ["env-filter", "json"] }
 
 sbd-server = { workspace = true, features = ["tungstenite"], optional = true }
 opentelemetry = { workspace = true }
+opentelemetry_sdk = { workspace = true }
+opentelemetry-otlp = { workspace = true }
 # iroh relay server-related dependencies
 iroh = { workspace = true, optional = true }
 iroh-base = { workspace = true, optional = true }
@@ -60,11 +62,16 @@ rcgen = { workspace = true, optional = true }
 criterion = { workspace = true }
 iroh = { workspace = true, features = ["tls-aws-lc-rs", "test-utils"] }
 iroh-base = { workspace = true }
-iroh-relay = { workspace = true, features = ["tls-aws-lc-rs", "test-utils"] }
+iroh-relay = { workspace = true, features = [
+  "server",
+  "tls-aws-lc-rs",
+  "test-utils",
+] }
 kitsune2_test_utils = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }
 sbd-client = { workspace = true }
+opentelemetry_sdk = { workspace = true, features = ["testing"] }
 
 [[bench]]
 name = "iroh_relay_bench"

--- a/crates/bootstrap_srv/src/bin/kitsune2-bootstrap-srv.rs
+++ b/crates/bootstrap_srv/src/bin/kitsune2-bootstrap-srv.rs
@@ -181,6 +181,11 @@ fn main() {
         config.allowed_origins = Some(allowed_origins);
     }
 
+    // Setup opentelemetry metrics
+    let meter_provider =
+        metrics::enable_otlp_metrics(args.otlp_endpoint.as_deref())
+            .expect("Failed to initialize OTLP metrics");
+
     #[cfg(feature = "sbd")]
     {
         // Apply SBD command line arguments
@@ -199,13 +204,9 @@ fn main() {
         if let Some(byte_burst) = args.sbd_limit_ip_byte_burst {
             config.sbd.limit_ip_byte_burst = byte_burst;
         }
-        config.sbd.otlp_endpoint = args.otlp_endpoint;
+        config.sbd.otlp_endpoint = args.otlp_endpoint.clone();
         config.sbd.authentication_hook_server =
             args.authentication_hook_server.clone();
-
-        // Setup opentelemetry metrics
-        sbd_server::enable_otlp_metrics_if_configured(&config.sbd)
-            .expect("Failed to initialize OTLP metrics");
     }
 
     #[cfg(feature = "iroh-relay")]
@@ -215,7 +216,6 @@ fn main() {
         }
     }
 
-    // Set auth in the new feature-independent location
     config.auth.authentication_hook_server = args.authentication_hook_server;
 
     tracing::info!(?config);
@@ -237,6 +237,13 @@ fn main() {
 
     tracing::info!("Terminating...");
     drop(srv);
+
+    if let Some(ref provider) = meter_provider
+        && let Err(e) = provider.force_flush()
+    {
+        tracing::warn!("Failed to flush OTEL metrics on shutdown: {e}");
+    }
+
     tracing::info!("Exit Process.");
     std::process::exit(0);
 }

--- a/crates/bootstrap_srv/src/http.rs
+++ b/crates/bootstrap_srv/src/http.rs
@@ -302,6 +302,12 @@ fn tokio_thread(
                     None
                 };
 
+            // Declare outside the `if` block so the guard lives until the
+            // server futures complete.  Dropping it earlier would
+            // unregister the OTEL observable-counter callbacks.
+            #[cfg(feature = "iroh-relay")]
+            let mut _relay_otel_metrics = None;
+
             if !config.no_relay_server {
                 #[cfg(feature = "sbd")]
                 {
@@ -320,6 +326,13 @@ fn tokio_thread(
                         } else {
                             crate::iroh_relay_axum::create_relay_state()
                         };
+
+                    _relay_otel_metrics = Some({
+                        crate::iroh_relay_metrics::register(
+                            relay_state.metrics.clone(),
+                        )
+                    });
+
                     let relay_router = Router::new()
                         .route("/relay", routing::get(crate::iroh_relay_axum::relay_handler))
                         .route("/ping", routing::get(crate::iroh_relay_axum::relay_probe_handler))
@@ -575,7 +588,7 @@ async fn handle_boot_get(
     headers: axum::http::HeaderMap,
     extract::State(state): extract::State<AppState>,
 ) -> response::Response {
-    // Check authentication (feature-independent)
+    // Check authentication
     let token: Option<Arc<str>> = headers
         .get("Authorization")
         .and_then(|t| t.to_str().ok())
@@ -602,7 +615,7 @@ async fn handle_boot_put(
     extract::State(state): extract::State<AppState>,
     body: bytes::Bytes,
 ) -> response::Response<body::Body> {
-    // Check authentication (feature-independent)
+    // Check authentication
     let token: Option<Arc<str>> = headers
         .get("Authorization")
         .and_then(|t| t.to_str().ok())

--- a/crates/bootstrap_srv/src/iroh_relay_metrics.rs
+++ b/crates/bootstrap_srv/src/iroh_relay_metrics.rs
@@ -1,0 +1,104 @@
+//! Bridges iroh-relay metrics to OpenTelemetry.
+//!
+//! The iroh relay server tracks metrics using `iroh_metrics::Counter` atomics.
+//! This module registers OTEL observable counters whose callbacks read those
+//! atomics at export time, so the metrics flow into whatever OTLP backend is
+//! configured via `--otlp_endpoint`.
+
+use iroh_relay::server::Metrics;
+use opentelemetry::metrics::ObservableCounter;
+use std::sync::Arc;
+
+/// Holds the OTEL instrument handles returned by registration.
+///
+/// The observable counter callbacks remain active for as long as this struct
+/// is alive. Drop it to unregister the callbacks.
+#[must_use]
+pub struct RelayOtelMetrics {
+    _instruments: Vec<ObservableCounter<u64>>,
+}
+
+/// Register OTEL observable counters that bridge iroh-relay metrics.
+///
+/// Each counter reads the corresponding `iroh_metrics::Counter` atomic
+/// when the OTEL SDK triggers an export. When no OTLP endpoint is
+/// configured the meter is a no-op and the overhead is negligible.
+pub fn register(metrics: Arc<Metrics>) -> RelayOtelMetrics {
+    let meter = opentelemetry::global::meter("iroh-relay");
+
+    // A small helper to cut down on the per-metric boilerplate.
+    macro_rules! counter {
+        ($name:expr, $desc:expr, $field:ident) => {{
+            let m = metrics.clone();
+            meter
+                .u64_observable_counter($name)
+                .with_description($desc)
+                .with_callback(move |observer| {
+                    observer.observe(m.$field.get(), &[]);
+                })
+                .build()
+        }};
+        ($name:expr, $desc:expr, $unit:expr, $field:ident) => {{
+            let m = metrics.clone();
+            meter
+                .u64_observable_counter($name)
+                .with_description($desc)
+                .with_unit($unit)
+                .with_callback(move |observer| {
+                    observer.observe(m.$field.get(), &[]);
+                })
+                .build()
+        }};
+    }
+
+    let instruments = vec![
+        counter!(
+            "relay.bytes_sent",
+            "Total bytes sent through the relay",
+            "By",
+            bytes_sent
+        ),
+        counter!(
+            "relay.bytes_recv",
+            "Total bytes received by the relay",
+            "By",
+            bytes_recv
+        ),
+        counter!("relay.accepts", "Total relay connections accepted", accepts),
+        counter!(
+            "relay.disconnects",
+            "Total relay client disconnections",
+            disconnects
+        ),
+        counter!(
+            "relay.unique_client_keys",
+            "Total unique client keys seen",
+            unique_client_keys
+        ),
+        counter!(
+            "relay.send_packets_dropped",
+            "Total send packets dropped",
+            send_packets_dropped
+        ),
+        counter!(
+            "relay.other_packets_dropped",
+            "Total non-send packets dropped",
+            other_packets_dropped
+        ),
+        counter!(
+            "relay.bytes_rx_ratelimited",
+            "Total bytes rate-limited on receive",
+            "By",
+            bytes_rx_ratelimited_total
+        ),
+        counter!(
+            "relay.conns_rx_ratelimited",
+            "Total connections that had frames rate-limited",
+            conns_rx_ratelimited_total
+        ),
+    ];
+
+    RelayOtelMetrics {
+        _instruments: instruments,
+    }
+}

--- a/crates/bootstrap_srv/src/lib.rs
+++ b/crates/bootstrap_srv/src/lib.rs
@@ -217,6 +217,8 @@ pub use tls::*;
 mod auth;
 pub use auth::*;
 
+pub mod metrics;
+
 #[cfg(feature = "sbd")]
 mod sbd;
 
@@ -230,6 +232,9 @@ pub mod iroh_relay_axum;
 
 #[cfg(feature = "iroh-relay")]
 pub(crate) mod qad;
+
+#[cfg(feature = "iroh-relay")]
+pub mod iroh_relay_metrics;
 
 #[cfg(test)]
 mod test;

--- a/crates/bootstrap_srv/src/metrics.rs
+++ b/crates/bootstrap_srv/src/metrics.rs
@@ -1,0 +1,47 @@
+//! OpenTelemetry metrics initialization for the bootstrap server.
+//!
+//! Sets up the OTLP metric exporter and installs it as the global meter
+//! provider. This is feature-independent — both the SBD and iroh-relay
+//! backends use the same provider.
+
+use opentelemetry::global;
+use opentelemetry_otlp::WithExportConfig;
+
+/// Initialize the global OTEL meter provider with an OTLP HTTP exporter.
+///
+/// If `otlp_endpoint` is `None`, this is a no-op and all meters returned
+/// by `opentelemetry::global::meter()` will be silent.
+///
+/// Returns the [`opentelemetry_sdk::metrics::SdkMeterProvider`] when an
+/// endpoint is configured so the caller can flush pending metric batches
+/// during graceful shutdown.
+pub fn enable_otlp_metrics(
+    otlp_endpoint: Option<&str>,
+) -> std::io::Result<Option<opentelemetry_sdk::metrics::SdkMeterProvider>> {
+    let Some(endpoint) = otlp_endpoint else {
+        tracing::info!("OTLP metrics export not configured");
+        return Ok(None);
+    };
+
+    tracing::info!("Enabling OpenTelemetry metrics export");
+
+    let exporter = opentelemetry_otlp::MetricExporter::builder()
+        .with_http()
+        .with_protocol(opentelemetry_otlp::Protocol::HttpBinary)
+        .with_endpoint(endpoint)
+        .build()
+        .map_err(|e| {
+            std::io::Error::other(format!(
+                "failed to create OTLP exporter: {e}"
+            ))
+        })?;
+
+    let meter_provider =
+        opentelemetry_sdk::metrics::SdkMeterProvider::builder()
+            .with_periodic_exporter(exporter)
+            .build();
+
+    global::set_meter_provider(meter_provider.clone());
+
+    Ok(Some(meter_provider))
+}

--- a/crates/bootstrap_srv/tests/relay_metrics.rs
+++ b/crates/bootstrap_srv/tests/relay_metrics.rs
@@ -1,0 +1,143 @@
+//! Integration test: verify that relay traffic produces OTEL metrics
+//! through the production server wiring.
+//!
+//! Boots a real `BootstrapSrv` (which installs the relay metrics guard
+//! via the production `http.rs` code path), exchanges traffic between
+//! two iroh endpoints, then flushes an in-memory OTEL exporter and
+//! asserts that the expected metric names appear with values > 0.
+
+#![cfg(feature = "iroh-relay")]
+
+use iroh::endpoint::presets::Minimal;
+use iroh::{EndpointAddr, RelayConfig, RelayMap, RelayUrl};
+use iroh_base::SecretKey;
+use kitsune2_bootstrap_srv::{BootstrapSrv, Config};
+use opentelemetry_sdk::metrics::{
+    InMemoryMetricExporter, PeriodicReader, SdkMeterProvider,
+    data::{AggregatedMetrics, MetricData},
+};
+use std::collections::HashMap;
+use std::str::FromStr;
+use std::sync::Arc;
+
+const TEST_ALPN: &[u8] = b"relay-metrics-test";
+
+#[test]
+fn relay_metrics_exported_via_otel() {
+    // --- OTEL setup with in-memory exporter ---
+    // Install *before* BootstrapSrv::new so the production code path
+    // picks up this meter provider when it calls register().
+    let exporter = InMemoryMetricExporter::default();
+    let reader = PeriodicReader::builder(exporter.clone()).build();
+    let meter_provider =
+        SdkMeterProvider::builder().with_reader(reader).build();
+    opentelemetry::global::set_meter_provider(meter_provider.clone());
+
+    // --- Boot the real server ---
+    let s = BootstrapSrv::new(Config {
+        prune_interval: std::time::Duration::from_millis(5),
+        ..Config::testing()
+    })
+    .unwrap();
+    let addr = s.listen_addrs()[0];
+
+    // --- Connect two iroh endpoints and exchange a message ---
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_io()
+        .enable_time()
+        .build()
+        .unwrap();
+
+    rt.block_on(async {
+        let relay_url =
+            RelayUrl::from_str(&format!("http://{addr:?}")).unwrap();
+        let relay_map = RelayMap::empty();
+        relay_map.insert(
+            relay_url.clone(),
+            Arc::new(RelayConfig::new(relay_url.clone(), None)),
+        );
+
+        let ep_1 = iroh::Endpoint::builder(Minimal)
+            .relay_mode(iroh::RelayMode::Custom(relay_map.clone()))
+            .secret_key(SecretKey::generate())
+            .alpns(vec![TEST_ALPN.to_vec()])
+            .ca_roots_config(
+                iroh_relay::tls::CaRootsConfig::insecure_skip_verify(),
+            )
+            .bind()
+            .await
+            .unwrap();
+
+        let ep_2 = iroh::Endpoint::builder(Minimal)
+            .relay_mode(iroh::RelayMode::Custom(relay_map))
+            .secret_key(SecretKey::generate())
+            .alpns(vec![TEST_ALPN.to_vec()])
+            .ca_roots_config(
+                iroh_relay::tls::CaRootsConfig::insecure_skip_verify(),
+            )
+            .bind()
+            .await
+            .unwrap();
+
+        let ep_2_addr = EndpointAddr::new(ep_2.id()).with_relay_url(relay_url);
+
+        let message = b"hello";
+
+        let accept_task = tokio::spawn(async move {
+            let conn = ep_2.accept().await.unwrap().await.unwrap();
+            let mut recv = conn.accept_uni().await.unwrap();
+            let data = recv.read_to_end(1_000).await.unwrap();
+            conn.close(0u8.into(), b"");
+            ep_2.close().await;
+            data
+        });
+
+        let conn = ep_1.connect(ep_2_addr, TEST_ALPN).await.unwrap();
+        let mut send_stream = conn.open_uni().await.unwrap();
+        send_stream.write_all(message).await.unwrap();
+        send_stream.finish().unwrap();
+
+        assert_eq!(accept_task.await.unwrap(), message);
+        ep_1.close().await;
+    });
+
+    // --- Flush and inspect exported metrics ---
+    meter_provider.force_flush().unwrap();
+
+    let resource_metrics = exporter.get_finished_metrics().unwrap();
+
+    // Collect all metric names and their summed values.
+    let mut metric_values: HashMap<String, u64> = HashMap::new();
+    for rm in &resource_metrics {
+        for sm in rm.scope_metrics() {
+            for metric in sm.metrics() {
+                if let AggregatedMetrics::U64(data) = metric.data()
+                    && let MetricData::Sum(sum) = data
+                {
+                    let total: u64 =
+                        sum.data_points().map(|dp| dp.value()).sum();
+                    metric_values.insert(metric.name().to_string(), total);
+                }
+            }
+        }
+    }
+
+    // After connecting two endpoints and sending a message through the
+    // relay, these counters must have been incremented.
+    assert!(
+        *metric_values.get("relay.bytes_sent").unwrap_or(&0) > 0,
+        "expected relay.bytes_sent > 0, got {metric_values:?}"
+    );
+    assert!(
+        *metric_values.get("relay.bytes_recv").unwrap_or(&0) > 0,
+        "expected relay.bytes_recv > 0, got {metric_values:?}"
+    );
+    assert!(
+        *metric_values.get("relay.accepts").unwrap_or(&0) >= 2,
+        "expected relay.accepts >= 2, got {metric_values:?}"
+    );
+    assert!(
+        *metric_values.get("relay.unique_client_keys").unwrap_or(&0) >= 2,
+        "expected relay.unique_client_keys >= 2, got {metric_values:?}"
+    );
+}


### PR DESCRIPTION
I notice that we're actually very short on metrics for the bootstrap service. When metrics were first integrated here, it was really only for SBD. So we now expose the Iroh metrics using opentelemetry but we could do with following up to add more bootstrap metrics.

## Summary
- Bridge iroh-relay-holochain metrics to OTEL using observable counters: `bytes_sent`, `bytes_recv`, `accepts`, `disconnects`, `unique_client_keys`, `send_packets_dropped`, `other_packets_dropped`, `bytes_rx_ratelimited`, `conns_rx_ratelimited`
- Move OTEL meter provider initialization out of the `sbd` feature gate into a feature-independent `metrics` module, so `--otlp_endpoint` works with the iroh-relay backend
- Add integration test proving the full chain: relay handles real client traffic → iroh-metrics atomics increment → OTEL exporter captures non-zero values

## Test plan
- [x] `cargo make static` passes (both `iroh-relay` and `sbd` features)
- [x] Integration test `relay_metrics_exported_via_otel` passes
- [ ] Deploy with `--otlp_endpoint` and verify metrics appear in the collector