### PR TITLE
feat(bootstrap_srv): rate-limit inbound bytes on embedded iroh relay

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -980,12 +980,12 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "5.0.0-pre.6"
+version = "5.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335f1947f241137a14106b6f5acc5918a5ede29c9d71d3f2cb1678d5075d9fc3"
+checksum = "4f359e08ca85e7bd759e1fd933ff2bccd81864c60a8fba0e259c7f822b0924bf"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
  "digest 0.11.3",
  "fiat-crypto 0.3.0",
@@ -1314,11 +1314,11 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "3.0.0-pre.7"
+version = "3.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20449acd54b660981ae5caa2bcb56d1fe7f25f2e37a38ec507400fab034d4bb6"
+checksum = "b011170fe4f04665565b4110afef66774fe9ffff278f3eb5b81cc73d26e27d60"
 dependencies = [
- "curve25519-dalek 5.0.0-pre.6",
+ "curve25519-dalek 5.0.0-rc.0",
  "ed25519 3.0.0",
  "rand_core 0.10.1",
  "serde",
@@ -2282,9 +2282,9 @@ dependencies = [
 
 [[package]]
 name = "iroh"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef865dc2d11a19fe670ff217b68ffc3b511bddf473dc3a3e120090b9f691803"
+checksum = "6435544bb3a5c4e6ff7affaa0c0aa0d1bca45bd700226329d5059d3eb54f9dff"
 dependencies = [
  "axum",
  "backon",
@@ -2294,7 +2294,7 @@ dependencies = [
  "ctutils",
  "data-encoding",
  "derive_more",
- "ed25519-dalek 3.0.0-pre.7",
+ "ed25519-dalek 3.0.0-rc.0",
  "futures-util",
  "getrandom 0.4.2",
  "hickory-resolver",
@@ -2320,7 +2320,6 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
- "rustls-webpki",
  "serde",
  "smallvec",
  "strum",
@@ -2331,36 +2330,32 @@ dependencies = [
  "tracing",
  "url",
  "wasm-bindgen-futures",
- "webpki-roots",
 ]
 
 [[package]]
 name = "iroh-base"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af93d67701c00c504982154569192ad384738c0450ba1196930314b955100552"
+checksum = "c9c95e4459d9bb828a77084277abd308aa2b58a096652b079bddfd6ef2361f53"
 dependencies = [
- "curve25519-dalek 5.0.0-pre.6",
+ "curve25519-dalek 5.0.0-rc.0",
  "data-encoding",
  "data-encoding-macro",
  "derive_more",
- "digest 0.11.3",
- "ed25519-dalek 3.0.0-pre.7",
+ "ed25519-dalek 3.0.0-rc.0",
  "getrandom 0.4.2",
  "n0-error",
  "rand 0.10.1",
  "serde",
- "sha2 0.11.0",
  "url",
  "zeroize",
- "zeroize_derive",
 ]
 
 [[package]]
 name = "iroh-dns"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de4112c91eb64094d77df9d3112606dcf7ff216421afccd2dc762fda5a7b2879"
+checksum = "754f7e0c1f67938e1d671007264ffef158f14a9f795a7cc219ea68ea09a9d4c9"
 dependencies = [
  "arc-swap",
  "cfg_aliases",
@@ -2370,8 +2365,8 @@ dependencies = [
  "n0-error",
  "n0-future",
  "ndk-context",
+ "portable-atomic",
  "rand 0.10.1",
- "reqwest 0.13.3",
  "rustls",
  "simple-dns",
  "strum",
@@ -2382,9 +2377,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-metrics"
-version = "1.0.0-rc.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d102597d0ee523f17fdb672c532395e634dbe945429284c811430d63bacc0d8a"
+checksum = "291065721ad7c477b972e581bbc528df031dc8eb5e39fe1ff3300ae5dfb157ef"
 dependencies = [
  "http-body-util",
  "hyper",
@@ -2405,9 +2400,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-metrics-derive"
-version = "1.0.0-rc.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c8e0c97f1dc787107f388433c349397c565572fe6406d600ff7bb7b7fe3b30"
+checksum = "1ae5f0c4405d1fbc9fb16ff422ca40620e93dc36c30ecaba0c2aee3992b7bd48"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -2417,11 +2412,10 @@ dependencies = [
 
 [[package]]
 name = "iroh-relay"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a70030b9e71c1183bd4f88fbdbebfa1af2a5be549dd6f20a1e8ac3cd0202ee9d"
+checksum = "1c12e48fef252fd04f8e6b6a8802b377baf72548d62ae4838816624cd0e06b79"
 dependencies = [
- "ahash",
  "blake3",
  "bytes",
  "cfg_aliases",
@@ -3114,9 +3108,9 @@ checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "n0-error"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223e946a84aa91644507a6b7865cfebbb9a231ace499041c747ab0fd30408212"
+checksum = "c37e81176a83a77d2514528b91bdafc70ef88aab428f0e1b91aebb8d99888895"
 dependencies = [
  "n0-error-macros",
  "spez",
@@ -3124,9 +3118,9 @@ dependencies = [
 
 [[package]]
 name = "n0-error-macros"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "565305a21e6b3bf26640ad98f05a0fda12d3ab4315394566b52a7bddb8b34828"
+checksum = "e2acd8b070213b0299282f884b4beba4e7b52d624fdcd504a3ad3665390c11e1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3156,9 +3150,9 @@ dependencies = [
 
 [[package]]
 name = "n0-watcher"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928d8039a66cce5efcfd35e88b32d3defc8eba630b3ac451522997f563956a52"
+checksum = "bbc618745ad0b7414b149d0517ad8b5573b2fb4d4e2717add3d2446ce1fdd826"
 dependencies = [
  "derive_more",
  "n0-error",
@@ -3173,19 +3167,22 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "netdev"
-version = "0.43.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bacaf873ee4eab5646f99b381b271ec75e716902a67cf962c0f328c5eb5bfb"
+checksum = "9d31e7286c21ceaf0ddb1d881964011214555ea0b317cc2eb1a1d68d861386fc"
 dependencies = [
  "block2",
  "dispatch2",
  "dlopen2",
  "ipnet",
+ "jni 0.21.1",
  "libc",
  "mac-addr",
+ "ndk-context",
  "netlink-packet-core",
  "netlink-packet-route 0.29.0",
  "netlink-sys",
+ "objc2",
  "objc2-core-foundation",
  "objc2-core-wlan",
  "objc2-foundation",
@@ -3218,9 +3215,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8919612f6028ab4eacbbfe1234a9a43e3722c6e0915e7ff519066991905092"
+checksum = "e2288fcb784eb3defd5fb16f4c4160d5f477de192eac730f43e1d11c24d9a007"
 dependencies = [
  "bitflags",
  "libc",
@@ -3257,14 +3254,15 @@ dependencies = [
 
 [[package]]
 name = "netwatch"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2071e0c2b5b229622c459096b84f1ad51afa150cdeeefdad491ef3704e581d91"
+checksum = "8487d26d691cd98d5c17b2adb4b1fd4b31cccc820da1eac827d483295d7bb94a"
 dependencies = [
  "atomic-waker",
  "bytes",
  "cfg_aliases",
  "derive_more",
+ "ipnet",
  "js-sys",
  "libc",
  "n0-error",
@@ -3272,7 +3270,7 @@ dependencies = [
  "n0-watcher",
  "netdev",
  "netlink-packet-core",
- "netlink-packet-route 0.30.0",
+ "netlink-packet-route 0.31.0",
  "netlink-proto",
  "netlink-sys",
  "noq-udp",
@@ -3333,9 +3331,9 @@ dependencies = [
 
 [[package]]
 name = "noq"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198b99fc085a5db1f7d259edb5ede8311e59f28cdd2687920b4313613d21a73f"
+checksum = "11f0c73794bfde94db01379c46990b9a773993fca2b61a66184ce148b7c7a187"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -3355,9 +3353,9 @@ dependencies = [
 
 [[package]]
 name = "noq-proto"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ab0ac774795ce1e42a7e61266e71f3be8110210630441169ac8dda403dd23f1"
+checksum = "775be06b8d66c2c64db60140bf54dee8410f67b73c81cc1e1e32f11dfdaae501"
 dependencies = [
  "aes-gcm",
  "aws-lc-rs",
@@ -3384,9 +3382,9 @@ dependencies = [
 
 [[package]]
 name = "noq-udp"
-version = "1.0.0-rc.1"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3c1520eacd33fd6b009e2e70116b05508ade51db5e0d315ff8bf6b702148c2b"
+checksum = "cd5a37756f168cf350d68a97c4f0158bdf3c76f10175123941569b09ab51f011"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -4010,9 +4008,9 @@ dependencies = [
 
 [[package]]
 name = "portmapper"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64959cbabf952c8ffcbaea13745308508f1f825922f4068353f3de08d42cf214"
+checksum = "ccc716c56a0a50f7e4e25f41446419599d47c6197cc5c9858174220e97c272e6"
 dependencies = [
  "base64",
  "bytes",
@@ -7031,18 +7029,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ ctrlc = { version = "3.4.5", features = ["termination"] }
 # bootstrap_srv for signature verification.
 ed25519-dalek = "2.1.1"
 # alternative transport implementation using iroh
-iroh = "1.0.0-rc.1"
+iroh = "1.0.0"
 # automock traits for tests
 mockall = "0.14"
 # watchable stream of values used in iroh transport
@@ -150,11 +150,11 @@ kitsune2_test_utils = { version = "0.5.0-dev.0", path = "crates/test_utils" }
 # used to test the bootstrap server with SBD enabled
 sbd-client = "0.3.2"
 # iroh relay for testing iroh transport
-iroh-relay = "1.0.0-rc.1"
-iroh-base = "1.0.0-rc.1"
+iroh-relay = "1.0.0"
+iroh-base = "1.0.0"
 # DNS resolver split out of iroh-relay in the 1.0 release; used in tests
 # that drive a relay client.
-iroh-dns = "1.0.0-rc.1"
+iroh-dns = "1.0.0"
 
 # used to hash op data
 sha2 = "0.11"

--- a/crates/bootstrap_srv/benches/iroh_relay_bench.rs
+++ b/crates/bootstrap_srv/benches/iroh_relay_bench.rs
@@ -47,7 +47,7 @@ fn spawn_local_relay() -> RelayUrl {
     std::thread::spawn(move || {
         let rt = Runtime::new().unwrap();
         rt.block_on(async {
-            let state = create_relay_state();
+            let state = create_relay_state(None);
             let app = Router::new()
                 .route("/relay", get(relay_handler))
                 .with_state(state);

--- a/crates/bootstrap_srv/src/bin/kitsune2-bootstrap-srv.rs
+++ b/crates/bootstrap_srv/src/bin/kitsune2-bootstrap-srv.rs
@@ -120,6 +120,28 @@ pub struct Args {
     /// Default port is 7842 (iroh's default for QAD).
     #[arg(long)]
     pub quic_bind_addr: Option<std::net::SocketAddr>,
+
+    /// Sustained inbound byte rate per relay client connection (bytes/s).
+    ///
+    /// When set, the bootstrap server's embedded iroh relay handler will
+    /// pace inbound WebSocket frames per connection. Use together with
+    /// `--relay-client-rx-burst-bytes` to control burst allowance; if
+    /// burst is omitted it defaults to about one tenth of this value.
+    ///
+    /// Default: unlimited.
+    #[cfg(feature = "iroh-relay")]
+    #[arg(long)]
+    pub relay_client_rx_bytes_per_second: Option<std::num::NonZeroU32>,
+
+    /// Maximum allowed inbound burst per relay client connection (bytes).
+    ///
+    /// Has effect only when `--relay-client-rx-bytes-per-second` is also
+    /// set.
+    ///
+    /// Default: derived as bps/10 when the sustained rate is set.
+    #[cfg(feature = "iroh-relay")]
+    #[arg(long)]
+    pub relay_client_rx_burst_bytes: Option<std::num::NonZeroU32>,
 }
 
 fn main() {
@@ -213,6 +235,12 @@ fn main() {
     {
         if let Some(quic_bind_addr) = args.quic_bind_addr {
             config.quic_bind_addr = Some(quic_bind_addr);
+        }
+        if let Some(bps) = args.relay_client_rx_bytes_per_second {
+            config.relay_client_rx_bytes_per_second = Some(bps);
+        }
+        if let Some(burst) = args.relay_client_rx_burst_bytes {
+            config.relay_client_rx_burst_bytes = Some(burst);
         }
     }
 

--- a/crates/bootstrap_srv/src/config.rs
+++ b/crates/bootstrap_srv/src/config.rs
@@ -82,6 +82,27 @@ pub struct Config {
     #[cfg(feature = "iroh-relay")]
     pub quic_bind_addr: Option<std::net::SocketAddr>,
 
+    /// Sustained inbound byte rate per relay client connection, in bytes
+    /// per second.
+    ///
+    /// `None` disables the limiter entirely. Setting this without
+    /// [`Self::relay_client_rx_burst_bytes`] derives the burst as
+    /// `(bytes_per_second / 10).max(1)` to match iroh's own default.
+    ///
+    /// Default: `None` in both `testing()` and `production()`.
+    #[cfg(feature = "iroh-relay")]
+    pub relay_client_rx_bytes_per_second: Option<std::num::NonZeroU32>,
+
+    /// Maximum allowed inbound burst per relay client connection, in bytes.
+    ///
+    /// Has effect only when [`Self::relay_client_rx_bytes_per_second`] is
+    /// also `Some`. Setting this alone is rejected at `BootstrapSrv::new`
+    /// time.
+    ///
+    /// Default: `None` in both `testing()` and `production()`.
+    #[cfg(feature = "iroh-relay")]
+    pub relay_client_rx_burst_bytes: Option<std::num::NonZeroU32>,
+
     /// Disable the relay server.
     pub no_relay_server: bool,
 
@@ -115,6 +136,10 @@ impl Config {
             tls_key: None,
             #[cfg(feature = "iroh-relay")]
             quic_bind_addr: Some((std::net::Ipv4Addr::LOCALHOST, 0).into()),
+            #[cfg(feature = "iroh-relay")]
+            relay_client_rx_bytes_per_second: None,
+            #[cfg(feature = "iroh-relay")]
+            relay_client_rx_burst_bytes: None,
             no_relay_server: false,
             allowed_origins: None,
             auth: crate::auth::AuthConfig::default(),
@@ -140,11 +165,131 @@ impl Config {
             quic_bind_addr: Some(
                 (std::net::Ipv6Addr::UNSPECIFIED, 7842).into(),
             ),
+            #[cfg(feature = "iroh-relay")]
+            relay_client_rx_bytes_per_second: None,
+            #[cfg(feature = "iroh-relay")]
+            relay_client_rx_burst_bytes: None,
             no_relay_server: false,
             allowed_origins: None,
             auth: crate::auth::AuthConfig::default(),
             #[cfg(feature = "sbd")]
             sbd: sbd_server::Config::default(),
         }
+    }
+}
+
+#[cfg(feature = "iroh-relay")]
+impl Config {
+    /// Resolve the per-connection inbound byte rate limit from the two
+    /// `relay_client_rx_*` fields.
+    ///
+    /// Returns:
+    /// - `Ok(None)` when no limit is configured.
+    /// - `Ok(Some(_))` with the resolved [`crate::iroh_relay_axum::RelayClientRxRateLimit`]
+    ///   when a sustained rate is set; burst defaults to `(bps / 10).max(1)` if
+    ///   not set explicitly.
+    /// - `Err(_)` when only the burst is set but not the sustained rate.
+    pub fn resolve_relay_rate_limit(
+        &self,
+    ) -> Result<
+        Option<crate::iroh_relay_axum::RelayClientRxRateLimit>,
+        std::io::Error,
+    > {
+        match (
+            self.relay_client_rx_bytes_per_second,
+            self.relay_client_rx_burst_bytes,
+        ) {
+            (None, None) => Ok(None),
+            (None, Some(_)) => Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "relay_client_rx_burst_bytes is set but \
+                 relay_client_rx_bytes_per_second is not; both required \
+                 (burst alone has no meaning)",
+            )),
+            // The token bucket uses a 100ms refill window, so
+            // refill = bytes_per_second * 100 / 1000. Rates below 10 B/s
+            // produce refill = 0, which iroh's Bucket::new rejects with
+            // InvalidBucketConfig and would panic the connection task.
+            (Some(bps), _) if bps.get() < 10 => Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "relay_client_rx_bytes_per_second must be >= 10 \
+                 (the 100ms refill window requires at least 1 byte per tick)",
+            )),
+            (Some(bps), Some(burst)) => {
+                Ok(Some(crate::iroh_relay_axum::RelayClientRxRateLimit {
+                    bytes_per_second: bps,
+                    burst_bytes: burst,
+                }))
+            }
+            (Some(bps), None) => {
+                let derived = bps.get() / 10;
+                let burst = std::num::NonZeroU32::new(derived)
+                    .expect("bps >= 10 ensures derived burst >= 1");
+                Ok(Some(crate::iroh_relay_axum::RelayClientRxRateLimit {
+                    bytes_per_second: bps,
+                    burst_bytes: burst,
+                }))
+            }
+        }
+    }
+}
+
+#[cfg(all(test, feature = "iroh-relay"))]
+mod resolve_rate_limit_tests {
+    use super::*;
+    use std::num::NonZeroU32;
+
+    fn cfg() -> Config {
+        Config::testing()
+    }
+
+    #[test]
+    fn none_when_unset() {
+        let c = cfg();
+        assert!(c.resolve_relay_rate_limit().unwrap().is_none());
+    }
+
+    #[test]
+    fn err_when_only_burst_set() {
+        let mut c = cfg();
+        c.relay_client_rx_burst_bytes = NonZeroU32::new(1024);
+        assert!(c.resolve_relay_rate_limit().is_err());
+    }
+
+    #[test]
+    fn explicit_burst_used_as_is() {
+        let mut c = cfg();
+        c.relay_client_rx_bytes_per_second = NonZeroU32::new(1000);
+        c.relay_client_rx_burst_bytes = NonZeroU32::new(2048);
+        let r = c.resolve_relay_rate_limit().unwrap().unwrap();
+        assert_eq!(r.bytes_per_second.get(), 1000);
+        assert_eq!(r.burst_bytes.get(), 2048);
+    }
+
+    #[test]
+    fn burst_defaults_to_one_tenth_when_unset() {
+        let mut c = cfg();
+        c.relay_client_rx_bytes_per_second = NonZeroU32::new(1000);
+        let r = c.resolve_relay_rate_limit().unwrap().unwrap();
+        assert_eq!(r.bytes_per_second.get(), 1000);
+        assert_eq!(r.burst_bytes.get(), 100);
+    }
+
+    #[test]
+    fn err_for_rate_below_refill_window_minimum() {
+        let mut c = cfg();
+        c.relay_client_rx_bytes_per_second = NonZeroU32::new(1);
+        assert!(c.resolve_relay_rate_limit().is_err());
+
+        c.relay_client_rx_bytes_per_second = NonZeroU32::new(9);
+        assert!(c.resolve_relay_rate_limit().is_err());
+    }
+
+    #[test]
+    fn min_valid_rate_yields_burst_of_one() {
+        let mut c = cfg();
+        c.relay_client_rx_bytes_per_second = NonZeroU32::new(10);
+        let r = c.resolve_relay_rate_limit().unwrap().unwrap();
+        assert_eq!(r.burst_bytes.get(), 1);
     }
 }

--- a/crates/bootstrap_srv/src/http.rs
+++ b/crates/bootstrap_srv/src/http.rs
@@ -320,11 +320,22 @@ fn tokio_thread(
                         routing::put(handle_relay_register),
                     );
 
+                    let relay_rate_limit = config
+                        .resolve_relay_rate_limit()
+                        .expect(
+                            "Config rate-limit invariants validated by \
+                             BootstrapSrv::new",
+                        );
                     let relay_state =
                         if let Some(allowlist) = relay_allowlist.clone() {
-                            crate::iroh_relay_axum::create_relay_state_with_allowlist(allowlist)
+                            crate::iroh_relay_axum::create_relay_state_with_allowlist(
+                                allowlist,
+                                relay_rate_limit,
+                            )
                         } else {
-                            crate::iroh_relay_axum::create_relay_state()
+                            crate::iroh_relay_axum::create_relay_state(
+                                relay_rate_limit,
+                            )
                         };
 
                     _relay_otel_metrics = Some({

--- a/crates/bootstrap_srv/src/iroh_relay_axum.rs
+++ b/crates/bootstrap_srv/src/iroh_relay_axum.rs
@@ -27,11 +27,29 @@ use iroh_relay::{
     protos::{handshake, streams::StreamError},
     server::{
         Access, AccessControl, AllowAll, ClientRequest, DynAccessControl,
-        Metrics, client::Config, clients::Clients, streams::RelayedStream,
+        Metrics,
+        client::Config,
+        clients::Clients,
+        streams::{Bucket, RelayedStream},
     },
 };
+use std::future::Future;
 
 use crate::RelayAllowlist;
+
+/// Per-connection inbound byte rate limit for the relay WebSocket handler.
+///
+/// The limiter applies to every binary frame received from a single
+/// WebSocket connection. Both fields are `NonZeroU32`, so neither value can
+/// degenerate to "unlimited via zero"; an unset limiter is represented by
+/// `None` on [`RelayState::rate_limit`].
+#[derive(Clone, Copy, Debug)]
+pub struct RelayClientRxRateLimit {
+    /// Sustained refill rate in bytes per second.
+    pub bytes_per_second: std::num::NonZeroU32,
+    /// Maximum bucket capacity (i.e. allowed burst above the sustained rate).
+    pub burst_bytes: std::num::NonZeroU32,
+}
 
 /// State required for the relay handler.
 #[derive(Clone, Debug)]
@@ -46,6 +64,8 @@ pub struct RelayState {
     pub write_timeout: std::time::Duration,
     /// Clients registry
     pub clients: Clients,
+    /// Optional per-connection inbound byte rate limit.
+    pub rate_limit: Option<RelayClientRxRateLimit>,
 }
 
 impl RelayState {
@@ -54,6 +74,7 @@ impl RelayState {
         key_cache: KeyCache,
         access: Arc<dyn DynAccessControl>,
         metrics: Arc<Metrics>,
+        rate_limit: Option<RelayClientRxRateLimit>,
     ) -> Self {
         Self {
             key_cache,
@@ -61,6 +82,7 @@ impl RelayState {
             metrics,
             write_timeout: iroh_relay::defaults::timeouts::SERVER_WRITE_TIMEOUT,
             clients: Clients::default(),
+            rate_limit,
         }
     }
 }
@@ -144,15 +166,80 @@ pub async fn relay_handler(
     })
 }
 
+/// Per-connection rate-limit state held inside [`AxumWebSocketAdapter`].
+///
+/// Pairs a [`Bucket`] with an optional pending sleep that gates
+/// the next read when the bucket has been overrun. The bucket is charged
+/// optimistically: every inbound binary frame's size is subtracted from the
+/// bucket *after* the frame is read but *before* the next frame is polled,
+/// so an overrun delays the *next* read rather than the current one. No
+/// frames are dropped — every frame is delivered, only paced.
+///
+/// Lifetime is tied to a single WebSocket connection. iroh's
+/// `Clients::register` is keyed on `EndpointId` and replaces existing
+/// entries, so per-connection is equivalent to per-endpoint by
+/// construction.
+struct RateLimitState {
+    /// Token bucket reused from `iroh_relay`. Counts inbound bytes.
+    bucket: Bucket,
+    /// `Some` when the previous charge overran the bucket. Resolves at the
+    /// deadline reported by [`Bucket::consume`], at which point
+    /// the next read is allowed.
+    sleep: Option<Pin<Box<tokio::time::Sleep>>>,
+}
+
+impl RateLimitState {
+    fn new(limit: RelayClientRxRateLimit) -> Self {
+        let bucket = Bucket::new(
+            limit.burst_bytes.get() as i64,
+            limit.bytes_per_second.get() as i64,
+            std::time::Duration::from_millis(100),
+        )
+        .expect(
+            "RelayClientRxRateLimit fields are NonZeroU32 so Bucket::new \
+             cannot fail with InvalidBucketConfig",
+        );
+        Self {
+            bucket,
+            sleep: None,
+        }
+    }
+
+    /// Returns `Poll::Pending` if the bucket is currently throttled,
+    /// `Poll::Ready(())` otherwise. Always wakes when the throttle clears.
+    fn poll_throttle(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+        if let Some(sleep) = self.sleep.as_mut() {
+            match sleep.as_mut().poll(cx) {
+                Poll::Pending => return Poll::Pending,
+                Poll::Ready(()) => self.sleep = None,
+            }
+        }
+        Poll::Ready(())
+    }
+
+    /// Charge `bytes` to the bucket. If the charge overruns, schedules a
+    /// sleep until the bucket refills enough.
+    fn charge(&mut self, bytes: usize) {
+        if let Err(deadline) = self.bucket.consume(bytes) {
+            self.sleep = Some(Box::pin(tokio::time::sleep_until(deadline)));
+        }
+    }
+}
+
 /// Adapter that wraps axum's WebSocket to implement the Stream/Sink traits needed by the relay
 struct AxumWebSocketAdapter {
     inner: Pin<Box<WebSocket>>,
+    rate_limit: Option<RateLimitState>,
 }
 
 impl AxumWebSocketAdapter {
-    fn new(socket: WebSocket) -> Self {
+    fn new(
+        socket: WebSocket,
+        rate_limit: Option<RelayClientRxRateLimit>,
+    ) -> Self {
         Self {
             inner: Box::pin(socket),
+            rate_limit: rate_limit.map(RateLimitState::new),
         }
     }
 }
@@ -164,21 +251,26 @@ impl Stream for AxumWebSocketAdapter {
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
     ) -> Poll<Option<Self::Item>> {
-        // Poll the underlying axum WebSocket
+        // If a previous frame overran the bucket, defer the next read
+        // until the bucket has refilled enough.
+        if let Some(rl) = self.rate_limit.as_mut()
+            && rl.poll_throttle(cx).is_pending()
+        {
+            return Poll::Pending;
+        }
+
         loop {
             match self.inner.as_mut().poll_next(cx) {
-                Poll::Ready(Some(Ok(msg))) => {
-                    match msg {
-                        AxumMessage::Binary(data) => {
-                            return Poll::Ready(Some(Ok(data)));
+                Poll::Ready(Some(Ok(msg))) => match msg {
+                    AxumMessage::Binary(data) => {
+                        if let Some(rl) = self.rate_limit.as_mut() {
+                            rl.charge(data.len());
                         }
-                        AxumMessage::Close(_) => return Poll::Ready(None),
-                        _ => {
-                            // Skip non-binary messages and continue polling
-                            continue;
-                        }
+                        return Poll::Ready(Some(Ok(data)));
                     }
-                }
+                    AxumMessage::Close(_) => return Poll::Ready(None),
+                    _ => continue,
+                },
                 Poll::Ready(Some(Err(e))) => {
                     return Poll::Ready(Some(Err(StreamError::from_std(e))));
                 }
@@ -260,7 +352,7 @@ async fn handle_relay_websocket(
     trace!("Relay WebSocket connection established");
 
     // Wrap the axum WebSocket to implement Stream/Sink
-    let mut adapter = AxumWebSocketAdapter::new(socket);
+    let mut adapter = AxumWebSocketAdapter::new(socket, state.rate_limit);
 
     // Perform the relay protocol handshake with a timeout to prevent
     // stalled clients from holding the WebSocket open indefinitely.
@@ -388,11 +480,13 @@ pub async fn captive_portal_handler(
 ///
 /// This creates the state needed for the relay handler which can be mounted
 /// as a standard axum route. All connections are permitted.
-pub fn create_relay_state() -> RelayState {
+pub fn create_relay_state(
+    rate_limit: Option<RelayClientRxRateLimit>,
+) -> RelayState {
     let key_cache = KeyCache::new(1024);
     let access = Arc::new(AllowAll);
     let metrics = Arc::new(Metrics::default());
-    RelayState::new(key_cache, access, metrics)
+    RelayState::new(key_cache, access, metrics, rate_limit)
 }
 
 struct AllowlistAccess {
@@ -437,11 +531,12 @@ impl AccessControl for AllowlistAccess {
 /// `PUT /relay/register` before their relay connection will be accepted.
 pub fn create_relay_state_with_allowlist(
     allowlist: RelayAllowlist,
+    rate_limit: Option<RelayClientRxRateLimit>,
 ) -> RelayState {
     let key_cache = KeyCache::new(1024);
     let access = Arc::new(AllowlistAccess::new(allowlist));
     let metrics = Arc::new(Metrics::default());
-    RelayState::new(key_cache, access, metrics)
+    RelayState::new(key_cache, access, metrics, rate_limit)
 }
 
 #[cfg(test)]
@@ -459,7 +554,7 @@ mod tests {
     use iroh_relay::{
         client::ClientBuilder,
         protos::relay::{ClientToRelayMsg, Datagrams, RelayToClientMsg},
-        tls::CaRootsConfig,
+        tls::CaTlsConfig,
     };
 
     /// Integration test: Start an axum server with the relay handler and connect clients
@@ -468,7 +563,7 @@ mod tests {
     async fn axum_relay_integration() -> Result<(), Box<dyn std::error::Error>>
     {
         // Create relay state
-        let state = create_relay_state();
+        let state = create_relay_state(None);
 
         // Create axum router with relay handler
         let app = Router::new()
@@ -489,7 +584,7 @@ mod tests {
         let relay_url = format!("http://{}/relay", addr);
         let relay_url: RelayUrl = relay_url.parse()?;
 
-        let tls_client_config = CaRootsConfig::default()
+        let tls_client_config = CaTlsConfig::default()
             .client_config(iroh_relay::tls::default_provider())?;
 
         // Create client A
@@ -588,5 +683,190 @@ mod tests {
 
         info!("Test completed successfully");
         Ok(())
+    }
+
+    #[tokio::test]
+    #[instrument]
+    async fn axum_relay_rate_limited() -> Result<(), Box<dyn std::error::Error>>
+    {
+        use std::num::NonZeroU32;
+        use std::time::Instant as StdInstant;
+
+        // Tight limit: 8 KiB/s sustained, 8 KiB burst. With 1 KiB
+        // datagrams that is 8 frames per second after the initial burst.
+        let rate_limit = RelayClientRxRateLimit {
+            bytes_per_second: NonZeroU32::new(8 * 1024).unwrap(),
+            burst_bytes: NonZeroU32::new(8 * 1024).unwrap(),
+        };
+
+        let state = create_relay_state(Some(rate_limit));
+
+        let app = Router::new()
+            .route("/relay", get(relay_handler))
+            .with_state(state.clone());
+
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await?;
+        let addr = listener.local_addr()?;
+        let server_handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("server error");
+        });
+
+        let relay_url = format!("http://{}/relay", addr);
+        let relay_url: RelayUrl = relay_url.parse()?;
+
+        let tls_client_config = CaTlsConfig::default()
+            .client_config(iroh_relay::tls::default_provider())?;
+
+        let a_secret_key = SecretKey::generate();
+        let resolver = DnsResolver::new();
+        let mut client_a = ClientBuilder::new(
+            relay_url.clone(),
+            a_secret_key,
+            resolver.clone(),
+        )
+        .tls_client_config(tls_client_config.clone())
+        .connect()
+        .await?;
+
+        let b_secret_key = SecretKey::generate();
+        let b_key = b_secret_key.public();
+        let mut client_b = ClientBuilder::new(
+            relay_url.clone(),
+            b_secret_key,
+            resolver.clone(),
+        )
+        .tls_client_config(tls_client_config)
+        .connect()
+        .await?;
+
+        // Send 24 KiB total in 24 x 1 KiB datagrams. With an 8 KiB bucket
+        // and 8 KiB/s refill, total wall time on the recv side should be
+        // significantly more than zero (>= ~1.5 s by the time the second
+        // and later batches drain the bucket).
+        let payload = vec![0u8; 1024];
+        let datagrams = Datagrams::from(payload);
+
+        let started = StdInstant::now();
+        for _ in 0..24 {
+            client_a
+                .send(ClientToRelayMsg::Datagrams {
+                    dst_endpoint_id: b_key,
+                    datagrams: datagrams.clone(),
+                })
+                .await?;
+        }
+
+        let mut received = 0usize;
+        while received < 24 {
+            let msg = tokio::time::timeout(
+                std::time::Duration::from_secs(10),
+                client_b.next(),
+            )
+            .await
+            .expect("timeout waiting for message")
+            .expect("stream ended")?;
+            if matches!(msg, RelayToClientMsg::Datagrams { .. }) {
+                received += 1;
+            }
+        }
+        let elapsed = started.elapsed();
+
+        assert!(
+            elapsed >= std::time::Duration::from_millis(1500),
+            "rate-limit appears not to be applied: elapsed = {elapsed:?}"
+        );
+        assert!(
+            elapsed < std::time::Duration::from_secs(9),
+            "rate-limit appears stuck: elapsed = {elapsed:?}"
+        );
+
+        drop(client_a);
+        drop(client_b);
+        server_handle.abort();
+        Ok(())
+    }
+
+    use std::num::NonZeroU32;
+
+    fn poll_throttle_now(state: &mut RateLimitState) -> Poll<()> {
+        let waker = futures::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        state.poll_throttle(&mut cx)
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn rate_limit_passes_under_burst() {
+        let limit = RelayClientRxRateLimit {
+            bytes_per_second: NonZeroU32::new(1024).unwrap(),
+            burst_bytes: NonZeroU32::new(1024).unwrap(),
+        };
+        let mut state = RateLimitState::new(limit);
+
+        state.charge(512);
+        assert!(matches!(poll_throttle_now(&mut state), Poll::Ready(())));
+        assert!(state.sleep.is_none());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn rate_limit_paces_overrun() {
+        let limit = RelayClientRxRateLimit {
+            bytes_per_second: NonZeroU32::new(1024).unwrap(),
+            burst_bytes: NonZeroU32::new(1024).unwrap(),
+        };
+        let mut state = RateLimitState::new(limit);
+
+        // Charge 512 bytes keeps fill > 0, so no throttle.
+        state.charge(512);
+        assert!(matches!(poll_throttle_now(&mut state), Poll::Ready(())));
+        assert!(state.sleep.is_none());
+
+        // Charge another 1024 bytes drains the bucket past zero. iroh's
+        // Bucket triggers throttle when fill is <= 0, so a sleep is
+        // scheduled.
+        state.charge(1024);
+        assert!(state.sleep.is_some());
+        assert!(matches!(poll_throttle_now(&mut state), Poll::Pending));
+
+        // Drive the throttle to completion. With `start_paused = true`,
+        // tokio auto-advances virtual time when the only work pending is
+        // a sleep, so this completes deterministically once the bucket's
+        // refill deadline passes.
+        let started = tokio::time::Instant::now();
+        std::future::poll_fn(|cx| state.poll_throttle(cx)).await;
+        let elapsed = started.elapsed();
+
+        assert!(state.sleep.is_none());
+        // Some real virtual time must have passed.
+        assert!(
+            elapsed >= std::time::Duration::from_millis(100),
+            "throttle cleared too soon: elapsed = {elapsed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn rate_limit_state_construction_safe_for_low_rates() {
+        // bytes_per_second = 100 over a 100ms refill window resolves to
+        // a per-period refill of 10 bytes (>0), so Bucket::new accepts
+        // it. Validates that small-but-nonzero rates do not panic.
+        let limit = RelayClientRxRateLimit {
+            bytes_per_second: NonZeroU32::new(100).unwrap(),
+            burst_bytes: NonZeroU32::new(10).unwrap(),
+        };
+        // Must not panic
+        RateLimitState::new(limit);
+    }
+
+    #[tokio::test]
+    #[should_panic]
+    async fn rate_limit_state_construction_panics_for_zero_burst() {
+        // bytes_per_second = 100 over a 100ms refill window resolves to
+        // a per-period refill of 10 bytes (>0), so Bucket::new accepts
+        // it. Validates that small-but-nonzero rates do not panic.
+        let limit = RelayClientRxRateLimit {
+            bytes_per_second: NonZeroU32::new(100).unwrap(),
+            burst_bytes: NonZeroU32::new(0).unwrap(),
+        };
+        // Must panic
+        RateLimitState::new(limit);
     }
 }

--- a/crates/bootstrap_srv/src/server.rs
+++ b/crates/bootstrap_srv/src/server.rs
@@ -49,6 +49,14 @@ impl Drop for BootstrapSrv {
 impl BootstrapSrv {
     /// Construct a new BootstrapSrv instance.
     pub fn new(config: Config) -> std::io::Result<Self> {
+        #[cfg(feature = "iroh-relay")]
+        config.resolve_relay_rate_limit().map_err(|err| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("invalid relay rate-limit config: {err}"),
+            )
+        })?;
+
         let config = Arc::new(config);
 
         // atomic flag for telling worker threads to shutdown

--- a/crates/bootstrap_srv/src/test/iroh_relay_axum.rs
+++ b/crates/bootstrap_srv/src/test/iroh_relay_axum.rs
@@ -227,7 +227,7 @@ fn assert_authenticated_relay_rejects_unregistered(addr: SocketAddr) {
             ))
             .secret_key(secret_key)
             .alpns(vec![TEST_ALPN.to_vec()])
-            .ca_roots_config(iroh_relay::tls::CaRootsConfig::insecure_skip_verify())
+            .ca_tls_config(iroh_relay::tls::CaTlsConfig::insecure_skip_verify())
         };
 
         let ep_1 = build_endpoint(ep_1_secret).bind().await.unwrap();
@@ -357,8 +357,8 @@ fn create_two_authenticated_endpoints_and_assert_message_is_received(
                 .relay_mode(iroh::RelayMode::Custom(RelayMap::empty()))
                 .secret_key(secret_key)
                 .alpns(vec![TEST_ALPN.to_vec()])
-                .ca_roots_config(
-                    iroh_relay::tls::CaRootsConfig::insecure_skip_verify(),
+                .ca_tls_config(
+                    iroh_relay::tls::CaTlsConfig::insecure_skip_verify(),
                 )
         };
 
@@ -460,18 +460,14 @@ fn create_two_endpoints_and_assert_message_is_received(
         let ep_1 = iroh::Endpoint::builder(Minimal)
             .relay_mode(iroh::RelayMode::Custom(relay_map.clone()))
             .alpns(vec![TEST_ALPN.to_vec()])
-            .ca_roots_config(
-                iroh_relay::tls::CaRootsConfig::insecure_skip_verify(),
-            )
+            .ca_tls_config(iroh_relay::tls::CaTlsConfig::insecure_skip_verify())
             .bind()
             .await
             .unwrap();
         let ep_2 = iroh::Endpoint::builder(Minimal)
             .relay_mode(iroh::RelayMode::Custom(relay_map))
             .alpns(vec![TEST_ALPN.to_vec()])
-            .ca_roots_config(
-                iroh_relay::tls::CaRootsConfig::insecure_skip_verify(),
-            )
+            .ca_tls_config(iroh_relay::tls::CaTlsConfig::insecure_skip_verify())
             .bind()
             .await
             .unwrap();

--- a/crates/bootstrap_srv/tests/relay_metrics.rs
+++ b/crates/bootstrap_srv/tests/relay_metrics.rs
@@ -61,9 +61,7 @@ fn relay_metrics_exported_via_otel() {
             .relay_mode(iroh::RelayMode::Custom(relay_map.clone()))
             .secret_key(SecretKey::generate())
             .alpns(vec![TEST_ALPN.to_vec()])
-            .ca_roots_config(
-                iroh_relay::tls::CaRootsConfig::insecure_skip_verify(),
-            )
+            .ca_tls_config(iroh_relay::tls::CaTlsConfig::insecure_skip_verify())
             .bind()
             .await
             .unwrap();
@@ -72,9 +70,7 @@ fn relay_metrics_exported_via_otel() {
             .relay_mode(iroh::RelayMode::Custom(relay_map))
             .secret_key(SecretKey::generate())
             .alpns(vec![TEST_ALPN.to_vec()])
-            .ca_roots_config(
-                iroh_relay::tls::CaRootsConfig::insecure_skip_verify(),
-            )
+            .ca_tls_config(iroh_relay::tls::CaTlsConfig::insecure_skip_verify())
             .bind()
             .await
             .unwrap();

--- a/crates/test_utils/src/bootstrap.rs
+++ b/crates/test_utils/src/bootstrap.rs
@@ -103,7 +103,9 @@ impl TestBootstrapSrv {
         #[cfg(feature = "relay")]
         let relay_state = {
             let relay_state =
-                kitsune2_bootstrap_srv::iroh_relay_axum::create_relay_state();
+                kitsune2_bootstrap_srv::iroh_relay_axum::create_relay_state(
+                    None,
+                );
 
             let relay_router = Router::new()
                 .route(

--- a/crates/transport_iroh/src/lib.rs
+++ b/crates/transport_iroh/src/lib.rs
@@ -490,8 +490,8 @@ impl IrohTransport {
         // Test relay server uses self-signed certificate, so skip certificate verification.
         #[cfg(feature = "test-utils")]
         {
-            builder = builder.ca_roots_config(
-                iroh_relay::tls::CaRootsConfig::insecure_skip_verify(),
+            builder = builder.ca_tls_config(
+                iroh_relay::tls::CaTlsConfig::insecure_skip_verify(),
             );
         }
 


### PR DESCRIPTION
## Summary

Adds per-connection inbound byte rate limiting to the embedded iroh relay server in `bootstrap_srv`. Closes #501.

## How it works

A token bucket lives inside the axum WebSocket adapter for each connection. Every inbound binary frame's size is charged to the bucket *after* the frame is read but *before* the next frame is polled. If a charge overruns, the next read is paced via `tokio::time::sleep_until(deadline)` where `deadline` comes from the bucket itself. No frames are dropped; every frame is delivered, only paced.

The bucket primitive is `iroh_relay::Bucket`, which is `pub(crate)` upstream. It is consumed here via `[patch.crates-io]` pinning the `holochain/iroh` fork (branch `kitsune2/expose-bucket`, SHA `4002ec17`) which flips the visibility and re-exports the type. Same semantics as Iroh's own `RateLimited`, applied at the frame layer instead of the raw byte stream, which is required because axum terminates the WebSocket upgrade before the relay handler runs.

## What's done

- `iroh_relay::Bucket` exposed on the holochain/iroh fork.
- `[patch.crates-io]` pinning all of `iroh-base`, `iroh-dns`, `iroh-relay` from the fork.
- `RelayClientRxRateLimit` config type plumbed from `Config` through `RelayState` into `AxumWebSocketAdapter`.
- `Config::resolve_relay_rate_limit()` normalises the (bps, burst) pair; burst defaults to `bps/10` when only the sustained rate is set. `BootstrapSrv::new` rejects `burst` without `bps`.
- CLI flags `--relay-client-rx-bytes-per-second`, `--relay-client-rx-burst-bytes`.
- Off by default in both `Config::testing()` and `Config::production()`.
