### PR TITLE
RE-APPLY: fix: stabilize iroh relay in bootstrap_srv (#491)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,6 +537,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,6 +595,33 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
 ]
 
 [[package]]
@@ -785,6 +824,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "futures",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "tokio",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -796,6 +873,16 @@ version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
@@ -813,6 +900,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -1686,6 +1779,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hash32"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2396,10 +2500,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -2608,6 +2732,7 @@ dependencies = [
  "base64",
  "bytes",
  "clap",
+ "criterion",
  "ctrlc",
  "ed25519-dalek 2.2.0",
  "futures",
@@ -3538,6 +3663,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3842,6 +3973,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4046,7 +4205,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
  "heck 0.5.0",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "multimap",
  "petgraph",
@@ -4065,7 +4224,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -4078,7 +4237,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -4263,6 +4422,26 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "rcgen"
@@ -5470,6 +5649,16 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,6 +139,8 @@ prost-build = "0.14"
 # Please be careful to only include them in dev dependencies or move them
 # above this section.
 # --- dev-dependencies ---
+# Criterion benchmarks
+criterion = { version = "0.5", features = ["async_tokio"] }
 kitsune2_bootstrap_srv = { version = "0.5.0-dev.0", path = "crates/bootstrap_srv" }
 kitsune2_core = { version = "0.5.0-dev.0", path = "crates/core" }
 kitsune2_test_utils = { version = "0.5.0-dev.0", path = "crates/test_utils" }

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -35,6 +35,11 @@ install_crate = false
 command = "cargo"
 args = ["test"]
 
+[tasks.bench-build]
+description = "Build all benchmarks without running them so they don't bit-rot"
+command = "cargo"
+args = ["bench", "--no-run"]
+
 #
 # Tasks that modify content and are not run on CI
 #
@@ -62,7 +67,13 @@ args = ["format"]
 
 [tasks.static]
 description = "Run all static checks"
-dependencies = ["format-toml-check", "format-check", "clippy", "doc-check"]
+dependencies = [
+  "format-toml-check",
+  "format-check",
+  "clippy",
+  "doc-check",
+  "bench-build",
+]
 
 [tasks.verify]
 description = "Run all static checks and tests"

--- a/crates/bootstrap_srv/Cargo.toml
+++ b/crates/bootstrap_srv/Cargo.toml
@@ -57,12 +57,19 @@ rustls-pemfile = { workspace = true, optional = true }
 rcgen = { workspace = true, optional = true }
 
 [dev-dependencies]
-rand = { workspace = true }
-sbd-client = { workspace = true }
+criterion = { workspace = true }
 iroh = { workspace = true, features = ["tls-aws-lc-rs", "test-utils"] }
 iroh-base = { workspace = true }
-rand_chacha = { workspace = true }
+iroh-relay = { workspace = true }
 kitsune2_test_utils = { workspace = true }
+rand = { workspace = true }
+rand_chacha = { workspace = true }
+sbd-client = { workspace = true }
+
+[[bench]]
+name = "iroh_relay_bench"
+harness = false
+required-features = ["iroh-relay"]
 
 [features]
 default = ["iroh-relay"]

--- a/crates/bootstrap_srv/benches/iroh_relay_bench.rs
+++ b/crates/bootstrap_srv/benches/iroh_relay_bench.rs
@@ -1,0 +1,297 @@
+//! Criterion benchmarks for relay message delivery.
+//!
+//! Benchmarks use the `iroh_relay::client::ClientBuilder` API directly
+//! (not `iroh::Endpoint`) to measure raw relay throughput without the
+//! overhead of QUIC negotiation, holepunching, or QAD.
+//!
+//! **Local relay** benchmarks always run against an in-process axum relay
+//! server — no network access required.
+//!
+//! **External relay** benchmarks are gated behind the
+//! `KITSUNE2_IROH_RELAY_BENCH_URLS` environment variable (comma-separated
+//! list of relay URLs). If unset, only local benchmarks run.
+//!
+//! # Examples
+//!
+//! ```sh
+//! # Local only:
+//! cargo bench -p kitsune2_bootstrap_srv
+//!
+//! # Compare against public and deployed relays:
+//! KITSUNE2_IROH_RELAY_BENCH_URLS="https://use1-1.relay.n0.iroh-canary.iroh.link./,https://dev-test-bootstrap2-iroh.holochain.org" \
+//!   cargo bench -p kitsune2_bootstrap_srv
+//! ```
+
+use std::{net::Ipv4Addr, time::Duration};
+
+use axum::{Router, routing::get};
+use criterion::{
+    BenchmarkId, Criterion, Throughput, criterion_group, criterion_main,
+};
+use futures::{SinkExt, StreamExt};
+use iroh_base::{RelayUrl, SecretKey};
+use iroh_relay::{
+    client::ClientBuilder,
+    dns::DnsResolver,
+    protos::relay::{ClientToRelayMsg, Datagrams, RelayToClientMsg},
+};
+use kitsune2_bootstrap_srv::iroh_relay_axum::{
+    create_relay_state, relay_handler,
+};
+use tokio::{net::TcpListener, runtime::Runtime};
+
+/// Spawn an in-process axum relay server on a dedicated thread.
+fn spawn_local_relay() -> RelayUrl {
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let rt = Runtime::new().unwrap();
+        rt.block_on(async {
+            let state = create_relay_state();
+            let app = Router::new()
+                .route("/relay", get(relay_handler))
+                .with_state(state);
+
+            let listener =
+                TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).await.unwrap();
+            let addr = listener.local_addr().unwrap();
+            tx.send(addr).unwrap();
+            axum::serve(listener, app).await.expect("server error");
+        });
+    });
+    let addr = rx.recv().unwrap();
+    format!("http://{}/relay", addr).parse().unwrap()
+}
+
+type ClientPair = (
+    iroh_relay::client::Client,
+    iroh_base::EndpointId,
+    iroh_relay::client::Client,
+    iroh_base::EndpointId,
+);
+
+/// Connect two relay clients to the given relay URL.
+async fn connect_client_pair(relay_url: &RelayUrl) -> ClientPair {
+    let resolver = DnsResolver::new();
+
+    let a_secret = SecretKey::generate();
+    let a_key = a_secret.public();
+    let client_a =
+        ClientBuilder::new(relay_url.clone(), a_secret, resolver.clone())
+            .connect()
+            .await
+            .unwrap();
+
+    let b_secret = SecretKey::generate();
+    let b_key = b_secret.public();
+    let client_b = ClientBuilder::new(relay_url.clone(), b_secret, resolver)
+        .connect()
+        .await
+        .unwrap();
+
+    (client_a, a_key, client_b, b_key)
+}
+
+fn local_relay_benchmarks(c: &mut Criterion) {
+    let relay_url = spawn_local_relay();
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    // Payload throughput at various sizes. The relay protocol has a max
+    // frame size of 64 KiB, so we stay below that limit. Fresh clients
+    // are created per size to avoid connection exhaustion across many
+    // Criterion iterations.
+    let mut group = c.benchmark_group("local_relay/throughput");
+    group.measurement_time(Duration::from_secs(15));
+    group.sample_size(20);
+
+    for (label, size) in [
+        ("1KiB", 1024usize),
+        ("8KiB", 8 * 1024),
+        ("32KiB", 32 * 1024),
+    ] {
+        let (mut client_a, a_key, mut client_b, b_key) =
+            rt.block_on(connect_client_pair(&relay_url));
+
+        let payload = vec![42u8; size];
+        group.throughput(Throughput::Bytes(size as u64));
+        group.bench_with_input(
+            BenchmarkId::new("payload", label),
+            &payload,
+            |b, payload| {
+                b.iter(|| {
+                    rt.block_on(async {
+                        let msg = Datagrams::from(payload.as_slice());
+                        client_a
+                            .send(ClientToRelayMsg::Datagrams {
+                                dst_endpoint_id: b_key,
+                                datagrams: msg,
+                            })
+                            .await
+                            .unwrap();
+
+                        // Read until we get the datagram, skipping pings.
+                        loop {
+                            let received = tokio::time::timeout(
+                                Duration::from_secs(5),
+                                client_b.next(),
+                            )
+                            .await
+                            .expect("timeout")
+                            .expect("stream ended")
+                            .unwrap();
+
+                            match received {
+                                RelayToClientMsg::Datagrams {
+                                    remote_endpoint_id,
+                                    ..
+                                } => {
+                                    assert_eq!(remote_endpoint_id, a_key);
+                                    break;
+                                }
+                                RelayToClientMsg::Ping { .. } => continue,
+                                other => {
+                                    panic!(
+                                        "unexpected message type: {:?}",
+                                        other
+                                    )
+                                }
+                            }
+                        }
+                    });
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+/// Roundtrip benchmark for the local relay: connect + handshake + 1 KiB
+/// send, same methodology as external_relay_benchmarks so numbers are
+/// directly comparable.
+fn local_relay_roundtrip(c: &mut Criterion) {
+    let relay_url = spawn_local_relay();
+
+    let mut group = c.benchmark_group("local_relay/roundtrip");
+    // Each iteration creates fresh TCP connections that linger in
+    // TIME_WAIT (~30s on macOS). Keep timing short and sample count
+    // low to stay within ephemeral port limits.
+    group.warm_up_time(Duration::from_millis(500));
+    group.measurement_time(Duration::from_secs(5));
+    group.sample_size(10);
+
+    group.bench_function(BenchmarkId::new("1KiB", "localhost"), |b| {
+        b.iter(|| {
+            relay_roundtrip(&relay_url);
+        });
+    });
+
+    group.finish();
+}
+
+/// Send a single 1 KiB datagram through a relay, including client
+/// connect + handshake time. Each call creates fresh clients to avoid
+/// hitting upstream rate limits on long-lived connections.
+fn relay_roundtrip(relay_url: &RelayUrl) {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    rt.block_on(async {
+        let resolver = DnsResolver::new();
+
+        let a_secret = SecretKey::generate();
+        let a_key = a_secret.public();
+        let mut client_a =
+            ClientBuilder::new(relay_url.clone(), a_secret, resolver.clone())
+                .connect()
+                .await
+                .unwrap();
+
+        let b_secret = SecretKey::generate();
+        let b_key = b_secret.public();
+        let mut client_b =
+            ClientBuilder::new(relay_url.clone(), b_secret, resolver)
+                .connect()
+                .await
+                .unwrap();
+
+        let payload = vec![42u8; 1024];
+        let msg = Datagrams::from(payload.as_slice());
+        client_a
+            .send(ClientToRelayMsg::Datagrams {
+                dst_endpoint_id: b_key,
+                datagrams: msg,
+            })
+            .await
+            .unwrap();
+
+        loop {
+            let received =
+                tokio::time::timeout(Duration::from_secs(10), client_b.next())
+                    .await
+                    .expect("timeout")
+                    .expect("stream ended")
+                    .unwrap();
+
+            match received {
+                RelayToClientMsg::Datagrams {
+                    remote_endpoint_id, ..
+                } => {
+                    assert_eq!(remote_endpoint_id, a_key);
+                    break;
+                }
+                RelayToClientMsg::Ping { .. } => continue,
+                other => panic!("unexpected message type: {:?}", other),
+            }
+        }
+    });
+}
+
+fn external_relay_benchmarks(c: &mut Criterion) {
+    let urls = match std::env::var("KITSUNE2_IROH_RELAY_BENCH_URLS") {
+        Ok(val) => {
+            let urls = val
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(str::to_string)
+                .collect::<Vec<_>>();
+            if urls.is_empty() {
+                return;
+            }
+            urls
+        }
+        Err(_) => return,
+    };
+
+    let mut group = c.benchmark_group("external_relay/roundtrip");
+    group.measurement_time(Duration::from_secs(60));
+    group.sample_size(10);
+
+    for url_str in &urls {
+        let relay_url: RelayUrl = url_str
+            .parse()
+            .unwrap_or_else(|e| panic!("invalid relay URL {url_str}: {e}"));
+
+        group.bench_function(BenchmarkId::new("1KiB", url_str), |b| {
+            b.iter(|| {
+                relay_roundtrip(&relay_url);
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    local_relay_benchmarks,
+    local_relay_roundtrip,
+    external_relay_benchmarks
+);
+criterion_main!(benches);

--- a/crates/bootstrap_srv/src/iroh_relay_axum.rs
+++ b/crates/bootstrap_srv/src/iroh_relay_axum.rs
@@ -18,7 +18,8 @@ use std::{
     sync::Arc,
     task::{Context, Poll},
 };
-use tracing::{debug, trace, warn};
+use tokio::time::timeout;
+use tracing::{debug, info, trace, warn};
 
 use futures::FutureExt;
 use iroh_relay::http::ProtocolVersion;
@@ -91,7 +92,32 @@ pub async fn relay_handler(
         if let Err(e) =
             handle_relay_websocket(socket, state, client_auth_header).await
         {
-            warn!("Error handling relay WebSocket: {:?}", e);
+            let msg = e.to_string().to_lowercase();
+            // String-matching error classifier. The substrings come from a
+            // few different sources; keep this list in sync if the upstream
+            // crates' error messages change in a future version:
+            //
+            // - "timed out": the `io::Error` we produce ourselves at the
+            //   handshake timeout below in `handle_relay_websocket`.
+            // - "connection reset", "broken pipe": `std::io::ErrorKind`
+            //   Display impls, surfaced via `tungstenite::Error::Io`.
+            // - "connection closed", "websocket protocol error":
+            //   `tokio_tungstenite::tungstenite::Error` Display.
+            // - "not allowed", "denied": rejection messages from the
+            //   `iroh_relay` handshake auth path
+            //   (`handshake::serverside`/`authorize_if`).
+            let is_expected = msg.contains("timed out")
+                || msg.contains("connection reset")
+                || msg.contains("connection closed")
+                || msg.contains("broken pipe")
+                || msg.contains("not allowed")
+                || msg.contains("denied")
+                || msg.contains("websocket protocol error");
+            if is_expected {
+                debug!("Relay WebSocket ended: {msg}");
+            } else {
+                warn!("Error handling relay WebSocket: {msg}");
+            }
         }
     })
 }
@@ -134,7 +160,7 @@ impl Stream for AxumWebSocketAdapter {
                 Poll::Ready(Some(Err(e))) => {
                     // Convert axum error to StreamError
                     return Poll::Ready(Some(Err(StreamError::Io(
-                        std::io::Error::other(format!("{:?}", e)),
+                        std::io::Error::other(e.to_string()),
                     ))));
                 }
                 Poll::Ready(None) => return Poll::Ready(None),
@@ -154,7 +180,7 @@ impl Sink<Bytes> for AxumWebSocketAdapter {
         match self.inner.as_mut().poll_ready(cx) {
             Poll::Ready(Ok(())) => Poll::Ready(Ok(())),
             Poll::Ready(Err(e)) => Poll::Ready(Err(StreamError::Io(
-                std::io::Error::other(format!("{:?}", e)),
+                std::io::Error::other(e.to_string()),
             ))),
             Poll::Pending => Poll::Pending,
         }
@@ -167,9 +193,7 @@ impl Sink<Bytes> for AxumWebSocketAdapter {
         self.inner
             .as_mut()
             .start_send(AxumMessage::Binary(item))
-            .map_err(|e| {
-                StreamError::Io(std::io::Error::other(format!("{:?}", e)))
-            })
+            .map_err(|e| StreamError::Io(std::io::Error::other(e.to_string())))
     }
 
     fn poll_flush(
@@ -179,7 +203,7 @@ impl Sink<Bytes> for AxumWebSocketAdapter {
         match self.inner.as_mut().poll_flush(cx) {
             Poll::Ready(Ok(())) => Poll::Ready(Ok(())),
             Poll::Ready(Err(e)) => Poll::Ready(Err(StreamError::Io(
-                std::io::Error::other(format!("{:?}", e)),
+                std::io::Error::other(e.to_string()),
             ))),
             Poll::Pending => Poll::Pending,
         }
@@ -192,7 +216,7 @@ impl Sink<Bytes> for AxumWebSocketAdapter {
         match self.inner.as_mut().poll_close(cx) {
             Poll::Ready(Ok(())) => Poll::Ready(Ok(())),
             Poll::Ready(Err(e)) => Poll::Ready(Err(StreamError::Io(
-                std::io::Error::other(format!("{:?}", e)),
+                std::io::Error::other(e.to_string()),
             ))),
             Poll::Pending => Poll::Pending,
         }
@@ -224,19 +248,34 @@ async fn handle_relay_websocket(
     // Wrap the axum WebSocket to implement Stream/Sink
     let mut adapter = AxumWebSocketAdapter::new(socket);
 
-    // Perform the relay protocol handshake
-    let authentication =
-        handshake::serverside(&mut adapter, client_auth_header).await?;
+    // Perform the relay protocol handshake with a timeout to prevent
+    // stalled clients from holding the WebSocket open indefinitely.
+    const HANDSHAKE_TIMEOUT: std::time::Duration =
+        std::time::Duration::from_secs(30);
 
-    trace!(?authentication.mechanism, "accept: verified authentication");
+    let client_key = timeout(HANDSHAKE_TIMEOUT, async {
+        let authentication =
+            handshake::serverside(&mut adapter, client_auth_header).await?;
 
-    let is_authorized =
-        state.access.is_allowed(authentication.client_key).await;
-    let client_key = authentication
-        .authorize_if(is_authorized, &mut adapter)
-        .await?;
+        debug!(?authentication.mechanism, "accept: verified authentication");
 
-    trace!("accept: verified authorization");
+        let is_authorized =
+            state.access.is_allowed(authentication.client_key).await;
+        let client_key = authentication
+            .authorize_if(is_authorized, &mut adapter)
+            .await?;
+
+        Ok::<_, Box<dyn std::error::Error + Send + Sync>>(client_key)
+    })
+    .await
+    .map_err(|_| {
+        std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "Relay handshake timed out",
+        )
+    })??;
+
+    debug!(key = %client_key.fmt_short(), "accept: verified authorization");
 
     // Wrap in RelayedStream for encryption
     let io = RelayedStream::new(adapter, state.key_cache.clone());
@@ -255,6 +294,8 @@ async fn handle_relay_websocket(
     state
         .clients
         .register(client_conn_builder, state.metrics.clone());
+
+    info!(key = %client_key.fmt_short(), "relay client registered");
 
     Ok(())
 }

--- a/crates/bootstrap_srv/tests/iroh_relay_probe.rs
+++ b/crates/bootstrap_srv/tests/iroh_relay_probe.rs
@@ -1,0 +1,66 @@
+use std::{str::FromStr, time::Instant};
+
+use iroh::{
+    EndpointAddr, RelayMap, RelayMode, RelayUrl, endpoint::presets::Minimal,
+};
+const ALPN: &[u8] = b"kitsune2-iroh-relay-probe";
+const DEFAULT_PUBLIC_RELAY_URL: &str =
+    "https://use1-1.relay.n0.iroh-canary.iroh.link./";
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "network probe; set KITSUNE2_IROH_RELAY_PROBE_URL to override the relay URL"]
+async fn iroh_relay_probe_sends_payload() {
+    let relay_url = std::env::var("KITSUNE2_IROH_RELAY_PROBE_URL")
+        .unwrap_or_else(|_| DEFAULT_PUBLIC_RELAY_URL.to_string());
+    let relay_url = RelayUrl::from_str(&relay_url).unwrap();
+    let payload = vec![42u8; 64 * 1024];
+
+    let elapsed = send_payload_through_relay(relay_url.clone(), payload).await;
+    println!("relay_url={relay_url}");
+    println!("elapsed_ms={}", elapsed.as_millis());
+}
+
+async fn send_payload_through_relay(
+    relay_url: RelayUrl,
+    payload: Vec<u8>,
+) -> std::time::Duration {
+    let relay_map = RelayMap::from_iter([relay_url.clone()]);
+    let start = Instant::now();
+
+    let ep_1 = iroh::Endpoint::builder(Minimal)
+        .relay_mode(RelayMode::Custom(relay_map.clone()))
+        .alpns(vec![ALPN.to_vec()])
+        .bind()
+        .await
+        .unwrap();
+    let ep_2 = iroh::Endpoint::builder(Minimal)
+        .relay_mode(RelayMode::Custom(relay_map))
+        .alpns(vec![ALPN.to_vec()])
+        .bind()
+        .await
+        .unwrap();
+
+    let ep_2_addr = EndpointAddr::new(ep_2.id()).with_relay_url(relay_url);
+    let expected = payload.clone();
+    let expected_len = expected.len();
+
+    let message_received = tokio::spawn(async move {
+        let conn = ep_2.accept().await.unwrap().await.unwrap();
+        let mut recv_stream = conn.accept_uni().await.unwrap();
+        let message_received =
+            recv_stream.read_to_end(expected_len).await.unwrap();
+        conn.close(0u8.into(), b"");
+        ep_2.close().await;
+        message_received
+    });
+
+    let conn = ep_1.connect(ep_2_addr, ALPN).await.unwrap();
+    let mut send_stream = conn.open_uni().await.unwrap();
+    send_stream.write_all(&payload).await.unwrap();
+    send_stream.finish().unwrap();
+
+    assert_eq!(message_received.await.unwrap(), expected);
+    ep_1.close().await;
+
+    start.elapsed()
+}


### PR DESCRIPTION
# Fix accidental removal of this commit 
As happened in https://github.com/holochain/kitsune2/pull/479 due to rebase/squash mistake.

# Original description
**Original author:** @veeso 

Add handshake timeout, fix QAD on authenticated relay path, improve error formatting and tracing, add relay benchmarks and probe test.

- Wrap handshake+auth in 30s timeout to prevent stalled clients
- Replace Debug formatting with Display in WebSocket adapter errors
- Fix QAD disabled on insert_relay auth path (RelayConfig::from)
- Upgrade relay tracing: debug for handshake/auth, info for registration
- Classify expected errors (timeout, disconnect, denied) as debug
- Add Criterion benchmarks for relay throughput (1/8/32 KiB)
- Add ignored relay probe test for external relay comparison
- Add code comparison analysis vs upstream iroh-relay
