### PR TITLE
ci: run cargo bench across the workspace on push to main

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -1,0 +1,78 @@
+name: Bench
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  deployments: write
+
+concurrency:
+  group: bench-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  bench:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Maximize build space (Linux)
+        uses: AdityaGarg8/remove-unwanted-software@v5
+        with:
+          remove-dotnet: "true"
+          remove-android: "true"
+          remove-codeql: "true"
+          remove-docker-images: "true"
+
+      - uses: Swatinem/rust-cache@v2
+
+      # we cannot use cmake 4 until openssl-src is updated
+      - name: cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: "3.31.x"
+
+      - name: Run benchmarks and write results to file
+        env:
+          RUST_LOG: info
+        shell: bash
+        run: |
+          set -euo pipefail
+          : > bench-output.txt
+          cargo metadata --format-version 1 --no-deps \
+            | jq -r '.packages[] as $p | $p.targets[] | select(.kind[] == "bench") | [$p.name, .name, ((.["required-features"] // []) | join(","))] | @tsv' \
+            | while IFS=$'\t' read -r pkg bench feats; do
+                echo "::group::bench $pkg::$bench"
+                args=(bench -p "$pkg" --bench "$bench")
+                if [ -n "$feats" ]; then
+                  args+=(--features "$feats")
+                fi
+                cargo "${args[@]}" -- --output-format bencher | tee -a bench-output.txt
+                echo "::endgroup::"
+              done
+
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Kitsune2 Benchmarks
+          tool: cargo
+          output-file-path: bench-output.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          alert-threshold: "150%"
+          comment-on-alert: true
+          fail-on-alert: true
+          gh-pages-branch: bench-history
+          benchmark-data-dir-path: dev/bench
+
+      - name: Upload raw bench output
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: bench-output
+          path: bench-output.txt

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -40,6 +40,11 @@ description = "Build all benchmarks without running them so they don't bit-rot"
 command = "cargo"
 args = ["bench", "--no-run"]
 
+[tasks.bench]
+description = "Run all benchmarks across the workspace"
+command = "cargo"
+args = ["bench"]
+
 #
 # Tasks that modify content and are not run on CI
 #

--- a/crates/bootstrap_srv/Cargo.toml
+++ b/crates/bootstrap_srv/Cargo.toml
@@ -60,7 +60,7 @@ rcgen = { workspace = true, optional = true }
 criterion = { workspace = true }
 iroh = { workspace = true, features = ["tls-aws-lc-rs", "test-utils"] }
 iroh-base = { workspace = true }
-iroh-relay = { workspace = true }
+iroh-relay = { workspace = true, features = ["tls-aws-lc-rs", "test-utils"] }
 kitsune2_test_utils = { workspace = true }
 rand = { workspace = true }
 rand_chacha = { workspace = true }

--- a/crates/bootstrap_srv/benches/iroh_relay_bench.rs
+++ b/crates/bootstrap_srv/benches/iroh_relay_bench.rs
@@ -34,6 +34,7 @@ use iroh_relay::{
     client::ClientBuilder,
     dns::DnsResolver,
     protos::relay::{ClientToRelayMsg, Datagrams, RelayToClientMsg},
+    tls::make_dangerous_client_config,
 };
 use kitsune2_bootstrap_srv::iroh_relay_axum::{
     create_relay_state, relay_handler,
@@ -77,6 +78,7 @@ async fn connect_client_pair(relay_url: &RelayUrl) -> ClientPair {
     let a_key = a_secret.public();
     let client_a =
         ClientBuilder::new(relay_url.clone(), a_secret, resolver.clone())
+            .tls_client_config(make_dangerous_client_config())
             .connect()
             .await
             .unwrap();
@@ -84,6 +86,7 @@ async fn connect_client_pair(relay_url: &RelayUrl) -> ClientPair {
     let b_secret = SecretKey::generate();
     let b_key = b_secret.public();
     let client_b = ClientBuilder::new(relay_url.clone(), b_secret, resolver)
+        .tls_client_config(make_dangerous_client_config())
         .connect()
         .await
         .unwrap();
@@ -208,6 +211,7 @@ fn relay_roundtrip(relay_url: &RelayUrl) {
         let a_key = a_secret.public();
         let mut client_a =
             ClientBuilder::new(relay_url.clone(), a_secret, resolver.clone())
+                .tls_client_config(make_dangerous_client_config())
                 .connect()
                 .await
                 .unwrap();
@@ -216,6 +220,7 @@ fn relay_roundtrip(relay_url: &RelayUrl) {
         let b_key = b_secret.public();
         let mut client_b =
             ClientBuilder::new(relay_url.clone(), b_secret, resolver)
+                .tls_client_config(make_dangerous_client_config())
                 .connect()
                 .await
                 .unwrap();
@@ -294,4 +299,5 @@ criterion_group!(
     local_relay_roundtrip,
     external_relay_benchmarks
 );
+
 criterion_main!(benches);


### PR DESCRIPTION
## Summary

- Add a `Bench` workflow that runs `cargo bench` across the workspace on every push to `main` (and on manual dispatch), tracks results via `benchmark-action/github-action-benchmark`, and fails the run if any benchmark drifts more than 150% versus the previous run. History is persisted on the `bench-history` branch.
- Fix the `iroh_relay_bench` in `kitsune2_bootstrap_srv` so it can actually run: pass an explicit TLS client config to `ClientBuilder` (iroh-relay 0.98 requires this even when targeting a local `http://` / `ws://` relay) and enable the `tls-aws-lc-rs` + `test-utils` features on the `iroh-relay` dev-dependency.

Closes #530

## Test plan

- [x] Local: `cargo bench -p kitsune2_bootstrap_srv --bench iroh_relay_bench -- --output-format bencher` succeeds and emits bencher-format output.
- [x] CI: `Bench` workflow runs end-to-end on the branch, including the `Store benchmark result` step pushing to `bench-history`.
- [ ] After merge: confirm `Bench` runs automatically on the push to `main`.