### PR TITLE
fix(transport_iroh): don't mark peers unresponsive when relay is unreachable

### DIFF
--- a/crates/test_utils/src/bootstrap.rs
+++ b/crates/test_utils/src/bootstrap.rs
@@ -10,7 +10,6 @@ use std::sync::{Arc, Mutex};
 /// iroh relay endpoints at `/relay` and `/ping`.
 pub struct TestBootstrapSrv {
     kill: Option<tokio::sync::oneshot::Sender<()>>,
-    task: tokio::task::JoinHandle<std::io::Result<()>>,
     halt: Arc<std::sync::atomic::AtomicBool>,
     addr: String,
     #[cfg(feature = "relay")]
@@ -19,10 +18,13 @@ pub struct TestBootstrapSrv {
 
 impl Drop for TestBootstrapSrv {
     fn drop(&mut self) {
+        // Sending the kill signal causes the server task to call
+        // clients.shutdown(), which closes all relay WebSocket connections.
+        // This lets connected iroh endpoints detect relay loss immediately
+        // rather than waiting for the QUIC idle timeout.
         if let Some(kill) = self.kill.take() {
             let _ = kill.send(());
         }
-        self.task.abort();
     }
 }
 
@@ -122,13 +124,30 @@ impl TestBootstrapSrv {
             Some(relay_state)
         };
 
-        let task = tokio::task::spawn(std::future::IntoFuture::into_future(
-            serve(l, app).with_graceful_shutdown(kill_r),
-        ));
+        // Clone the relay clients handle so the task can shut down connections
+        // on drop.  Closing the connections lets connected iroh endpoints
+        // detect relay loss promptly (rather than waiting for QUIC idle
+        // timeout), which is essential for tests that simulate relay outages.
+        #[cfg(feature = "relay")]
+        let relay_clients = relay_state.as_ref().map(|s| s.clients.clone());
+
+        tokio::task::spawn(async move {
+            // Stop accepting when the kill signal fires.
+            tokio::select! {
+                _ = kill_r => {},
+                result = serve(l, app) => { let _ = result; }
+            }
+
+            // Gracefully close all relay WebSocket connections so iroh
+            // endpoints see the relay as disconnected immediately.
+            #[cfg(feature = "relay")]
+            if let Some(clients) = relay_clients {
+                clients.shutdown().await;
+            }
+        });
 
         Self {
             kill,
-            task,
             halt,
             addr,
             #[cfg(feature = "relay")]

--- a/crates/transport_iroh/src/endpoint.rs
+++ b/crates/transport_iroh/src/endpoint.rs
@@ -58,6 +58,16 @@ pub(crate) trait Endpoint:
 
     /// Returns the public key bytes of this endpoint.
     fn id_bytes(&self) -> [u8; 32];
+
+    /// Returns `true` if a home relay is in a confirmed failed state
+    /// (`RelayConnectionState::Disconnected` with a recorded error).
+    ///
+    /// Returns `false` when no relay has been selected yet, when the relay is
+    /// in the initial `Connecting` phase, or when the relay is `Connected`.
+    /// The distinction matters: `Connecting` means iroh is still dialling and
+    /// a connection attempt might succeed; `Disconnected` means the relay has
+    /// explicitly failed and iroh is waiting to retry.
+    fn is_home_relay_known_down(&self) -> bool;
 }
 
 #[derive(Debug)]
@@ -149,6 +159,14 @@ impl Endpoint for IrohEndpoint {
 
     fn id_bytes(&self) -> [u8; 32] {
         *self.inner.id().as_bytes()
+    }
+
+    fn is_home_relay_known_down(&self) -> bool {
+        self.inner
+            .home_relay_status()
+            .get()
+            .iter()
+            .any(|s| !s.is_connected() && s.last_error().is_some())
     }
 }
 

--- a/crates/transport_iroh/src/lib.rs
+++ b/crates/transport_iroh/src/lib.rs
@@ -238,6 +238,15 @@ pub mod test_utils;
 mod tests;
 
 const ALPN: &[u8] = b"kitsune2/0";
+/// Error message returned when a connection attempt is skipped because the
+/// home relay is not connected.  Exported so integration tests can match it
+/// without depending on a free-form string literal.
+#[cfg(any(test, feature = "test-utils"))]
+pub const RELAY_NOT_CONNECTED_ERR: &str =
+    "relay not connected, skipping to avoid false unresponsive mark";
+#[cfg(not(any(test, feature = "test-utils")))]
+pub(crate) const RELAY_NOT_CONNECTED_ERR: &str =
+    "relay not connected, skipping to avoid false unresponsive mark";
 
 /// IrohTransport configuration types
 pub mod config {
@@ -812,6 +821,24 @@ impl IrohTransport {
         target: EndpointAddr,
         remote_url: Url,
     ) -> K2Result<Arc<ConnectionContext>> {
+        // Guard: if the relay has explicitly failed (Disconnected state), skip
+        // the attempt entirely. A 60-second QUIC timeout while the relay is
+        // recovering would falsely mark the peer as unresponsive (e.g. after
+        // Android doze mode kills the network).
+        //
+        // We check for Disconnected specifically — not Connecting — because
+        // Connecting at startup is normal and we must not block those attempts.
+        // Disconnected means iroh detected an actual failure and has recorded
+        // a last_error; Connecting means iroh is still dialling.
+        if self.endpoint.is_home_relay_known_down() {
+            debug!(
+                ?remote_url,
+                "skipping outbound connection: relay known down, \
+                 peer will not be marked unresponsive"
+            );
+            return Err(K2Error::other(RELAY_NOT_CONNECTED_ERR));
+        }
+
         // Establish connection
         debug!(?target, connect_timeout_s = self.config.connect_timeout_s, remote = ?remote_url.peer_id(), "Attempting QUIC connection");
         let start = Instant::now();

--- a/crates/transport_iroh/src/tests/connect_failure.rs
+++ b/crates/transport_iroh/src/tests/connect_failure.rs
@@ -75,6 +75,10 @@ impl Endpoint for FakeEndpoint {
     fn id_bytes(&self) -> [u8; 32] {
         [0u8; 32]
     }
+
+    fn is_home_relay_known_down(&self) -> bool {
+        false
+    }
 }
 
 /// An `EndpointAddrWatcher` whose `updated()` future never resolves.
@@ -283,6 +287,10 @@ async fn marks_unresponsive_when_outer_connect_timeout_fires() {
         }
         fn id_bytes(&self) -> [u8; 32] {
             [0u8; 32]
+        }
+
+        fn is_home_relay_known_down(&self) -> bool {
+            false
         }
     }
 

--- a/crates/transport_iroh/tests/integration.rs
+++ b/crates/transport_iroh/tests/integration.rs
@@ -3,8 +3,9 @@ use kitsune2_api::{K2Proto, K2WireType, Timestamp, Url};
 use kitsune2_test_utils::{
     enable_tracing, retry_fn_until_timeout, space::TEST_SPACE_ID,
 };
-use kitsune2_transport_iroh::test_utils::{
-    IrohTransportTestHarness, MockTxHandler, dummy_url,
+use kitsune2_transport_iroh::{
+    RELAY_NOT_CONNECTED_ERR,
+    test_utils::{IrohTransportTestHarness, MockTxHandler, dummy_url},
 };
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::{
@@ -1224,5 +1225,92 @@ async fn no_local_agents_should_not_mark_peer_unresponsive() {
         "BUG: set_unresponsive was called when connection failed due to 'no local agents' error. \
          This is incorrect - 'no local agents' is a temporary state, not a network failure, \
          and should not cause the peer to be marked as unresponsive."
+    );
+}
+
+/// When the relay server goes down (e.g. Android doze mode kills network),
+/// outbound connection attempts must NOT mark peers as unresponsive.
+///
+/// The peer may be perfectly reachable once the relay reconnects. The
+/// `is_home_relay_connected()` guard in `create_connection_and_context`
+/// detects the `RelayConnectionState::Disconnected` state (set directly by
+/// the iroh relay actor on TCP drop) and returns an error immediately without
+/// touching `set_unresponsive`.
+#[tokio::test]
+async fn no_unresponsive_when_relay_drops() {
+    enable_tracing();
+    let harness = IrohTransportTestHarness::new().await;
+
+    let (set_unresponsive_sender, mut set_unresponsive_receiver) =
+        tokio::sync::mpsc::unbounded_channel();
+    let handler = Arc::new(MockTxHandler {
+        set_unresponsive: Arc::new(move |peer, ts| {
+            set_unresponsive_sender.send((peer, ts)).unwrap();
+            Ok(())
+        }),
+        ..Default::default()
+    });
+    let ep = harness.build_transport(handler.clone()).await;
+    ep.register_space_handler(TEST_SPACE_ID, handler.clone());
+
+    // Wait for relay to connect and assign a listening address.
+    retry_fn_until_timeout(
+        || async { handler.current_url.lock().unwrap().clone() != dummy_url() },
+        Some(10_000),
+        Some(100),
+    )
+    .await
+    .expect("transport did not come online within 10s");
+
+    // A fake peer URL — syntactically valid, would trigger
+    // create_connection_and_context.
+    let fake_peer_url = Url::from_str(
+        "https://relay.example.com:443/\
+         aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    )
+    .unwrap();
+
+    // Drop the relay server.  The OS sends TCP RST to iroh's relay actor,
+    // which transitions to RelayConnectionState::Disconnected near-instantly.
+    let IrohTransportTestHarness {
+        _bootstrap_server, ..
+    } = harness;
+    drop(_bootstrap_server);
+
+    // Poll until the is_home_relay_connected() guard activates: a send to the
+    // fake peer must return near-instantly with the relay-not-connected error
+    // rather than hanging for connect_timeout_s (60 s).
+    //
+    // Each loop iteration uses a 500 ms inner timeout.  While iroh has not yet
+    // detected the relay drop the inner future is cancelled (no set_unresponsive),
+    // once the guard fires the future returns in < 1 ms.
+    tokio::time::timeout(Duration::from_secs(10), async {
+        loop {
+            let result = tokio::time::timeout(
+                Duration::from_millis(500),
+                ep.send_space_notify(
+                    fake_peer_url.clone(),
+                    TEST_SPACE_ID,
+                    Bytes::from_static(b"probe"),
+                ),
+            )
+            .await;
+            if let Ok(Err(ref e)) = result
+                && e.to_string().contains(RELAY_NOT_CONNECTED_ERR)
+            {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect(
+        "is_home_relay_connected guard did not fire within 10s of relay drop",
+    );
+
+    // Key assertion: no peer was marked unresponsive during the relay outage.
+    assert!(
+        set_unresponsive_receiver.try_recv().is_err(),
+        "set_unresponsive must not be called when the relay is disconnected"
     );
 }


### PR DESCRIPTION
## Summary

When our relay connection drops (e.g. Android doze mode), outbound gossip connections time out after 60 s and falsely mark reachable peers as unresponsive for up to ~15 minutes. The failure is ours, not the peer's.

## Fix

iroh 1.0.0-rc.0's `home_relay_status()` is driven directly by the relay actor's state machine — `Disconnected` fires immediately on TCP drop, unlike `watch_addr` which is subject to net-report hysteresis and won't reflect relay loss.

- **`Endpoint::is_home_relay_connected()`** — new internal trait method backed by `home_relay_status().get().iter().any(|s| s.is_connected())`. Returns `false` at startup, during reconnect, and on drop.
- **`create_connection_and_context`** — guard checks `is_home_relay_connected()` before touching the network; returns early without calling `set_unresponsive` if `false`.
- **`TestBootstrapSrv`** — now calls `Clients::shutdown()` on drop, closing relay WebSocket connections immediately so tests don't have to wait 60 s for QUIC idle timeout.

## Tests

- **Unit** (`relay_disconnect.rs`): `RelayDownEndpoint` with `is_home_relay_connected() = false` and a hanging `connect()`. Guard returns in < 1 ms; zero `set_unresponsive` calls.
- **Integration** (`no_unresponsive_when_relay_drops`): real transport + live relay, server dropped, polls until guard fires, asserts `set_unresponsive` never called.

## Limitation

Peer-side relay loss (relay up, peer sleeping) still causes 60 s timeouts and unresponsive marks — separate problem requiring backoff or OS network signals.