### PR TITLE
Fix the metrics integration tests in transport_iroh crate and fix cargo-make to run them

### DIFF
--- a/crates/transport_iroh/Makefile.toml
+++ b/crates/transport_iroh/Makefile.toml
@@ -1,1 +1,10 @@
 extend = "../../Makefile.toml"
+
+[tasks.test]
+workspace = false
+dependencies = ["test-metrics-feature"]
+
+[tasks.test-metrics-feature]
+workspace = false
+command = "cargo"
+args = ["test", "--features", "metrics"]

--- a/crates/transport_iroh/tests/metrics.rs
+++ b/crates/transport_iroh/tests/metrics.rs
@@ -96,7 +96,7 @@ async fn connection_counter() {
             assert_eq!(metrics[0].name(), "kitsune2.transport.connections");
             assert_eq!(
                 metrics[0].description(),
-                "The number of active connections"
+                "The number of open connections"
             );
             if let AggregatedMetrics::I64(MetricData::Sum(sum)) =
                 metrics[0].data()
@@ -143,7 +143,7 @@ async fn connection_counter() {
             assert_eq!(metrics[0].name(), "kitsune2.transport.connections");
             assert_eq!(
                 metrics[0].description(),
-                "The number of active connections"
+                "The number of open connections"
             );
             if let AggregatedMetrics::I64(MetricData::Sum(sum)) =
                 metrics[0].data()


### PR DESCRIPTION
The wording in the metrics in `transport_iroh` was changed but the tests were not updated. This was not being caught because the tests were never run via cargo-make.

This PR adds the `--all-features` flag by default when running `cargo make test` and relies on crates to unset it if they want to do something different rather than relying on crates to enable the features. This is actually the way that [cargo-make handles it by default](https://github.com/sagiegurari/cargo-make/blob/95dcc545db8cf08af6fbec524e200e7c80b06027/src/lib/descriptor/makefiles/rust.toml#L415-L425) but the default tasks have been disabled so this doesn't carry through.