### PR TITLE
feat(bootstrap_srv): add TLS security headers to relay HTTP responses

### DIFF
--- a/crates/bootstrap_srv/Cargo.toml
+++ b/crates/bootstrap_srv/Cargo.toml
@@ -20,7 +20,7 @@ axum = { workspace = true, default-features = false, features = [
   "ws",
 ] }
 axum-server = { workspace = true, features = ["tls-rustls-no-provider"] }
-tower-http = { workspace = true, features = ["cors"] }
+tower-http = { workspace = true, features = ["cors", "set-header"] }
 http = { workspace = true }
 rustls = { workspace = true, features = ["ring"] }
 base64 = { workspace = true }

--- a/crates/bootstrap_srv/src/http.rs
+++ b/crates/bootstrap_srv/src/http.rs
@@ -509,6 +509,29 @@ fn tokio_thread(
             #[cfg(feature = "iroh-relay")]
             let relay_allowlist_for_ready = relay_allowlist.clone();
 
+            // Only advertise TLS-related security headers when TLS is
+            // actually terminated here; they would be misleading on a plain
+            // HTTP listener. Values are kept in sync with the headers
+            // upstream `iroh-relay` sets on its own HTTP(S) server. This is
+            // applied last, after every route (including the relay routes
+            // merged in above) has been added, since `Router::layer` only
+            // wraps routes that already exist at the time it's called.
+            if rustls_config.is_some() {
+                app = app
+                    .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+                        http::header::STRICT_TRANSPORT_SECURITY,
+                        HeaderValue::from_static(
+                            "max-age=63072000; includeSubDomains",
+                        ),
+                    ))
+                    .layer(tower_http::set_header::SetResponseHeaderLayer::overriding(
+                        http::header::CONTENT_SECURITY_POLICY,
+                        HeaderValue::from_static(
+                            "default-src 'none'; frame-ancestors 'none'; form-action 'none'; base-uri 'self'; block-all-mixed-content; plugin-types 'none'",
+                        ),
+                    ));
+            }
+
             let app: Router = app
                 .layer(extract::DefaultBodyLimit::max(1024))
                 .with_state(AppState {

--- a/crates/bootstrap_srv/src/test.rs
+++ b/crates/bootstrap_srv/src/test.rs
@@ -941,3 +941,79 @@ fn start_with_tls() {
     .call()
     .unwrap();
 }
+
+#[test]
+fn security_headers_present_with_tls() {
+    // We have mixed features between ring and aws_lc so the "lookup by crate features" doesn't
+    // return a default.
+    // If this is called twice due to parallel tests, ignore result, because it'll fail.
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let cert =
+        rcgen::generate_simple_self_signed(vec!["bootstrap.test".to_string()])
+            .unwrap();
+
+    let cert_dir = tempfile::tempdir().unwrap();
+
+    let cert_path = cert_dir.path().join("test_cert.pem");
+    File::create_new(&cert_path)
+        .unwrap()
+        .write_all(cert.cert.pem().as_bytes())
+        .unwrap();
+
+    let key_path = cert_dir.path().join("test_key.pem");
+    File::create_new(&key_path)
+        .unwrap()
+        .write_all(cert.signing_key.serialize_pem().as_bytes())
+        .unwrap();
+
+    let mut config = Config::testing();
+    config.tls_cert = Some(cert_path);
+    config.tls_key = Some(key_path);
+
+    let s = BootstrapSrv::new(config).unwrap();
+
+    let agent = ureq::Agent::config_builder()
+        .tls_config(
+            ureq::tls::TlsConfig::builder()
+                .disable_verification(true)
+                .build(),
+        )
+        .build()
+        .new_agent();
+
+    let res = agent
+        .get(format!("https://{}/health", s.listen_addrs()[0]))
+        .call()
+        .unwrap();
+
+    assert_eq!(
+        "max-age=63072000; includeSubDomains",
+        res.headers()
+            .get("strict-transport-security")
+            .unwrap()
+            .to_str()
+            .unwrap()
+    );
+    assert_eq!(
+        "default-src 'none'; frame-ancestors 'none'; form-action 'none'; \
+         base-uri 'self'; block-all-mixed-content; plugin-types 'none'",
+        res.headers()
+            .get("content-security-policy")
+            .unwrap()
+            .to_str()
+            .unwrap()
+    );
+}
+
+#[test]
+fn security_headers_absent_without_tls() {
+    let s = BootstrapSrv::new(Config::testing()).unwrap();
+
+    let res = ureq::get(format!("http://{}/health", s.listen_addrs()[0]))
+        .call()
+        .unwrap();
+
+    assert!(!res.headers().contains_key("strict-transport-security"));
+    assert!(!res.headers().contains_key("content-security-policy"));
+}

--- a/crates/bootstrap_srv/src/test/iroh_relay_axum.rs
+++ b/crates/bootstrap_srv/src/test/iroh_relay_axum.rs
@@ -103,6 +103,29 @@ fn use_bootstrap_and_iroh_relay_with_tls() {
     let res: Vec<DecodeAgent> = serde_json::from_str(&res).unwrap();
     assert_eq!(1, res.len());
 
+    // Security headers must reach relay routes too, not just the bootstrap
+    // routes: they are added last so they wrap every route, including the
+    // ones merged in from the relay router.
+    let ping_res = ureq::get(format!("https://{addr}/ping"))
+        .config()
+        .tls_config(
+            ureq::tls::TlsConfig::builder()
+                .disable_verification(true)
+                .build(),
+        )
+        .build()
+        .call()
+        .unwrap();
+    assert_eq!(
+        "max-age=63072000; includeSubDomains",
+        ping_res
+            .headers()
+            .get("strict-transport-security")
+            .unwrap()
+            .to_str()
+            .unwrap()
+    );
+
     create_two_endpoints_and_assert_message_is_received(true, addr);
 }
 


### PR DESCRIPTION
## Summary
- Add `Strict-Transport-Security` and `Content-Security-Policy` response headers to the bootstrap_srv axum server, matching upstream `iroh-relay` 1.0.0's `TLS_HEADERS`.
- Headers are only applied when TLS cert/key are configured (no-op on plain HTTP listeners).
- Applied via `tower_http::set_header::SetResponseHeaderLayer`, added after all routes (including the merged-in relay routes) are registered, so it covers `/health`, `/authenticate`, `/bootstrap/*`, and the relay routes `/relay`, `/ping`, `/generate_204`, `/relay/register`.
- Tests: headers present with TLS on `/health`, absent without TLS, and present on the relay `/ping` route with TLS.

Closes #503

## Test plan
- [x] `cargo fmt --check -p kitsune2_bootstrap_srv`
- [x] `cargo clippy -p kitsune2_bootstrap_srv --all-targets -- --deny=warnings`
- [x] `cargo test -p kitsune2_bootstrap_srv` (53 tests pass)
- [x] `cargo build -p kitsune2_bootstrap_srv --no-default-features` (builds without the `iroh-relay` feature)