### PR TITLE
feat: stabilize authenticated iroh relay hosted in the bootstrap server

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,14 @@ Pick the level based on whether the event is a real problem and whether anyone c
 - **`debug`** — information that would be too noisy for `info` but is still useful when actively debugging.
 - **`trace`** — permitted, but rarely enabled in practice.
 
+### Code conventions
+
+- **Mutex poisoning** — always handle a poisoned mutex with `.expect("poison")`, never with `.unwrap()` or any other message:
+
+  ```rust
+  let guard = mutex.lock().expect("poison");
+  ```
+
 ## Testing strategy
 
 Tests are layered, and you should reach for the fastest, most reliable layer that can meaningfully cover the change. Usually, that means we follow the "testing triangle" with more unit tests than functional test, and more functional tests than integration tests. Almost all code should be unit tested, but it's acceptable for a few integration tests to cover a lot of functionality in one test.

--- a/crates/bootstrap_client/src/lib.rs
+++ b/crates/bootstrap_client/src/lib.rs
@@ -4,7 +4,7 @@
 
 use base64::Engine;
 use kitsune2_api::{AgentInfoSigned, DynVerifier, K2Error, K2Result, SpaceId};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, PoisonError};
 use url::Url;
 
 /// Determine how we should handle an internal request for authorization
@@ -43,13 +43,25 @@ impl AuthMaterial {
         &self.auth_token
     }
 
+    /// Returns the currently cached auth token, if any.
+    pub fn token(&self) -> Option<String> {
+        self.auth_token
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .clone()
+    }
+
     fn priv_authenticate(
         &self,
         auth_url: &str,
         auth_type: AuthType,
     ) -> K2Result<()> {
         if matches!(auth_type, AuthType::IfUninit)
-            && self.auth_token.lock().unwrap().is_some()
+            && self
+                .auth_token
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .is_some()
         {
             return Ok(());
         }
@@ -83,7 +95,11 @@ impl AuthMaterial {
         let auth_token: AuthToken = serde_json::from_str(&token)
             .map_err(|err| K2Error::other_src("Authenticate Failed", err))?;
 
-        *self.auth_token.lock().unwrap() = Some(auth_token.auth_token);
+        *self
+            .auth_token
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner) =
+            Some(auth_token.auth_token);
 
         tracing::debug!("Authentication successful, token acquired");
         Ok(())
@@ -188,8 +204,12 @@ pub fn blocking_put_auth(
         let mut req = ureq::put(put_url);
 
         if let Some(auth_material) = auth_material {
-            let token =
-                auth_material.auth_token.lock().unwrap().clone().unwrap();
+            let token = auth_material
+                .auth_token
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .clone()
+                .expect("authenticated token must be cached");
             req = req.header("Authorization", &format!("Bearer {token}"));
         }
 
@@ -216,20 +236,57 @@ pub fn blocking_put_auth(
     res.into()
 }
 
-/// Register an iroh endpoint public key with the relay on the bootstrap server.
+/// Fetch the bearer token for the relay on the bootstrap server.
 ///
-/// After authenticating (which yields a bearer token), this function registers
-/// the 32-byte iroh public key with the server's relay allowlist so that the
-/// endpoint is permitted to connect to the relay.
+/// The returned token should be presented on the relay WebSocket upgrade via
+/// `RelayConfig::with_auth_token`, which sends it as an
+/// `Authorization: Bearer` header that the relay validates at connect time.
 ///
-/// This function should only be called when the server is configured with an
-/// auth hook server. Open relays do not expose the `relay/register` endpoint,
-/// and registration is not required when the relay has no access restrictions.
+/// A cached token is reused without contacting the server. Operations that
+/// receive a 401 response refresh the token internally before retrying.
 ///
 /// Note the `blocking_` prefix. This is a hint to the caller that if the
 /// function is used in an async context, it should be treated as a blocking
 /// operation.
-pub fn blocking_register_relay_key(
+///
+/// # Errors
+/// Returns an error if the authentication request fails, if the key is
+/// pending approval on the hook server, or if the response is malformed.
+pub fn blocking_fetch_relay_token(
+    mut server_url: Url,
+    auth_material: &AuthMaterial,
+) -> K2Result<String> {
+    server_url.set_path("authenticate");
+    auth_material.priv_authenticate(server_url.as_str(), AuthType::IfUninit)?;
+    auth_material.token().ok_or_else(|| {
+        K2Error::other("authentication succeeded but no token was cached")
+    })
+}
+
+/// Keep an iroh endpoint public key registered with the relay on the
+/// bootstrap server.
+///
+/// After authenticating (which yields a bearer token), this function
+/// registers the 32-byte iroh public key with the server's relay allowlist
+/// so that the endpoint stays permitted to connect to the relay.
+///
+/// The allowlist complements the bearer token presented on the relay
+/// WebSocket upgrade (see [`blocking_fetch_relay_token`]): iroh captures
+/// that token once per relay connection actor and cannot refresh it while
+/// the actor lives, so the allowlist — keyed on the handshake-proven public
+/// key — is what re-admits an actor whose token has gone stale. After a
+/// bootstrap server restart, this call first obtains a fresh token and then
+/// repopulates the allowlist. Call it periodically to keep the entry alive.
+///
+/// This function should only be called when the server is configured with an
+/// auth hook server. Open relays do not expose the `relay/keepalive`
+/// endpoint, and the keepalive is not required when the relay has no access
+/// restrictions.
+///
+/// Note the `blocking_` prefix. This is a hint to the caller that if the
+/// function is used in an async context, it should be treated as a blocking
+/// operation.
+pub fn blocking_relay_keepalive(
     mut server_url: Url,
     auth_material: &AuthMaterial,
     key_bytes: &[u8; 32],
@@ -237,23 +294,28 @@ pub fn blocking_register_relay_key(
     tracing::info!(
         server_url = %server_url,
         iroh_key = %base64::prelude::BASE64_URL_SAFE_NO_PAD.encode(key_bytes),
-        "Registering iroh endpoint key with relay service",
+        "Keeping iroh endpoint key registered with relay service",
     );
 
     server_url.set_path("authenticate");
     let auth_url = server_url.as_str().to_string();
     auth_material.priv_authenticate(&auth_url, AuthType::IfUninit)?;
 
-    server_url.set_path("relay/register");
-    let register_url = server_url.as_str().to_string();
+    server_url.set_path("relay/keepalive");
+    let keepalive_url = server_url.as_str().to_string();
 
-    fn priv_register(
-        register_url: &str,
+    fn priv_keepalive(
+        keepalive_url: &str,
         key_bytes: &[u8; 32],
         auth_material: &AuthMaterial,
     ) -> Res<()> {
-        let token = auth_material.auth_token.lock().unwrap().clone().unwrap();
-        ureq::put(register_url)
+        let token = auth_material
+            .auth_token
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .clone()
+            .expect("authenticated token must be cached");
+        ureq::put(keepalive_url)
             .header("Content-Type", "application/octet-stream")
             .header("Authorization", &format!("Bearer {token}"))
             .send(key_bytes.as_ref())
@@ -261,22 +323,20 @@ pub fn blocking_register_relay_key(
             .into()
     }
 
-    let mut res = priv_register(&register_url, key_bytes, auth_material);
+    let mut res = priv_keepalive(&keepalive_url, key_bytes, auth_material);
 
     if res.needs_auth() {
-        tracing::debug!(
-            "Relay key registration returned 401, re-authenticating"
-        );
+        tracing::debug!("Relay keepalive returned 401, re-authenticating");
         server_url.set_path("authenticate");
         let auth_url = server_url.as_str().to_string();
         auth_material.priv_authenticate(&auth_url, AuthType::Force)?;
-        res = priv_register(&register_url, key_bytes, auth_material);
+        res = priv_keepalive(&keepalive_url, key_bytes, auth_material);
     }
 
     let result: K2Result<()> = res.into();
     match &result {
-        Ok(()) => tracing::info!("Iroh relay key registration succeeded"),
-        Err(e) => tracing::warn!(?e, "Iroh relay key registration failed"),
+        Ok(()) => tracing::info!("Iroh relay keepalive succeeded"),
+        Err(e) => tracing::warn!(?e, "Iroh relay keepalive failed"),
     }
     result
 }
@@ -330,8 +390,12 @@ pub fn blocking_get_auth(
         let mut req = ureq::get(get_url);
 
         if let Some(auth_material) = auth_material {
-            let token =
-                auth_material.auth_token.lock().unwrap().clone().unwrap();
+            let token = auth_material
+                .auth_token
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner)
+                .clone()
+                .expect("authenticated token must be cached");
             req = req.header("Authorization", &format!("Bearer {token}"));
         }
 

--- a/crates/bootstrap_client/tests/integration.rs
+++ b/crates/bootstrap_client/tests/integration.rs
@@ -1,6 +1,6 @@
 use kitsune2_bootstrap_srv::{BootstrapSrv, Config};
 use kitsune2_core::{Ed25519LocalAgent, Ed25519Verifier};
-use kitsune2_test_utils::enable_tracing;
+use kitsune2_test_utils::{auth::AuthHookServer, enable_tracing};
 use std::sync::Arc;
 use url::Url;
 
@@ -108,40 +108,10 @@ fn connect_with_bad_auth_retries() {
 async fn auth_with_real_token_provider() {
     enable_tracing();
 
-    async fn handle_auth(body: bytes::Bytes) -> axum::response::Response {
-        if &body[..] != b"hello" {
-            return axum::response::IntoResponse::into_response((
-                axum::http::StatusCode::UNAUTHORIZED,
-                "Unauthorized",
-            ));
-        }
-        axum::response::IntoResponse::into_response(axum::Json(
-            serde_json::json!({
-                "authToken": "bob",
-            }),
-        ))
-    }
-
-    let app: axum::Router<()> = axum::Router::new()
-        .route("/authenticate", axum::routing::put(handle_auth));
-
-    let h = axum_server::Handle::default();
-    let h2 = h.clone();
-
-    let auth_hook_server_task = tokio::task::spawn(async move {
-        axum_server::bind(([127, 0, 0, 1], 0).into())
-            .handle(h2)
-            .serve(app.into_make_service_with_connect_info::<std::net::SocketAddr>())
-            .await
-            .unwrap();
-    });
-
-    let hook_addr = h.listening().await.unwrap();
-    println!("hook_addr: {hook_addr:?}");
+    let auth_hook = AuthHookServer::spawn(Some(b"hello".to_vec()));
 
     let mut config = Config::testing();
-    let auth_hook_url = format!("http://{hook_addr:?}");
-    config.auth.authentication_hook_server = Some(auth_hook_url.clone());
+    config.auth.authentication_hook_server = Some(auth_hook.url());
 
     config.allowed_origins = Some(vec!["http://localhost".into()]);
 
@@ -171,8 +141,6 @@ async fn auth_with_real_token_provider() {
     tokio::task::block_in_place(|| {
         blocking_put_auth(server_url.clone(), &info, Some(&auth2)).unwrap_err();
     });
-
-    auth_hook_server_task.abort();
 }
 
 /// Test that authentication works using only the relay-independent auth module.
@@ -182,41 +150,11 @@ async fn auth_with_real_token_provider() {
 async fn auth_feature_independent() {
     enable_tracing();
 
-    async fn handle_auth(body: bytes::Bytes) -> axum::response::Response {
-        if &body[..] != b"secret" {
-            return axum::response::IntoResponse::into_response((
-                axum::http::StatusCode::UNAUTHORIZED,
-                "Unauthorized",
-            ));
-        }
-        axum::response::IntoResponse::into_response(axum::Json(
-            serde_json::json!({
-                "authToken": "valid-token-123",
-            }),
-        ))
-    }
-
-    let app: axum::Router<()> = axum::Router::new()
-        .route("/authenticate", axum::routing::put(handle_auth));
-
-    let h = axum_server::Handle::default();
-    let h2 = h.clone();
-
-    let auth_hook_server_task = tokio::task::spawn(async move {
-        axum_server::bind(([127, 0, 0, 1], 0).into())
-            .handle(h2)
-            .serve(app.into_make_service_with_connect_info::<std::net::SocketAddr>())
-            .await
-            .unwrap();
-    });
-
-    let hook_addr = h.listening().await.unwrap();
-    println!("hook_addr: {hook_addr:?}");
+    let auth_hook = AuthHookServer::spawn(Some(b"secret".to_vec()));
 
     let mut config = Config::testing();
     // Configure the relay-independent auth module via config.auth.
-    config.auth.authentication_hook_server =
-        Some(format!("http://{hook_addr:?}"));
+    config.auth.authentication_hook_server = Some(auth_hook.url());
     // Disable the relay server entirely - we're only testing HTTP bootstrap endpoints
     config.no_relay_server = true;
     config.allowed_origins = Some(vec!["http://localhost".into()]);
@@ -283,8 +221,6 @@ async fn auth_feature_independent() {
         )
         .unwrap_err();
     });
-
-    auth_hook_server_task.abort();
 }
 
 /// Test that the client re-authenticates when the server returns 401
@@ -293,39 +229,10 @@ async fn auth_feature_independent() {
 async fn reauth_on_token_expiration() {
     enable_tracing();
 
-    async fn handle_auth(body: bytes::Bytes) -> axum::response::Response {
-        if &body[..] != b"secret" {
-            return axum::response::IntoResponse::into_response((
-                axum::http::StatusCode::UNAUTHORIZED,
-                "Unauthorized",
-            ));
-        }
-        axum::response::IntoResponse::into_response(axum::Json(
-            serde_json::json!({
-                "authToken": "valid-token",
-            }),
-        ))
-    }
-
-    let app: axum::Router<()> = axum::Router::new()
-        .route("/authenticate", axum::routing::put(handle_auth));
-
-    let h = axum_server::Handle::default();
-    let h2 = h.clone();
-
-    let auth_hook_server_task = tokio::task::spawn(async move {
-        axum_server::bind(([127, 0, 0, 1], 0).into())
-            .handle(h2)
-            .serve(app.into_make_service_with_connect_info::<std::net::SocketAddr>())
-            .await
-            .unwrap();
-    });
-
-    let hook_addr = h.listening().await.unwrap();
+    let auth_hook = AuthHookServer::spawn(Some(b"secret".to_vec()));
 
     let mut config = Config::testing();
-    config.auth.authentication_hook_server =
-        Some(format!("http://{hook_addr:?}"));
+    config.auth.authentication_hook_server = Some(auth_hook.url());
     // Set a very short token timeout so we can test expiration
     config.auth.auth_token_idle_timeout = std::time::Duration::from_millis(200);
     config.no_relay_server = true;
@@ -366,6 +273,31 @@ async fn reauth_on_token_expiration() {
         assert_eq!(1, infos.len());
         assert_eq!(info, infos[0]);
     });
+}
 
-    auth_hook_server_task.abort();
+#[test]
+fn fetch_relay_token_authenticates_and_caches() {
+    enable_tracing();
+
+    let auth_hook = AuthHookServer::spawn(Some(b"material".to_vec()));
+    let mut config = Config::testing();
+    config.auth.authentication_hook_server = Some(auth_hook.url());
+    config.no_relay_server = true;
+    let server =
+        BootstrapSrv::new(config).expect("bootstrap server should start");
+    let server_url =
+        Url::parse(&format!("http://{}", server.listen_addrs()[0]))
+            .expect("bootstrap server URL should parse");
+
+    let auth = AuthMaterial::new(b"material".to_vec());
+
+    let tok1 = blocking_fetch_relay_token(server_url.clone(), &auth)
+        .expect("first fetch should succeed");
+    assert_eq!(tok1, "test-auth-token-1");
+    assert_eq!(auth.token().as_deref(), Some("test-auth-token-1"));
+
+    let tok2 = blocking_fetch_relay_token(server_url, &auth)
+        .expect("cached fetch should succeed");
+    assert_eq!(tok2, "test-auth-token-1");
+    assert_eq!(auth_hook.request_count(), 1);
 }

--- a/crates/bootstrap_srv/src/auth.rs
+++ b/crates/bootstrap_srv/src/auth.rs
@@ -120,6 +120,12 @@ impl AuthTokenTracker {
         });
         expired
     }
+
+    /// Returns a token's last-used timestamp for unit-test assertions.
+    #[cfg(test)]
+    pub(crate) fn last_used(&self, token: &str) -> Option<Instant> {
+        self.tokens.lock().unwrap().get(token).copied()
+    }
 }
 
 /// Errors that can occur during authentication.

--- a/crates/bootstrap_srv/src/http.rs
+++ b/crates/bootstrap_srv/src/http.rs
@@ -240,6 +240,8 @@ pub struct Server {
     auth_tracker: crate::auth::AuthTokenTracker,
     #[cfg(feature = "iroh-relay")]
     relay_allowlist: Option<crate::RelayAllowlist>,
+    #[cfg(feature = "iroh-relay")]
+    relay_conn_tracker: Option<crate::RelayConnTracker>,
     /// Held to keep the QAD server task alive; dropped on shutdown.
     #[cfg(feature = "iroh-relay")]
     _qad_server: Option<iroh_relay::server::Server>,
@@ -280,6 +282,8 @@ impl Server {
                 #[cfg(feature = "iroh-relay")]
                 relay_allowlist,
                 #[cfg(feature = "iroh-relay")]
+                relay_conn_tracker,
+                #[cfg(feature = "iroh-relay")]
                 qad_server,
             })) => Ok(Self {
                 t_join: Some(t_join),
@@ -291,6 +295,8 @@ impl Server {
                 auth_tracker,
                 #[cfg(feature = "iroh-relay")]
                 relay_allowlist,
+                #[cfg(feature = "iroh-relay")]
+                relay_conn_tracker,
                 #[cfg(feature = "iroh-relay")]
                 _qad_server: qad_server,
             }),
@@ -315,6 +321,11 @@ impl Server {
     pub fn relay_allowlist(&self) -> Option<&crate::RelayAllowlist> {
         self.relay_allowlist.as_ref()
     }
+
+    #[cfg(feature = "iroh-relay")]
+    pub fn relay_conn_tracker(&self) -> Option<&crate::RelayConnTracker> {
+        self.relay_conn_tracker.as_ref()
+    }
 }
 
 struct Ready {
@@ -326,6 +337,8 @@ struct Ready {
     auth_tracker: crate::auth::AuthTokenTracker,
     #[cfg(feature = "iroh-relay")]
     relay_allowlist: Option<crate::RelayAllowlist>,
+    #[cfg(feature = "iroh-relay")]
+    relay_conn_tracker: Option<crate::RelayConnTracker>,
     #[cfg(feature = "iroh-relay")]
     qad_server: Option<iroh_relay::server::Server>,
 }
@@ -456,6 +469,14 @@ fn tokio_thread(
                     None
                 };
 
+            // Tracks which auth token backs each live relay connection so
+            // the prune worker can keep those tokens from idle-expiring.
+            #[cfg(feature = "iroh-relay")]
+            let relay_conn_tracker: Option<crate::RelayConnTracker> =
+                relay_allowlist
+                    .as_ref()
+                    .map(|_| crate::RelayConnTracker::default());
+
             // Declare outside the `if` block so the guard lives until the
             // server futures complete.  Dropping it earlier would
             // unregister the OTEL observable-counter callbacks.
@@ -466,8 +487,8 @@ fn tokio_thread(
                 #[cfg(feature = "iroh-relay")]
                 {
                     app = app.route(
-                        "/relay/register",
-                        routing::put(handle_relay_register),
+                        "/relay/keepalive",
+                        routing::put(handle_relay_keepalive),
                     );
 
                     let relay_rate_limit = config
@@ -478,7 +499,13 @@ fn tokio_thread(
                         );
                     let relay_state =
                         if let Some(allowlist) = relay_allowlist.clone() {
-                            crate::iroh_relay_axum::create_relay_state_with_allowlist(
+                            let conn_tracker = relay_conn_tracker
+                                .clone()
+                                .expect("created together with the allowlist");
+                            crate::iroh_relay_axum::create_relay_state_with_auth(
+                                config.auth.clone(),
+                                auth_tracker.clone(),
+                                conn_tracker,
                                 allowlist,
                                 relay_rate_limit,
                             )
@@ -660,6 +687,8 @@ fn tokio_thread(
                     #[cfg(feature = "iroh-relay")]
                     relay_allowlist: relay_allowlist_for_ready,
                     #[cfg(feature = "iroh-relay")]
+                    relay_conn_tracker,
+                    #[cfg(feature = "iroh-relay")]
                     qad_server,
                 }))
                 .is_err()
@@ -819,12 +848,12 @@ async fn handle_boot_put(
 }
 
 #[cfg(feature = "iroh-relay")]
-async fn handle_relay_register(
+async fn handle_relay_keepalive(
     extract::State(state): extract::State<AppState>,
     headers: axum::http::HeaderMap,
     body: bytes::Bytes,
 ) -> response::Response {
-    tracing::debug!(body_len = body.len(), "Relay register request received");
+    tracing::debug!(body_len = body.len(), "Relay keepalive request received");
 
     // Validate bearer token
     let token: Option<Arc<str>> = headers
@@ -834,7 +863,7 @@ async fn handle_relay_register(
         .map(<Arc<str>>::from);
 
     if !state.auth_tracker.is_valid(&token, &state.auth_config) {
-        tracing::warn!("Relay register: bearer token invalid or missing");
+        tracing::warn!("Relay keepalive: bearer token invalid or missing");
         return axum::response::IntoResponse::into_response((
             axum::http::StatusCode::UNAUTHORIZED,
             "Unauthorized",
@@ -847,7 +876,7 @@ async fn handle_relay_register(
         Err(_) => {
             tracing::warn!(
                 body_len = body.len(),
-                "Relay register: expected 32 bytes"
+                "Relay keepalive: expected 32 bytes"
             );
             return axum::response::IntoResponse::into_response((
                 axum::http::StatusCode::BAD_REQUEST,
@@ -859,7 +888,7 @@ async fn handle_relay_register(
     let key = match iroh_base::PublicKey::from_bytes(key_bytes) {
         Ok(k) => k,
         Err(_) => {
-            tracing::warn!("Relay register: invalid public key bytes");
+            tracing::warn!("Relay keepalive: invalid public key bytes");
             return axum::response::IntoResponse::into_response((
                 axum::http::StatusCode::BAD_REQUEST,
                 "Invalid public key bytes",
@@ -881,11 +910,11 @@ async fn handle_relay_register(
         allowlist.register(key, token);
         tracing::info!(
             key = %key.fmt_short(),
-            "Relay register: key added to allowlist"
+            "Relay keepalive: key added to allowlist"
         );
     } else {
         tracing::warn!(
-            "Relay register: no allowlist configured, registration has no effect"
+            "Relay keepalive: no allowlist configured, registration has no effect"
         );
     }
 

--- a/crates/bootstrap_srv/src/iroh_relay_axum.rs
+++ b/crates/bootstrap_srv/src/iroh_relay_axum.rs
@@ -26,8 +26,7 @@ use iroh_relay::{
     ExportKeyingMaterial, KeyCache,
     protos::{handshake, streams::StreamError},
     server::{
-        Access, AccessControl, AllowAll, ClientRequest, DynAccessControl,
-        Metrics,
+        AllowAll, ClientRequest, DynAccessControl, Metrics,
         client::Config,
         clients::Clients,
         streams::{Bucket, RelayedStream},
@@ -510,52 +509,27 @@ pub fn create_relay_state(
     RelayState::new(key_cache, access, metrics, rate_limit)
 }
 
-struct AllowlistAccess {
-    allowlist: RelayAllowlist,
-}
-
-impl AllowlistAccess {
-    fn new(allowlist: RelayAllowlist) -> Self {
-        Self { allowlist }
-    }
-}
-
-impl std::fmt::Debug for AllowlistAccess {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("AllowlistAccess").finish()
-    }
-}
-
-impl AccessControl for AllowlistAccess {
-    async fn on_connect(&self, request: &ClientRequest) -> Access {
-        let endpoint_id = request.endpoint_id();
-        let allowed = self.allowlist.is_allowed(&endpoint_id);
-        tracing::debug!(
-            key = %endpoint_id.fmt_short(),
-            allowed,
-            allowlist_size = self.allowlist.len(),
-            "Relay access check"
-        );
-        if allowed {
-            Access::Allow
-        } else {
-            Access::Deny { reason: None }
-        }
-    }
-}
-
-/// Creates a RelayState that restricts connections to endpoints registered
-/// in the provided allowlist.
+/// Creates a RelayState that restricts connections to clients presenting a
+/// valid bearer token on the WebSocket upgrade (`Authorization: Bearer`),
+/// with a recovery fallback to the `PUT /relay/keepalive` allowlist for
+/// clients whose token went stale.
 ///
 /// Use this when the bootstrap server is configured with an authentication
-/// hook server. Clients must call `PUT /authenticate` and then
-/// `PUT /relay/register` before their relay connection will be accepted.
-pub fn create_relay_state_with_allowlist(
+/// hook server.
+pub fn create_relay_state_with_auth(
+    auth_config: crate::AuthConfig,
+    auth_tracker: crate::AuthTokenTracker,
+    conn_tracker: crate::RelayConnTracker,
     allowlist: RelayAllowlist,
     rate_limit: Option<RelayClientRxRateLimit>,
 ) -> RelayState {
     let key_cache = KeyCache::new(1024);
-    let access = Arc::new(AllowlistAccess::new(allowlist));
+    let access = Arc::new(crate::TokenAccess::new(
+        auth_config,
+        auth_tracker,
+        conn_tracker,
+        allowlist,
+    ));
     let metrics = Arc::new(Metrics::default());
     RelayState::new(key_cache, access, metrics, rate_limit)
 }

--- a/crates/bootstrap_srv/src/lib.rs
+++ b/crates/bootstrap_srv/src/lib.rs
@@ -225,6 +225,11 @@ mod relay_allowlist;
 pub use relay_allowlist::*;
 
 #[cfg(feature = "iroh-relay")]
+mod relay_access;
+#[cfg(feature = "iroh-relay")]
+pub use relay_access::*;
+
+#[cfg(feature = "iroh-relay")]
 pub mod iroh_relay_axum;
 
 #[cfg(feature = "iroh-relay")]

--- a/crates/bootstrap_srv/src/relay_access.rs
+++ b/crates/bootstrap_srv/src/relay_access.rs
@@ -1,0 +1,315 @@
+//! Bearer-token access control for the embedded iroh relay.
+//!
+//! Replicates upstream iroh's authenticated-relay model: the client presents
+//! its auth token as an `Authorization: Bearer` header on the relay WebSocket
+//! upgrade (set via `RelayConfig::with_auth_token` on the client side), and
+//! the server validates it once per connection in
+//! [`AccessControl::on_connect`].
+//!
+//! Validation goes through [`AuthTokenTracker::is_valid`], which also
+//! refreshes the token's last-used timestamp, so every relay (re)connect
+//! keeps the token alive. [`RelayConnTracker`] additionally records which
+//! token backs each live connection so the prune worker can keep tokens
+//! with open relay connections from idle-expiring.
+
+use crate::auth::{AuthConfig, AuthTokenTracker};
+use crate::relay_allowlist::RelayAllowlist;
+use iroh_base::EndpointId;
+use iroh_relay::server::{Access, AccessControl, ClientRequest, ConnectionId};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, PoisonError};
+
+/// Tracks which bearer token authorized each live relay connection.
+#[derive(Clone, Debug, Default)]
+pub struct RelayConnTracker {
+    // ConnectionId is process-unique (guaranteed upstream), so it is safe to
+    // use as a key here; multiple connections may share one token.
+    conns: Arc<Mutex<HashMap<ConnectionId, Arc<str>>>>,
+}
+
+impl RelayConnTracker {
+    fn insert(&self, id: ConnectionId, token: Arc<str>) {
+        self.conns
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .insert(id, token);
+    }
+
+    fn remove(&self, id: ConnectionId) {
+        self.conns
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .remove(&id);
+    }
+
+    /// Tokens that back at least one live relay connection, deduplicated.
+    pub fn live_tokens(&self) -> Vec<Arc<str>> {
+        let conns = self.conns.lock().unwrap_or_else(PoisonError::into_inner);
+        let mut tokens: Vec<Arc<str>> = conns.values().cloned().collect();
+        tokens.sort();
+        tokens.dedup();
+        tokens
+    }
+}
+
+/// Relay access control gating connections on a valid bearer token.
+///
+/// Falls back to the public-key allowlist populated via
+/// `PUT /relay/keepalive` when the presented token is stale. iroh captures
+/// the token once per relay connection actor and cannot refresh it while
+/// the actor lives, so this recovery path is what re-admits an actor whose
+/// token expired. It can be removed once iroh supports refreshing the token
+/// on a live connection.
+pub struct TokenAccess {
+    auth_config: AuthConfig,
+    auth_tracker: AuthTokenTracker,
+    conns: RelayConnTracker,
+    recovery_allowlist: RelayAllowlist,
+}
+
+impl TokenAccess {
+    /// Create a new token-based access control.
+    pub fn new(
+        auth_config: AuthConfig,
+        auth_tracker: AuthTokenTracker,
+        conns: RelayConnTracker,
+        recovery_allowlist: RelayAllowlist,
+    ) -> Self {
+        Self {
+            auth_config,
+            auth_tracker,
+            conns,
+            recovery_allowlist,
+        }
+    }
+}
+
+impl std::fmt::Debug for TokenAccess {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TokenAccess").finish()
+    }
+}
+
+impl AccessControl for TokenAccess {
+    async fn on_connect(&self, request: &ClientRequest) -> Access {
+        if let Some(token) = request.auth_token() {
+            let token: Arc<str> = Arc::from(token);
+            if self
+                .auth_tracker
+                .is_valid(&Some(token.clone()), &self.auth_config)
+            {
+                self.conns.insert(request.connection_id(), token);
+                tracing::debug!(
+                    key = %request.endpoint_id().fmt_short(),
+                    "Relay access granted via bearer token"
+                );
+                return Access::Allow;
+            }
+
+            // Iroh cannot replace a stale token on the live relay actor, so
+            // admit it by its handshake-proven public key when a keepalive
+            // has registered the key. Connections without a token are never
+            // admitted this way.
+            if self.recovery_allowlist.is_allowed(&request.endpoint_id()) {
+                tracing::debug!(
+                    key = %request.endpoint_id().fmt_short(),
+                    "Relay access granted via recovery allowlist"
+                );
+                return Access::Allow;
+            }
+        }
+
+        tracing::debug!(
+            key = %request.endpoint_id().fmt_short(),
+            "Relay access denied"
+        );
+        Access::Deny {
+            reason: Some("not authorized".to_string()),
+        }
+    }
+
+    fn on_disconnect(
+        &self,
+        _endpoint_id: EndpointId,
+        connection_id: ConnectionId,
+    ) {
+        self.conns.remove(connection_id);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::auth::{AuthConfig, AuthTokenTracker};
+    use crate::relay_allowlist::RelayAllowlist;
+    use iroh_base::SecretKey;
+    use iroh_relay::http::ProtocolVersion;
+    use iroh_relay::server::{Access, ClientRequest};
+    use std::sync::Arc;
+
+    fn auth_config() -> AuthConfig {
+        AuthConfig {
+            authentication_hook_server: Some("http://example.com".into()),
+            auth_token_idle_timeout: std::time::Duration::from_secs(300),
+        }
+    }
+
+    fn client_request(key: &SecretKey, bearer: Option<&str>) -> ClientRequest {
+        let mut builder = http::Request::builder()
+            .method(http::Method::GET)
+            .uri("https://relay.test/relay");
+        if let Some(token) = bearer {
+            builder = builder
+                .header(http::header::AUTHORIZATION, format!("Bearer {token}"));
+        }
+        let parts = builder.body(()).unwrap().into_parts().0;
+        ClientRequest::new(key.public(), ProtocolVersion::V2, parts)
+    }
+
+    /// Mint a fresh, process-unique `ConnectionId` for tests.
+    ///
+    /// `ConnectionId` has no public constructor; a new one is assigned to
+    /// every `ClientRequest`, so build a throwaway request and take its id.
+    fn test_connection_id() -> ConnectionId {
+        client_request(&SecretKey::generate(), None).connection_id()
+    }
+
+    #[test]
+    fn live_tokens_survive_prune_refresh() {
+        let config = AuthConfig {
+            authentication_hook_server: Some("http://example.com".into()),
+            auth_token_idle_timeout: std::time::Duration::from_millis(100),
+        };
+        let tracker = AuthTokenTracker::default();
+        tracker.register_token("live-tok".into());
+        tracker.register_token("idle-tok".into());
+
+        let conns = RelayConnTracker::default();
+        conns.insert(test_connection_id(), "live-tok".into());
+
+        std::thread::sleep(std::time::Duration::from_millis(150));
+
+        // Mirrors the prune worker: refresh live tokens, then prune.
+        for token in conns.live_tokens() {
+            tracker.register_token(token);
+        }
+        let expired = tracker.prune_expired(&config);
+
+        assert_eq!(expired, vec![Arc::<str>::from("idle-tok")]);
+        assert!(tracker.is_valid(&Some("live-tok".into()), &config));
+    }
+
+    #[tokio::test]
+    async fn valid_token_is_allowed_and_tracked() {
+        let tracker = AuthTokenTracker::default();
+        tracker.register_token("tok-1".into());
+        let conns = RelayConnTracker::default();
+        let access = TokenAccess::new(
+            auth_config(),
+            tracker,
+            conns.clone(),
+            RelayAllowlist::default(),
+        );
+
+        let req = client_request(&SecretKey::generate(), Some("tok-1"));
+        assert!(matches!(access.on_connect(&req).await, Access::Allow));
+        assert_eq!(conns.live_tokens(), vec![Arc::<str>::from("tok-1")]);
+    }
+
+    #[tokio::test]
+    async fn missing_or_invalid_token_is_denied_with_reason() {
+        let access = TokenAccess::new(
+            auth_config(),
+            AuthTokenTracker::default(),
+            RelayConnTracker::default(),
+            RelayAllowlist::default(),
+        );
+
+        for bearer in [None, Some("unknown-token")] {
+            let req = client_request(&SecretKey::generate(), bearer);
+            match access.on_connect(&req).await {
+                Access::Deny { reason } => {
+                    assert_eq!(reason.as_deref(), Some("not authorized"))
+                }
+                Access::Allow => panic!("must deny"),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn registered_key_with_stale_token_is_allowed() {
+        let allowlist = RelayAllowlist::default();
+        let key = SecretKey::generate();
+        allowlist.register(key.public(), "fresh-tok".into());
+        let access = TokenAccess::new(
+            auth_config(),
+            AuthTokenTracker::default(),
+            RelayConnTracker::default(),
+            allowlist,
+        );
+
+        // The actor still presents an expired token, so recovery must admit
+        // it by its registered public key.
+        let req = client_request(&key, Some("stale-tok"));
+        assert!(matches!(access.on_connect(&req).await, Access::Allow));
+    }
+
+    #[tokio::test]
+    async fn registered_key_without_token_is_denied() {
+        let allowlist = RelayAllowlist::default();
+        let key = SecretKey::generate();
+        allowlist.register(key.public(), "fresh-tok".into());
+        let access = TokenAccess::new(
+            auth_config(),
+            AuthTokenTracker::default(),
+            RelayConnTracker::default(),
+            allowlist,
+        );
+
+        // Recovery only applies to actors that present a (stale) token;
+        // a connection with no token at all is denied even when the key
+        // is registered.
+        let req = client_request(&key, None);
+        assert!(matches!(access.on_connect(&req).await, Access::Deny { .. }));
+    }
+
+    #[tokio::test]
+    async fn disconnect_removes_live_token() {
+        let tracker = AuthTokenTracker::default();
+        tracker.register_token("tok-1".into());
+        let conns = RelayConnTracker::default();
+        let access = TokenAccess::new(
+            auth_config(),
+            tracker,
+            conns.clone(),
+            RelayAllowlist::default(),
+        );
+
+        let key = SecretKey::generate();
+        let req = client_request(&key, Some("tok-1"));
+        access.on_connect(&req).await;
+        access.on_disconnect(req.endpoint_id(), req.connection_id());
+        assert!(conns.live_tokens().is_empty());
+    }
+
+    #[tokio::test]
+    async fn on_connect_refreshes_token_last_used() {
+        let tracker = AuthTokenTracker::default();
+        tracker.register_token("tok-1".into());
+        let last_used_before = tracker.last_used("tok-1").unwrap();
+        let access = TokenAccess::new(
+            auth_config(),
+            tracker.clone(),
+            RelayConnTracker::default(),
+            RelayAllowlist::default(),
+        );
+
+        // Ensure the monotonic clock advances before on_connect refreshes it.
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        let req = client_request(&SecretKey::generate(), Some("tok-1"));
+        assert!(matches!(access.on_connect(&req).await, Access::Allow));
+        let last_used_after = tracker.last_used("tok-1").unwrap();
+
+        assert!(last_used_after > last_used_before);
+    }
+}

--- a/crates/bootstrap_srv/src/relay_allowlist.rs
+++ b/crates/bootstrap_srv/src/relay_allowlist.rs
@@ -6,10 +6,12 @@ use std::sync::{Arc, Mutex};
 /// that was used to register them.
 ///
 /// When the bootstrap server is configured with an authentication hook
-/// server, the relay endpoint uses this allowlist (via `AccessConfig::Restricted`)
-/// to gate relay connections. A client must first call `PUT /authenticate`
-/// to obtain a bearer token and then `PUT /relay/register` to register
-/// its iroh public key before it will be permitted to connect to the relay.
+/// server, the relay validates the bearer token presented on the WebSocket
+/// upgrade, and falls back to this allowlist for recovery: iroh cannot
+/// refresh the token on a live relay connection actor, so an actor whose
+/// token went stale is re-admitted by its handshake-proven public key.
+/// Clients keep their entry alive by periodically calling
+/// `PUT /relay/keepalive` with a valid bearer token.
 #[derive(Clone, Default)]
 pub struct RelayAllowlist {
     entries: Arc<Mutex<HashMap<PublicKey, Arc<str>>>>,

--- a/crates/bootstrap_srv/src/server.rs
+++ b/crates/bootstrap_srv/src/server.rs
@@ -16,6 +16,8 @@ const EXPIRES_AT_DURATION_MAX_ALLOWED_MICROS: i64 =
 
 type OnTokensPruned = Option<Box<dyn Fn(&[Arc<str>]) + Send>>;
 
+type LiveRelayTokens = Option<Box<dyn Fn() -> Vec<Arc<str>> + Send>>;
+
 /// Print out a message if this thread dies.
 struct ThreadGuard(&'static str);
 
@@ -121,6 +123,18 @@ impl BootstrapSrv {
         #[cfg(not(feature = "iroh-relay"))]
         let on_tokens_pruned: OnTokensPruned = None;
 
+        // Tokens backing live relay connections are in active use even when
+        // no HTTP request has touched them: report them so the prune worker
+        // can refresh them before pruning.
+        #[cfg(feature = "iroh-relay")]
+        let live_relay_tokens: LiveRelayTokens =
+            server.relay_conn_tracker().cloned().map(|tracker| {
+                Box::new(move || tracker.live_tokens())
+                    as Box<dyn Fn() -> Vec<Arc<str>> + Send>
+            });
+        #[cfg(not(feature = "iroh-relay"))]
+        let live_relay_tokens: LiveRelayTokens = None;
+
         workers.push(std::thread::spawn(move || {
             prune_worker(
                 config,
@@ -128,6 +142,7 @@ impl BootstrapSrv {
                 prune_space_map,
                 prune_auth_tracker,
                 on_tokens_pruned,
+                live_relay_tokens,
             )
         }));
 
@@ -183,6 +198,7 @@ fn prune_worker(
     space_map: crate::SpaceMap,
     auth_tracker: crate::auth::AuthTokenTracker,
     on_tokens_pruned: OnTokensPruned,
+    live_relay_tokens: LiveRelayTokens,
 ) -> std::io::Result<()> {
     let _g = ThreadGuard("prune_worker thread has ended");
 
@@ -196,6 +212,15 @@ fn prune_worker(
 
             // Prune expired space infos
             space_map.update_all(config.max_entries_per_space);
+
+            // Tokens backing live relay connections are in active use even
+            // when no HTTP request has touched them: refresh so they don't
+            // idle-expire underneath an open relay connection.
+            if let Some(live_tokens) = &live_relay_tokens {
+                for token in live_tokens() {
+                    auth_tracker.register_token(token);
+                }
+            }
 
             // Prune expired auth tokens, collecting the list of expired tokens
             // so dependent subsystems (e.g. the relay allowlist) can clean up too.

--- a/crates/bootstrap_srv/src/test/iroh_relay_axum.rs
+++ b/crates/bootstrap_srv/src/test/iroh_relay_axum.rs
@@ -1,7 +1,7 @@
 use super::*;
 use iroh::endpoint::presets::Minimal;
 use iroh::{EndpointAddr, RelayConfig, RelayMap, RelayUrl, SecretKey};
-use kitsune2_test_utils::enable_tracing;
+use kitsune2_test_utils::{auth::AuthHookServer, enable_tracing};
 use std::{net::SocketAddr, str::FromStr, sync::Arc, time::Duration};
 
 const TEST_ALPN: &[u8] = b"alpn";
@@ -129,56 +129,44 @@ fn use_bootstrap_and_iroh_relay_with_tls() {
     create_two_endpoints_and_assert_message_is_received(true, addr);
 }
 
-#[test]
-fn use_bootstrap_and_iroh_relay_with_auth() {
-    enable_tracing();
-    let _ = rustls::crypto::ring::default_provider().install_default();
-
-    // Start a fake authentication hook server in its own thread and runtime.
-    // BootstrapSrv creates its own multi-thread tokio runtime internally, so
-    // we keep the fake hook server isolated in a separate runtime.
-    let (auth_addr_tx, auth_addr_rx) = std::sync::mpsc::channel();
-    let _auth_server = std::thread::spawn(move || {
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_io()
-            .enable_time()
-            .build()
-            .unwrap();
-        rt.block_on(async {
-            let listener =
-                tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-            let addr = listener.local_addr().unwrap();
-            let _ = auth_addr_tx.send(addr);
-
-            let app = axum::Router::new().route(
-                "/authenticate",
-                axum::routing::put(|| async {
-                    axum::Json(
-                        serde_json::json!({"authToken": "iroh-relay-test-token"}),
-                    )
-                }),
-            );
-            let _ = axum::serve(listener, app).await;
-        });
-    });
-
-    let auth_addr = auth_addr_rx
-        .recv_timeout(std::time::Duration::from_secs(5))
-        .expect("auth hook server did not start in time");
-    let hook_url = format!("http://{auth_addr}");
-
-    let s = BootstrapSrv::new(Config {
+fn start_authenticated_bootstrap_srv() -> (BootstrapSrv, AuthHookServer) {
+    let auth_hook = AuthHookServer::spawn(None);
+    let server = BootstrapSrv::new(Config {
         prune_interval: std::time::Duration::from_millis(5),
         auth: crate::auth::AuthConfig {
-            authentication_hook_server: Some(hook_url),
+            authentication_hook_server: Some(auth_hook.url()),
             ..Default::default()
         },
         ..Config::testing()
     })
     .unwrap();
+    (server, auth_hook)
+}
+
+#[test]
+fn use_bootstrap_and_iroh_relay_with_auth() {
+    enable_tracing();
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let (s, _auth_hook) = start_authenticated_bootstrap_srv();
     let addr = s.listen_addrs()[0];
 
-    create_two_authenticated_endpoints_and_assert_message_is_received(addr);
+    create_two_authenticated_endpoints_and_assert_message_is_received(
+        addr, false,
+    );
+}
+
+#[test]
+fn use_bootstrap_and_iroh_relay_recovers_with_stale_token() {
+    enable_tracing();
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let (s, _auth_hook) = start_authenticated_bootstrap_srv();
+    let addr = s.listen_addrs()[0];
+
+    create_two_authenticated_endpoints_and_assert_message_is_received(
+        addr, true,
+    );
 }
 
 #[test]
@@ -186,45 +174,7 @@ fn use_bootstrap_and_iroh_relay_auth_rejects_unregistered() {
     enable_tracing();
     let _ = rustls::crypto::ring::default_provider().install_default();
 
-    let (auth_addr_tx, auth_addr_rx) = std::sync::mpsc::channel();
-    let _auth_server = std::thread::spawn(move || {
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_io()
-            .enable_time()
-            .build()
-            .unwrap();
-        rt.block_on(async {
-            let listener =
-                tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-            let addr = listener.local_addr().unwrap();
-            let _ = auth_addr_tx.send(addr);
-
-            let app = axum::Router::new().route(
-                "/authenticate",
-                axum::routing::put(|| async {
-                    axum::Json(
-                        serde_json::json!({"authToken": "iroh-relay-test-token"}),
-                    )
-                }),
-            );
-            let _ = axum::serve(listener, app).await;
-        });
-    });
-
-    let auth_addr = auth_addr_rx
-        .recv_timeout(Duration::from_secs(5))
-        .expect("auth hook server did not start in time");
-    let hook_url = format!("http://{auth_addr}");
-
-    let s = BootstrapSrv::new(Config {
-        prune_interval: std::time::Duration::from_millis(5),
-        auth: crate::auth::AuthConfig {
-            authentication_hook_server: Some(hook_url),
-            ..Default::default()
-        },
-        ..Config::testing()
-    })
-    .unwrap();
+    let (s, _auth_hook) = start_authenticated_bootstrap_srv();
     let addr = s.listen_addrs()[0];
 
     assert_authenticated_relay_rejects_unregistered(addr);
@@ -257,31 +207,14 @@ fn assert_authenticated_relay_rejects_unregistered(addr: SocketAddr) {
         let ep_2 = build_endpoint(ep_2_secret).bind().await.unwrap();
         let ep_3 = build_endpoint(ep_3_secret).bind().await.unwrap();
 
-        let authenticate_and_register = |key_bytes: [u8; 32]| async move {
-            let token_resp = ureq::put(&format!("http://{addr}/authenticate"))
-                .send(b"test-auth-material".as_ref())
-                .unwrap()
-                .into_body()
-                .read_to_string()
-                .unwrap();
-            let token = serde_json::from_str::<serde_json::Value>(&token_resp)
-                .unwrap()["authToken"]
-                .as_str()
-                .unwrap()
-                .to_owned();
-            ureq::put(&format!("http://{addr}/relay/register"))
-                .header("Authorization", &format!("Bearer {token}"))
-                .send(key_bytes.as_ref())
-                .unwrap();
-        };
+        // ep_1 and ep_2 authenticate and present the bearer token on the
+        // relay WebSocket upgrade.
+        let token = fetch_auth_token(addr);
 
-        authenticate_and_register(*ep_1.id().as_bytes()).await;
-        authenticate_and_register(*ep_2.id().as_bytes()).await;
-
-        // ep_3 attempts registration with the correct key but an invalid bearer
-        // token. Assert the server rejects it with 401; ep_3 remains absent
-        // from the allowlist.
-        let err = ureq::put(&format!("http://{addr}/relay/register"))
+        // ep_3 attempts a relay keepalive with an invalid bearer token.
+        // Assert the server rejects it with 401; ep_3 remains absent from
+        // the allowlist.
+        let err = ureq::put(&format!("http://{addr}/relay/keepalive"))
             .header("Authorization", "Bearer invalid-token")
             .send(ep_3.id().as_bytes().as_ref())
             .unwrap_err();
@@ -293,21 +226,27 @@ fn assert_authenticated_relay_rejects_unregistered(addr: SocketAddr) {
             "expected 401 Unauthorized, got {err:?}"
         );
 
-        let relay_cfg = Arc::new(RelayConfig::new(
+        let auth_relay_cfg = Arc::new(
+            RelayConfig::new(relay_url.clone(), None)
+                .with_auth_token(token),
+        );
+        // ep_3 has no token and no registered key.
+        let anon_relay_cfg = Arc::new(RelayConfig::new(
             relay_url.clone(),
             None,
         ));
-        ep_1.insert_relay(relay_url.clone(), relay_cfg.clone()).await;
-        ep_2.insert_relay(relay_url.clone(), relay_cfg.clone()).await;
-        ep_3.insert_relay(relay_url.clone(), relay_cfg.clone()).await;
+        ep_1.insert_relay(relay_url.clone(), auth_relay_cfg.clone()).await;
+        ep_2.insert_relay(relay_url.clone(), auth_relay_cfg.clone()).await;
+        ep_3.insert_relay(relay_url.clone(), anon_relay_cfg.clone()).await;
 
         let ep_1_addr =
             EndpointAddr::new(ep_1.id()).with_relay_url(relay_url.clone());
         let ep_2_addr =
             EndpointAddr::new(ep_2.id()).with_relay_url(relay_url.clone());
 
-        // ep_3 has no registered key, so the relay denies its WebSocket
-        // connection, leaving it with no path to reach ep_1 or ep_2.
+        // ep_3 presents no token and has no registered key, so the relay
+        // denies its WebSocket connection, leaving it with no path to reach
+        // ep_1 or ep_2.
         // iroh retries the denied relay connection with backoff rather than
         // returning an explicit error from connect(), so the expected outcome
         // is that the attempt does not succeed within the timeout window.
@@ -354,8 +293,23 @@ fn assert_authenticated_relay_rejects_unregistered(addr: SocketAddr) {
     });
 }
 
+/// Authenticate against the bootstrap server and return the bearer token.
+fn fetch_auth_token(addr: SocketAddr) -> String {
+    let token_resp = ureq::put(&format!("http://{addr}/authenticate"))
+        .send(b"test-auth-material".as_ref())
+        .unwrap()
+        .into_body()
+        .read_to_string()
+        .unwrap();
+    serde_json::from_str::<serde_json::Value>(&token_resp).unwrap()["authToken"]
+        .as_str()
+        .unwrap()
+        .to_owned()
+}
+
 fn create_two_authenticated_endpoints_and_assert_message_is_received(
     addr: SocketAddr,
+    use_stale_token: bool,
 ) {
     let rt = tokio::runtime::Builder::new_current_thread()
         .enable_io()
@@ -366,16 +320,15 @@ fn create_two_authenticated_endpoints_and_assert_message_is_received(
         let relay_url =
             RelayUrl::from_str(&format!("http://{addr:?}")).unwrap();
 
-        // Create two iroh endpoints without relay initially.
-        // We must register each endpoint's public key with the server before
-        // connecting to the relay.
+        // Create two iroh endpoints without relay initially. Authentication
+        // material must be obtained before connecting to the relay.
         let ep_1_secret = SecretKey::generate();
         let ep_2_secret = SecretKey::generate();
 
         let build_endpoint_without_relay = |secret_key: SecretKey| {
             // Start with an empty relay map so the endpoint binds without
             // immediately connecting to the relay. The relay transport is
-            // kept so that insert_relay (called after registration) works.
+            // kept so that insert_relay (called after authentication) works.
             iroh::Endpoint::builder(Minimal)
                 .relay_mode(iroh::RelayMode::Custom(RelayMap::empty()))
                 .secret_key(secret_key)
@@ -394,34 +347,30 @@ fn create_two_authenticated_endpoints_and_assert_message_is_received(
             .await
             .unwrap();
 
-        // Authenticate and register an endpoint's public key directly via HTTP.
-        let authenticate_and_register = |key_bytes: [u8; 32]| async move {
-            let auth_url = format!("http://{addr}/authenticate");
-            let token_resp = ureq::put(&auth_url)
-                .send(b"test-auth-material".as_ref())
-                .unwrap()
-                .into_body()
-                .read_to_string()
-                .unwrap();
-            let token = serde_json::from_str::<serde_json::Value>(&token_resp)
-                .unwrap()["authToken"]
-                .as_str()
-                .unwrap()
-                .to_owned();
-
-            let register_url = format!("http://{addr}/relay/register");
-            ureq::put(&register_url)
-                .header("Authorization", &format!("Bearer {token}"))
-                .send(key_bytes.as_ref())
-                .unwrap();
+        // Build the relay config for the chosen auth flow and insert the
+        // relay into both endpoints. The relay WebSocket connection is
+        // established lazily when traffic is needed.
+        let relay_cfg = if use_stale_token {
+            // Register each endpoint's public key, then connect with a stale
+            // token to exercise recovery through the allowlist.
+            for key_bytes in [*ep_1.id().as_bytes(), *ep_2.id().as_bytes()] {
+                let token = fetch_auth_token(addr);
+                ureq::put(&format!("http://{addr}/relay/keepalive"))
+                    .header("Authorization", &format!("Bearer {token}"))
+                    .send(key_bytes.as_ref())
+                    .unwrap();
+            }
+            Arc::new(
+                RelayConfig::new(relay_url.clone(), None)
+                    .with_auth_token("stale-token".to_string()),
+            )
+        } else {
+            let token = fetch_auth_token(addr);
+            Arc::new(
+                RelayConfig::new(relay_url.clone(), None)
+                    .with_auth_token(token),
+            )
         };
-
-        authenticate_and_register(*ep_1.id().as_bytes()).await;
-        authenticate_and_register(*ep_2.id().as_bytes()).await;
-
-        // Insert the relay into both endpoints. The relay WebSocket connection
-        // is established lazily when traffic is needed.
-        let relay_cfg = Arc::new(RelayConfig::new(relay_url.clone(), None));
         ep_1.insert_relay(relay_url.clone(), relay_cfg.clone())
             .await;
         ep_2.insert_relay(relay_url.clone(), relay_cfg.clone())

--- a/crates/test_utils/src/auth.rs
+++ b/crates/test_utils/src/auth.rs
@@ -1,0 +1,136 @@
+//! Authentication test fixtures.
+
+use axum::response::IntoResponse;
+use axum::{
+    Router,
+    http::{StatusCode, header},
+    routing::put,
+};
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+// Rust guideline compliant 2026-07-23
+
+/// Runs a local authentication hook for integration tests.
+#[derive(Debug)]
+pub struct AuthHookServer {
+    addr: SocketAddr,
+    request_count: Arc<AtomicUsize>,
+    shutdown_tx: Option<tokio::sync::oneshot::Sender<()>>,
+    thread: Option<std::thread::JoinHandle<()>>,
+}
+
+impl AuthHookServer {
+    /// Starts an authentication hook on an available local port.
+    ///
+    /// When `expected_auth_material` is set, requests with other bodies are
+    /// rejected. Successful requests receive a unique bearer token.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the Tokio runtime or local listener cannot be created, or if
+    /// the server thread does not report its address within five seconds.
+    pub fn spawn(expected_auth_material: Option<Vec<u8>>) -> Self {
+        let request_count = Arc::new(AtomicUsize::new(0));
+        let request_count_for_handler = request_count.clone();
+        let (started_tx, started_rx) = std::sync::mpsc::sync_channel(1);
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+
+        let thread = std::thread::spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_io()
+                .enable_time()
+                .build()
+                .expect("auth hook Tokio runtime should build");
+
+            runtime.block_on(async move {
+                let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+                    .await
+                    .expect("auth hook should bind to a local port");
+                let addr = listener
+                    .local_addr()
+                    .expect("auth hook should have a local address");
+                let app = Router::new().route(
+                    "/authenticate",
+                    put(move |body: bytes::Bytes| {
+                        let expected_auth_material =
+                            expected_auth_material.clone();
+                        let request_count = request_count_for_handler.clone();
+                        async move {
+                            if expected_auth_material.as_deref().is_some_and(
+                                |expected| body.as_ref() != expected,
+                            ) {
+                                return (
+                                    StatusCode::UNAUTHORIZED,
+                                    "Unauthorized",
+                                )
+                                    .into_response();
+                            }
+
+                            let token_number = request_count
+                                .fetch_add(1, Ordering::SeqCst)
+                                + 1;
+                            let body = serde_json::json!({
+                                "authToken": format!(
+                                    "test-auth-token-{token_number}"
+                                ),
+                            })
+                            .to_string();
+                            ([(header::CONTENT_TYPE, "application/json")], body)
+                                .into_response()
+                        }
+                    }),
+                );
+
+                started_tx
+                    .send(addr)
+                    .expect("auth hook address receiver should be available");
+
+                axum::serve(listener, app)
+                    .with_graceful_shutdown(async {
+                        let _ = shutdown_rx.await;
+                    })
+                    .await
+                    .expect("auth hook server should run");
+            });
+        });
+
+        let addr = started_rx
+            .recv_timeout(std::time::Duration::from_secs(5))
+            .expect("auth hook did not start within five seconds");
+
+        Self {
+            addr,
+            request_count,
+            shutdown_tx: Some(shutdown_tx),
+            thread: Some(thread),
+        }
+    }
+
+    /// Returns the hook's listening address.
+    pub fn addr(&self) -> SocketAddr {
+        self.addr
+    }
+
+    /// Returns the hook's base URL.
+    pub fn url(&self) -> String {
+        format!("http://{}", self.addr)
+    }
+
+    /// Returns the number of successful authentication requests.
+    pub fn request_count(&self) -> usize {
+        self.request_count.load(Ordering::SeqCst)
+    }
+}
+
+impl Drop for AuthHookServer {
+    fn drop(&mut self) {
+        if let Some(shutdown_tx) = self.shutdown_tx.take() {
+            let _ = shutdown_tx.send(());
+        }
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}

--- a/crates/test_utils/src/lib.rs
+++ b/crates/test_utils/src/lib.rs
@@ -5,6 +5,7 @@ use rand::RngCore;
 use tokio::time::error::Elapsed;
 
 pub mod agent;
+pub mod auth;
 pub mod bootstrap;
 pub mod id;
 pub mod noop_bootstrap;

--- a/crates/transport_iroh/src/lib.rs
+++ b/crates/transport_iroh/src/lib.rs
@@ -291,6 +291,23 @@ pub mod config {
         #[serde(default)]
         #[cfg_attr(feature = "schema", schemars(skip))]
         pub auth_material_relay_base64: Option<String>,
+
+        /// Interval in seconds of the keepalive that re-registers the
+        /// endpoint public key with an authenticated relay's bootstrap
+        /// server.
+        ///
+        /// The keepalive keeps the server-side relay allowlist entry alive.
+        /// Only used when auth material is configured.
+        ///
+        /// Defaults to 120 seconds, well within the server's default
+        /// 5-minute auth token idle timeout.
+        #[serde(default = "default_relay_keepalive_interval_s")]
+        #[cfg_attr(feature = "schema", schemars(default))]
+        pub relay_keepalive_interval_s: u32,
+    }
+
+    fn default_relay_keepalive_interval_s() -> u32 {
+        120
     }
 
     impl Default for IrohTransportConfig {
@@ -301,6 +318,8 @@ pub mod config {
                 max_frame_bytes: 100 * 1024 * 1024,
                 connect_timeout_s: 60,
                 auth_material_relay_base64: None,
+                relay_keepalive_interval_s: default_relay_keepalive_interval_s(
+                ),
             }
         }
     }
@@ -335,6 +354,14 @@ impl TransportFactory for IrohTransportFactory {
 
     fn validate_config(&self, config: &Config) -> K2Result<()> {
         let config: IrohTransportModConfig = config.get_module_config()?;
+
+        // Prevent a zero-duration sleep from creating a busy
+        // keepalive loop that continuously issues blocking HTTP requests.
+        if config.iroh_transport.relay_keepalive_interval_s == 0 {
+            return Err(K2Error::other(
+                "Relay keepalive interval must be greater than zero",
+            ));
+        }
 
         if let Some(relay) = &config.iroh_transport.relay_url {
             let relay_server_url = ::url::Url::parse(relay)
@@ -388,17 +415,21 @@ type Connections = Arc<RwLock<HashMap<Url, Arc<ConnectionContext>>>>;
 /// Per-space relay state: maps SpaceId to (relay URL, our local URL on that relay).
 type SpaceRelays = Arc<RwLock<HashMap<SpaceId, (RelayUrl, Option<Url>)>>>;
 
-/// Parameters needed for periodic relay key re-registration.
+/// Parameters needed to (re-)authenticate for relay access.
 #[derive(Debug)]
-struct RelayRegistrationParams {
+struct RelayAuthParams {
     /// Base URL of the bootstrap server (e.g. `http://addr/`), used to
-    /// reach the `/authenticate` and `/relay/register` endpoints.
+    /// reach the `/authenticate` and `/relay/keepalive` endpoints.
     server_url: ::url::Url,
 
     /// Credentials used to obtain a bearer token from the auth server.
     auth_material: kitsune2_bootstrap_client::AuthMaterial,
 
-    /// The 32-byte iroh endpoint public key registered on the relay allowlist.
+    /// The relay URL the bearer token is presented to.
+    relay_url: RelayUrl,
+
+    /// The 32-byte iroh endpoint public key registered on the relay
+    /// allowlist.
     key_bytes: [u8; 32],
 }
 
@@ -412,7 +443,9 @@ struct IrohTransport {
     connection_locks: Arc<Mutex<HashMap<Url, Arc<tokio::sync::Mutex<()>>>>>,
     watch_addr_task: AbortHandle,
     accept_task: AbortHandle,
-    relay_re_registration_task: Option<AbortHandle>,
+    relay_keepalive_task: Option<AbortHandle>,
+    /// Keepalive tasks for per-space relays, keyed by relay URL.
+    space_relay_keepalives: Arc<Mutex<HashMap<RelayUrl, AbortHandle>>>,
     config: IrohTransportConfig,
     space_relays: SpaceRelays,
 }
@@ -422,9 +455,14 @@ impl Drop for IrohTransport {
         info!(local_url = ?self.local_url, "Dropping transport");
         self.watch_addr_task.abort();
         self.accept_task.abort();
-        if let Some(handle) = self.relay_re_registration_task.take() {
+        if let Some(handle) = self.relay_keepalive_task.take() {
             handle.abort();
         }
+        self.space_relay_keepalives
+            .lock()
+            .expect("poisoned")
+            .drain()
+            .for_each(|(_, handle)| handle.abort());
         // The connection reader task inside the connection context
         // holds a reference to the context. Thus the context can
         // only be dropped once that reference is dropped, which
@@ -448,19 +486,20 @@ impl IrohTransport {
         handler: Arc<TxImpHnd>,
         auth_material: Option<Vec<u8>>,
     ) -> K2Result<DynTxImp> {
-        // Determine whether we need to register with the relay before connecting.
-        // Registration is required when both a relay URL and auth material are provided.
-        let needs_relay_registration =
+        // Determine whether we need to authenticate for relay access.
+        // Authentication is required when both a relay URL and auth material
+        // are provided.
+        let needs_relay_auth =
             config.relay_url.is_some() && auth_material.is_some();
 
         // If a relay server is configured, only use that.
         // Otherwise, use the default relay servers provided by n0.
         let mut builder = if let Some(relay_url) = &config.relay_url {
-            if needs_relay_registration {
+            if needs_relay_auth {
                 // Start with an empty relay map so the endpoint binds without
                 // immediately connecting to the relay. The relay transport is
-                // kept intact so that insert_relay (called after registration)
-                // can establish the WebSocket connection.
+                // kept intact so that insert_relay (called after
+                // authentication) can establish the WebSocket connection.
                 Endpoint::builder(Minimal)
                     .relay_mode(RelayMode::Custom(RelayMap::empty()))
             } else {
@@ -499,11 +538,13 @@ impl IrohTransport {
             K2Error::other_src("Failed to bind iroh endpoint", err)
         })?;
 
-        // If we need relay registration, authenticate and register our public
-        // key with the server before inserting the relay into the endpoint.
-        // insert_relay is deferred until after the watcher task is spawned so
-        // that the address update it fires is guaranteed to be observed.
-        let relay_registration_params = if needs_relay_registration {
+        // If relay auth is needed, obtain a bearer token from the bootstrap
+        // server before inserting the relay into the endpoint. The token is
+        // presented on the relay WebSocket upgrade and validated by the
+        // server at connect time. insert_relay is deferred until after the
+        // watcher task is spawned so that the address update it fires is
+        // guaranteed to be observed.
+        let relay_auth = if needs_relay_auth {
             let relay_url_str = config
                 .relay_url
                 .as_deref()
@@ -513,41 +554,35 @@ impl IrohTransport {
 
             // Derive the server base URL from the relay URL by removing the path.
             // e.g. "http://addr/relay/" -> "http://addr/"
-            let server_url = ::url::Url::parse(relay_url_str).map_err(|e| {
-                K2Error::other_src("Invalid relay URL for registration", e)
-            })?;
-            let mut server_url = server_url;
+            let mut server_url =
+                ::url::Url::parse(relay_url_str).map_err(|e| {
+                    K2Error::other_src(
+                        "Invalid relay URL for authentication",
+                        e,
+                    )
+                })?;
             server_url.set_path("/");
 
-            let key_bytes = *endpoint.id().as_bytes();
-            let auth_material =
-                kitsune2_bootstrap_client::AuthMaterial::new(auth_bytes);
+            let relay_url = RelayUrl::from_str(relay_url_str)
+                .map_err(|err| K2Error::other_src("Invalid relay URL", err))?;
 
-            let params = Arc::new(RelayRegistrationParams {
+            let params = Arc::new(RelayAuthParams {
                 server_url,
-                auth_material,
-                key_bytes,
+                auth_material: kitsune2_bootstrap_client::AuthMaterial::new(
+                    auth_bytes,
+                ),
+                relay_url,
+                key_bytes: *endpoint.id().as_bytes(),
             });
 
-            info!(server_url = %params.server_url, relay_url = relay_url_str, "Starting relay key registration");
+            info!(server_url = %params.server_url, relay_url = relay_url_str, "Authenticating for relay access");
 
-            // Perform the initial authentication and key registration.
-            let params_clone = params.clone();
-            tokio::task::spawn_blocking(move || {
-                kitsune2_bootstrap_client::blocking_register_relay_key(
-                    params_clone.server_url.clone(),
-                    &params_clone.auth_material,
-                    &params_clone.key_bytes,
-                )
-            })
-            .await
-            .map_err(|e| K2Error::other_src("Registration task failed", e))??;
+            let token = Self::fetch_relay_token(&params).await?;
+            Self::relay_keepalive(&params).await?;
 
-            info!(
-                "Relay key registration complete, proceeding to insert relay"
-            );
+            info!("Relay authentication complete, proceeding to insert relay");
 
-            Some(params)
+            Some((params, token))
         } else {
             None
         };
@@ -555,7 +590,7 @@ impl IrohTransport {
         // Clone the raw endpoint before consuming it into IrohEndpoint so that
         // insert_relay can be called after the watcher task is subscribed.
         // iroh::Endpoint is Arc-backed so this is a cheap reference copy.
-        let raw_endpoint_for_relay = if needs_relay_registration {
+        let raw_endpoint_for_relay = if needs_relay_auth {
             Some(endpoint.clone())
         } else {
             None
@@ -576,16 +611,14 @@ impl IrohTransport {
         // update it fires is captured by the running watcher task, ensuring
         // local_url is populated before any outbound send can run.
         if let Some(raw_ep) = raw_endpoint_for_relay {
-            let relay_url_str = config
-                .relay_url
-                .as_deref()
-                .expect("relay_url checked above");
-            let relay_url = RelayUrl::from_str(relay_url_str)
-                .map_err(|err| K2Error::other_src("Invalid relay URL", err))?;
+            let (params, token) = relay_auth
+                .as_ref()
+                .expect("relay_auth is Some when raw_endpoint_for_relay is");
+            let relay_url = params.relay_url.clone();
             raw_ep
                 .insert_relay(
                     relay_url.clone(),
-                    Arc::new(RelayConfig::new(relay_url.clone(), None)),
+                    Self::relay_config_with_token(&relay_url, Some(token)),
                 )
                 .await;
             info!(
@@ -605,12 +638,13 @@ impl IrohTransport {
             space_relays.clone(),
         );
 
-        // Spawn a periodic re-registration task so the relay allowlist
-        // entry is refreshed before the server prunes it. This also
-        // handles the case where the server restarts and loses its
-        // in-memory allowlist.
-        let relay_re_registration_task = relay_registration_params
-            .map(Self::spawn_relay_re_registration_task);
+        // Keep the endpoint's relay allowlist entry alive.
+        let relay_keepalive_task = relay_auth.map(|(params, _)| {
+            Self::spawn_relay_keepalive_task(
+                params,
+                Duration::from_secs(config.relay_keepalive_interval_s as u64),
+            )
+        });
 
         let out: DynTxImp = Arc::new(Self {
             endpoint,
@@ -620,11 +654,79 @@ impl IrohTransport {
             connection_locks,
             watch_addr_task,
             accept_task,
-            relay_re_registration_task,
+            relay_keepalive_task,
+            space_relay_keepalives: Arc::new(Mutex::new(HashMap::new())),
             config,
             space_relays,
         });
         Ok(out)
+    }
+
+    /// Keep the endpoint public key registered with the bootstrap server's
+    /// relay allowlist, re-authenticating on 401.
+    async fn relay_keepalive(params: &Arc<RelayAuthParams>) -> K2Result<()> {
+        let params = params.clone();
+        tokio::task::spawn_blocking(move || {
+            kitsune2_bootstrap_client::blocking_relay_keepalive(
+                params.server_url.clone(),
+                &params.auth_material,
+                &params.key_bytes,
+            )
+        })
+        .await
+        .map_err(|e| K2Error::other_src("Registration task failed", e))?
+    }
+
+    /// Spawns periodic calls to [`Self::relay_keepalive`].
+    fn spawn_relay_keepalive_task(
+        params: Arc<RelayAuthParams>,
+        interval: Duration,
+    ) -> AbortHandle {
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(interval).await;
+
+                match Self::relay_keepalive(&params).await {
+                    Ok(()) => {
+                        debug!("Relay keepalive succeeded");
+                    }
+                    Err(e) => warn!(?e, "Relay keepalive failed"),
+                }
+            }
+        })
+        .abort_handle()
+    }
+
+    /// Authenticate against the bootstrap server and return the relay
+    /// bearer token.
+    async fn fetch_relay_token(
+        params: &Arc<RelayAuthParams>,
+    ) -> K2Result<String> {
+        let params = params.clone();
+        tokio::task::spawn_blocking(move || {
+            kitsune2_bootstrap_client::blocking_fetch_relay_token(
+                params.server_url.clone(),
+                &params.auth_material,
+            )
+        })
+        .await
+        .map_err(|e| K2Error::other_src("Authentication task failed", e))?
+    }
+
+    /// Build a relay config, attaching the bearer token when provided.
+    ///
+    /// iroh sends the token as an `Authorization: Bearer` header on every
+    /// relay WebSocket upgrade, so it is automatically re-presented on
+    /// every reconnect.
+    fn relay_config_with_token(
+        relay_url: &RelayUrl,
+        token: Option<&str>,
+    ) -> Arc<RelayConfig> {
+        let mut config = RelayConfig::new(relay_url.clone(), None);
+        if let Some(token) = token {
+            config = config.with_auth_token(token);
+        }
+        Arc::new(config)
     }
 
     /// Spawns a background task to watch for changes in the endpoint's listening address.
@@ -660,47 +762,6 @@ impl IrohTransport {
                             "Address watcher update failed, stopping watch loop"
                         );
                         break;
-                    }
-                }
-            }
-        })
-        .abort_handle()
-    }
-
-    /// Spawns a periodic task that re-registers the relay key with the
-    /// bootstrap server. This keeps the allowlist entry alive and recovers
-    /// from server restarts that clear the in-memory allowlist.
-    ///
-    /// Re-registration runs every 2 minutes, well within the default
-    /// 5-minute auth token idle timeout on the server.
-    fn spawn_relay_re_registration_task(
-        params: Arc<RelayRegistrationParams>,
-    ) -> AbortHandle {
-        const RE_REGISTRATION_INTERVAL: Duration = Duration::from_secs(120);
-
-        tokio::spawn(async move {
-            loop {
-                tokio::time::sleep(RE_REGISTRATION_INTERVAL).await;
-
-                let params = params.clone();
-                let result = tokio::task::spawn_blocking(move || {
-                    kitsune2_bootstrap_client::blocking_register_relay_key(
-                        params.server_url.clone(),
-                        &params.auth_material,
-                        &params.key_bytes,
-                    )
-                })
-                .await;
-
-                match result {
-                    Ok(Ok(())) => {
-                        debug!("Relay key re-registration succeeded");
-                    }
-                    Ok(Err(e)) => {
-                        warn!(?e, "Relay key re-registration failed");
-                    }
-                    Err(e) => {
-                        warn!(?e, "Relay key re-registration task panicked");
                     }
                 }
             }
@@ -939,51 +1000,59 @@ impl IrohTransport {
 
     /// Dynamically add a relay server to the shared iroh endpoint.
     ///
-    /// If `auth_material` is provided, the endpoint's public key is
-    /// registered with the relay server before connecting.
+    /// If `auth_material` is provided, a bearer token is obtained from the
+    /// bootstrap server and presented on the relay WebSocket upgrade, and
+    /// the endpoint public key is registered on the relay allowlist.
     ///
-    /// Returns the parsed RelayUrl and our kitsune2 peer URL on that relay.
+    /// Returns the parsed RelayUrl, our kitsune2 peer URL on that relay,
+    /// and the auth params when authentication is in use, so the caller
+    /// can spawn a keepalive task.
     async fn do_insert_relay(
         endpoint: DynIrohEndpoint,
         relay_url: String,
         auth_material: Option<Vec<u8>>,
-    ) -> K2Result<(RelayUrl, Url)> {
+    ) -> K2Result<(RelayUrl, Url, Option<Arc<RelayAuthParams>>)> {
         let relay_url_str = if relay_url.ends_with('/') {
             relay_url
         } else {
             format!("{relay_url}/")
         };
 
-        if let Some(auth_bytes) = auth_material {
-            let server_url =
-                ::url::Url::parse(&relay_url_str).map_err(|e| {
-                    K2Error::other_src("Invalid relay URL for registration", e)
-                })?;
-            let mut server_url = server_url;
-            server_url.set_path("/");
-
-            let key_bytes = endpoint.id_bytes();
-            let auth_material =
-                kitsune2_bootstrap_client::AuthMaterial::new(auth_bytes);
-
-            tokio::task::spawn_blocking(move || {
-                kitsune2_bootstrap_client::blocking_register_relay_key(
-                    server_url,
-                    &auth_material,
-                    &key_bytes,
-                )
-            })
-            .await
-            .map_err(|e| K2Error::other_src("Registration task failed", e))??;
-        }
-
         let relay_url_parsed = RelayUrl::from_str(&relay_url_str)
             .map_err(|err| K2Error::other_src("Invalid relay URL", err))?;
+
+        let (auth_params, token) = if let Some(auth_bytes) = auth_material {
+            let mut server_url =
+                ::url::Url::parse(&relay_url_str).map_err(|e| {
+                    K2Error::other_src(
+                        "Invalid relay URL for authentication",
+                        e,
+                    )
+                })?;
+            server_url.set_path("/");
+
+            let params = Arc::new(RelayAuthParams {
+                server_url,
+                auth_material: kitsune2_bootstrap_client::AuthMaterial::new(
+                    auth_bytes,
+                ),
+                relay_url: relay_url_parsed.clone(),
+                key_bytes: endpoint.id_bytes(),
+            });
+            let token = Self::fetch_relay_token(&params).await?;
+            Self::relay_keepalive(&params).await?;
+            (Some(params), Some(token))
+        } else {
+            (None, None)
+        };
 
         endpoint
             .insert_relay(
                 relay_url_parsed.clone(),
-                Arc::new(RelayConfig::new(relay_url_parsed.clone(), None)),
+                Self::relay_config_with_token(
+                    &relay_url_parsed,
+                    token.as_deref(),
+                ),
             )
             .await;
 
@@ -1000,7 +1069,7 @@ impl IrohTransport {
             "do_insert_relay: relay added, local URL constructed"
         );
 
-        Ok((relay_url_parsed, local_url))
+        Ok((relay_url_parsed, local_url, auth_params))
     }
 }
 
@@ -1194,6 +1263,10 @@ impl TxImp for IrohTransport {
         if let Some(url) = relay_url {
             let endpoint = self.endpoint.clone();
             let space_relays = self.space_relays.clone();
+            let space_relay_keepalives = self.space_relay_keepalives.clone();
+            let keepalive_interval = Duration::from_secs(
+                self.config.relay_keepalive_interval_s as u64,
+            );
             let handler = self.handler.clone();
             let space_id_clone = space_id.clone();
 
@@ -1202,11 +1275,25 @@ impl TxImp for IrohTransport {
                     match Self::do_insert_relay(endpoint, url, auth_material)
                         .await
                     {
-                        Ok((relay_url, local_url)) => {
+                        Ok((relay_url, local_url, auth_params)) => {
                             space_relays.write().expect("poisoned").insert(
                                 space_id_clone.clone(),
-                                (relay_url, Some(local_url.clone())),
+                                (relay_url.clone(), Some(local_url.clone())),
                             );
+                            // Keep the allowlist entry for this relay alive
+                            // for as long as the relay is in use.
+                            if let Some(params) = auth_params {
+                                space_relay_keepalives
+                                    .lock()
+                                    .expect("poisoned")
+                                    .entry(relay_url)
+                                    .or_insert_with(|| {
+                                        Self::spawn_relay_keepalive_task(
+                                            params,
+                                            keepalive_interval,
+                                        )
+                                    });
+                            }
                             handler
                                 .new_listening_address(
                                     local_url,
@@ -1254,6 +1341,14 @@ impl TxImp for IrohTransport {
 
                 if !still_used {
                     self.endpoint.remove_relay(&relay_url).await;
+                    if let Some(handle) = self
+                        .space_relay_keepalives
+                        .lock()
+                        .expect("poisoned")
+                        .remove(&relay_url)
+                    {
+                        handle.abort();
+                    }
                     tracing::info!(
                         ?space_id,
                         %relay_url,

--- a/crates/transport_iroh/src/tests/connect_failure.rs
+++ b/crates/transport_iroh/src/tests/connect_failure.rs
@@ -176,7 +176,8 @@ fn build_transport(
         connection_locks: Arc::new(Mutex::new(HashMap::new())),
         watch_addr_task: noop_handle(),
         accept_task: noop_handle(),
-        relay_re_registration_task: None,
+        relay_keepalive_task: None,
+        space_relay_keepalives: Arc::new(Mutex::new(HashMap::new())),
         config,
         space_relays: Arc::new(RwLock::new(HashMap::new())),
     }

--- a/crates/transport_iroh/src/tests/mod.rs
+++ b/crates/transport_iroh/src/tests/mod.rs
@@ -50,6 +50,31 @@ fn validate_allowed_plain_text_relay_url() {
     assert!(result.is_ok());
 }
 
+#[test]
+fn validate_zero_relay_keepalive_interval() {
+    let builder = Builder {
+        transport: IrohTransportFactory::create(),
+        ..kitsune2_core::default_test_builder()
+    };
+
+    builder
+        .config
+        .set_module_config(&IrohTransportModConfig {
+            iroh_transport: IrohTransportConfig {
+                relay_keepalive_interval_s: 0,
+                ..Default::default()
+            },
+        })
+        .unwrap();
+
+    let result = builder.validate_config();
+    assert!(result.is_err());
+    assert!(
+        format!("{result:?}")
+            .contains("Relay keepalive interval must be greater than zero")
+    );
+}
+
 /// Test that `configure_for_space` reads the per-space iroh transport
 /// config and dynamically adds a relay to the transport.
 #[cfg(feature = "test-utils")]

--- a/crates/transport_iroh/tests/relay_auth.rs
+++ b/crates/transport_iroh/tests/relay_auth.rs
@@ -6,53 +6,24 @@
 
 use std::{sync::Arc, time::Duration};
 
-use axum::routing;
 use base64::Engine as _;
 use bytes::Bytes;
 use kitsune2_api::Builder;
 use kitsune2_bootstrap_srv::{AuthConfig, BootstrapSrv, Config};
 use kitsune2_test_utils::{
-    enable_tracing, retry_fn_until_timeout, space::TEST_SPACE_ID,
+    auth::AuthHookServer, enable_tracing, retry_fn_until_timeout,
+    space::TEST_SPACE_ID,
 };
 use kitsune2_transport_iroh::{
     IrohTransportConfig, IrohTransportFactory, IrohTransportModConfig,
     test_utils::{MockTxHandler, dummy_url},
 };
 
-fn start_local_auth_hook() -> (std::net::SocketAddr, std::thread::JoinHandle<()>)
-{
-    let (tx, rx) = std::sync::mpsc::channel();
-    let handle = std::thread::spawn(move || {
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_io()
-            .enable_time()
-            .build()
-            .unwrap();
-        rt.block_on(async {
-            let listener =
-                tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-            tx.send(listener.local_addr().unwrap()).unwrap();
-            let app = axum::Router::new().route(
-                "/authenticate",
-                routing::put(|| async {
-                    axum::Json(
-                        serde_json::json!({"authToken": "relay-auth-test-token"}),
-                    )
-                }),
-            );
-            axum::serve(listener, app).await.ok();
-        });
-    });
-    let addr = rx
-        .recv_timeout(Duration::from_secs(5))
-        .expect("auth hook did not start in time");
-    (addr, handle)
-}
-
 async fn build_auth_transport(
     relay_url: &str,
     auth_bytes: Vec<u8>,
     allow_plain_text: bool,
+    keepalive_interval_s: u32,
     handler: Arc<MockTxHandler>,
 ) -> kitsune2_api::DynTransport {
     let mut builder = Builder {
@@ -69,6 +40,7 @@ async fn build_auth_transport(
             iroh_transport: IrohTransportConfig {
                 relay_url: Some(relay_url.to_string()),
                 relay_allow_plain_text: allow_plain_text,
+                relay_keepalive_interval_s: keepalive_interval_s,
                 ..Default::default()
             },
         })
@@ -106,8 +78,8 @@ async fn authenticated_relay_two_transports_can_communicate() {
             (url, bytes, false, None)
         }
         _ => {
-            let (auth_addr, auth_handle) = start_local_auth_hook();
-            let hook_url = format!("http://{auth_addr}");
+            let auth_hook = AuthHookServer::spawn(None);
+            let hook_url = auth_hook.url();
             tracing::info!(%hook_url, "started local auth hook");
 
             // BootstrapSrv::new() creates its own tokio runtime and cannot
@@ -130,7 +102,7 @@ async fn authenticated_relay_two_transports_can_communicate() {
             tracing::info!(%relay_url, "started local bootstrap+relay");
 
             let auth_bytes = b"local-test-auth-material".to_vec();
-            (relay_url, auth_bytes, true, Some((auth_handle, srv)))
+            (relay_url, auth_bytes, true, Some((auth_hook, srv)))
         }
     };
 
@@ -141,6 +113,7 @@ async fn authenticated_relay_two_transports_can_communicate() {
         &relay_url,
         auth_bytes.clone(),
         allow_plain_text,
+        120,
         handler_1.clone(),
     )
     .await;
@@ -158,6 +131,7 @@ async fn authenticated_relay_two_transports_can_communicate() {
         &relay_url,
         auth_bytes,
         allow_plain_text,
+        120,
         handler_2.clone(),
     )
     .await;
@@ -188,4 +162,146 @@ async fn authenticated_relay_two_transports_can_communicate() {
     })
     .await
     .expect("message was not received by ep_2 within 30 s");
+}
+
+/// The bootstrap server restarts, wiping its in-memory token state. The
+/// transport's registration keepalive must re-authenticate, re-register
+/// the endpoint key, and restore relay connectivity without intervention.
+///
+#[tokio::test(flavor = "multi_thread")]
+async fn relay_auth_recovers_after_server_restart() {
+    enable_tracing();
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let auth_hook = AuthHookServer::spawn(None);
+    let hook_url = auth_hook.url();
+
+    let make_config =
+        |hook_url: String, listen: Vec<std::net::SocketAddr>| -> Config {
+            Config {
+                prune_interval: Duration::from_millis(100),
+                listen_address_list: listen,
+                auth: AuthConfig {
+                    authentication_hook_server: Some(hook_url),
+                    ..Default::default()
+                },
+                ..Config::testing()
+            }
+        };
+
+    // BootstrapSrv::new() creates its own tokio runtime and cannot be
+    // called from within an existing runtime.
+    let hook_url_1 = hook_url.clone();
+    let srv = tokio::task::spawn_blocking(move || {
+        BootstrapSrv::new(make_config(
+            hook_url_1,
+            vec![(std::net::Ipv4Addr::LOCALHOST, 0).into()],
+        ))
+    })
+    .await
+    .expect("spawn_blocking panicked")
+    .expect("failed to start local bootstrap server");
+
+    let srv_addr = srv.listen_addrs()[0];
+    let relay_url = format!("http://{srv_addr}/relay");
+    tracing::info!(%relay_url, "started local bootstrap+relay");
+
+    let dummy = dummy_url();
+    let auth_bytes = b"local-test-auth-material".to_vec();
+
+    // ep_1 authenticates and connects to the relay.
+    let (msg_tx, mut msg_rx) = tokio::sync::mpsc::unbounded_channel::<Bytes>();
+    let handler_1 = Arc::new(MockTxHandler {
+        recv_space_notify: Arc::new(move |_peer, _space_id, data| {
+            msg_tx.send(data).ok();
+            Ok(())
+        }),
+        ..Default::default()
+    });
+    // A short re-registration interval keeps the recovery window (and the
+    // test) fast; production defaults to 120 s.
+    let ep_1 = build_auth_transport(
+        &relay_url,
+        auth_bytes.clone(),
+        true,
+        1,
+        handler_1.clone(),
+    )
+    .await;
+    ep_1.register_space_handler(TEST_SPACE_ID, handler_1.clone());
+
+    retry_fn_until_timeout(
+        || async { *handler_1.current_url.lock().unwrap() != dummy },
+        Some(30_000),
+        Some(200),
+    )
+    .await
+    .expect("ep_1 did not obtain a listening address within 30 s");
+    let ep1_url = handler_1.current_url.lock().unwrap().clone();
+
+    // Restart the server on the same address: all in-memory token and
+    // allowlist state is gone, so ep_1's relay reconnect with its cached
+    // token is denied until the registration heartbeat re-authenticates
+    // and re-registers ep_1's public key on the allowlist. (The relay
+    // actor inside iroh keeps dialing with the stale token — it cannot be
+    // refreshed while the actor lives — so recovery comes from the
+    // allowlist admitting the handshake-proven key.)
+    tracing::info!("restarting bootstrap server");
+    let hook_url_2 = hook_url.clone();
+    let srv = tokio::task::spawn_blocking(move || {
+        drop(srv);
+        BootstrapSrv::new(make_config(hook_url_2, vec![srv_addr]))
+    })
+    .await
+    .expect("spawn_blocking panicked")
+    .expect("failed to restart local bootstrap server on the same address");
+    assert_eq!(srv.listen_addrs()[0], srv_addr);
+    tracing::info!("bootstrap server restarted on the same address");
+
+    // ep_2 joins after the restart with fresh authentication and must be
+    // able to reach ep_1 via the relay — which requires ep_1 to have
+    // re-registered and restored its relay connection.
+    let handler_2 = Arc::new(MockTxHandler::default());
+    let ep_2 = build_auth_transport(
+        &relay_url,
+        auth_bytes,
+        true,
+        1,
+        handler_2.clone(),
+    )
+    .await;
+    ep_2.register_space_handler(TEST_SPACE_ID, handler_2.clone());
+
+    retry_fn_until_timeout(
+        || async { *handler_2.current_url.lock().unwrap() != dummy },
+        Some(30_000),
+        Some(200),
+    )
+    .await
+    .expect("ep_2 did not obtain a listening address within 30 s");
+
+    // Recovery needs one heartbeat tick (1 s here) plus the relay
+    // reconnect backoff, so allow a generous window and keep re-sending
+    // until the message lands.
+    let message = Bytes::from_static(b"hello after server restart");
+    let ep_1_recovered = retry_fn_until_timeout(
+        || async {
+            ep_2.send_space_notify(
+                ep1_url.clone(),
+                TEST_SPACE_ID,
+                message.clone(),
+            )
+            .await
+            .ok();
+            !msg_rx.is_empty()
+        },
+        Some(90_000),
+        Some(2_000),
+    )
+    .await;
+    ep_1_recovered
+        .expect("ep_1 did not recover relay connectivity within 90 s");
+
+    let received = msg_rx.recv().await.unwrap();
+    assert_eq!(received, message);
 }


### PR DESCRIPTION
## What changed

Authenticated clients now send their bearer token when connecting to the relay. The server validates it on every connection and keeps tokens used by live connections from expiring.

The transport also calls `PUT /relay/keepalive` every 120 seconds. This lets clients recover after a token becomes stale or the bootstrap server restarts, including relays configured for a single space. The endpoint replaces `PUT /relay/register`, and connecting without a token is no longer supported on this branch. Rejected connections now include the reason "not authorized".

## Why

Fixes #492. Authenticated nodes could lose relay access after token expiry or a server restart, then keep retrying with credentials the server no longer accepted.

## Authentication flow

The client authenticates, attaches the returned token to the relay connection, and starts a periodic keepalive:

```mermaid
sequenceDiagram
    participant Node as Kitsune2 node
    participant Conn as iroh relay connection<br>(lives inside the node)
    participant Srv as Bootstrap server<br>(embedded relay)
    participant Hook as Auth hook service

    Node->>Srv: PUT /authenticate with auth material
    Srv->>Hook: check auth material
    Hook-->>Srv: bearer token
    Srv-->>Node: bearer token
    Node->>Conn: start relay connection, token attached
    Conn->>Srv: connect with Authorization Bearer header
    Srv-->>Conn: allowed, token is valid
    Note over Node,Srv: every 120s the node also calls PUT /relay/keepalive,<br>which keeps its public key on the server's allowlist
```

## Recovery flow

Iroh 1.0.0 cannot replace the token on a running relay connection. The keepalive re-registers the node's public key, so the existing connection can recover even while it still presents the old token:

```mermaid
sequenceDiagram
    participant Node as Kitsune2 node
    participant Conn as iroh relay connection<br>(lives inside the node)
    participant Srv as Bootstrap server<br>(embedded relay)

    Note over Srv: server restarts or token expires,<br>all known tokens are gone
    Conn->>Srv: reconnect with the old token
    Srv-->>Conn: denied
    Note over Conn: iroh 1.0.0 cannot give a running relay<br>connection a new token, so it would<br>retry with the dead token forever
    Node->>Srv: keepalive, PUT /relay/keepalive<br>(re-authenticates first, so it carries a fresh token)
    Note over Srv: node's public key is back on the allowlist
    Conn->>Srv: retry, still with the old token
    Srv-->>Conn: allowed, public key is registered
```

## Notes

- The keepalive remains necessary until iroh supports refreshing the token on a live connection.
- Tests cover token authentication, stale-token recovery, single-space relays, and recovery after a bootstrap server restart.

## Follow-ups

- Document auth setup for dino-adventure-kangaroo.
- Verify the hosted relay after this change is deployed.
- Remove the keepalive endpoint when iroh supports live token refresh.

Refs #492
