### PR TITLE
fix(core): mem transport marks peers unresponsive on send failure

### DIFF
--- a/crates/core/src/factories/mem_transport.rs
+++ b/crates/core/src/factories/mem_transport.rs
@@ -53,6 +53,9 @@ struct MemTransport {
     task_list: Arc<Mutex<tokio::task::JoinSet<()>>>,
     cmd_send: CmdSend,
     net_stats: Arc<Mutex<TransportStats>>,
+    /// Handler used to notify the wrapping transport of peer state
+    /// changes, e.g. marking a peer unresponsive after a failed send.
+    handler: Arc<TxImpHnd>,
 }
 
 impl Drop for MemTransport {
@@ -64,6 +67,9 @@ impl Drop for MemTransport {
 }
 
 impl MemTransport {
+    /// Construct a new memory transport implementation: registers a fresh
+    /// in-process listener, reports its address to the handler, and spawns
+    /// the connection-listener and command-runner tasks.
     pub async fn create(handler: Arc<TxImpHnd>) -> DynTxImp {
         let mut listener = get_transport_instances().listen();
         let this_url = listener.url();
@@ -102,7 +108,7 @@ impl MemTransport {
         // our core command runner task
         task_list.lock().unwrap().spawn(cmd_task(
             task_list.clone(),
-            handler,
+            handler.clone(),
             this_url.clone(),
             cmd_send.clone(),
             cmd_recv,
@@ -114,6 +120,7 @@ impl MemTransport {
             task_list,
             cmd_send,
             net_stats,
+            handler,
         });
 
         out
@@ -142,17 +149,31 @@ impl TxImp for MemTransport {
         })
     }
 
+    /// Send `data` to `peer` over the in-memory channel. On failure the
+    /// peer is marked unresponsive via [TxImpHnd::set_unresponsive],
+    /// matching the behavior of the production transport.
     fn send(&self, peer: Url, data: bytes::Bytes) -> BoxFut<'_, K2Result<()>> {
         Box::pin(async move {
             let (result_sender, result_receiver) =
                 tokio::sync::oneshot::channel();
-            match self.cmd_send.send(Cmd::Send(peer, data, result_sender)) {
+            let result = match self.cmd_send.send(Cmd::Send(
+                peer.clone(),
+                data,
+                result_sender,
+            )) {
                 Err(_) => Err(K2Error::other("Connection Closed")),
                 Ok(_) => match result_receiver.await {
                     Ok(result) => result,
                     Err(_) => Err(K2Error::other("Connection Closed")),
                 },
+            };
+            if result.is_err() {
+                // Without this, tests that kill nodes never see those
+                // nodes become unresponsive.
+                let _ =
+                    self.handler.set_unresponsive(peer, Timestamp::now()).await;
             }
+            result
         })
     }
 


### PR DESCRIPTION
`TxImpHnd::set_unresponsive` documents that transports should call it whenever a connection fails to establish, a send fails, or a peer disconnects. The iroh transport honours this; the mem transport returned `Connection Closed` errors without ever marking the peer — so in any test built on the mem transport, a killed node never becomes unresponsive: peer selection keeps offering it, and anything downstream of unresponsive tracking is blind to the death.

This is the standalone fix we offered in [#160 (comment)](https://github.com/holochain/kitsune2/issues/160#issuecomment-4949241059) — it's independent of everything else discussed there, and just brings the mem transport up to the contract in `transport.rs` so failure-mode tests can see node deaths.

The change keeps a handle on the `TxImpHnd` and marks the peer when a send fails (mirroring the iroh transport's behaviour). One existing behaviour is preserved: the error returned to the caller is unchanged.

Tested: full `kitsune2_core` suite passes (99 + 3), no regressions. We found this while writing a multi-node failure test — post-kill, ghost peers stayed "responsive" indefinitely, which quietly invalidates any mem-transport test that kills nodes.

Transparency: developed with AI assistance (Claude), human-directed and reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)