### PR TITLE
feat(transport_iroh): close connections gracefully with close codes

### DIFF
--- a/crates/transport_iroh/src/close_code.rs
+++ b/crates/transport_iroh/src/close_code.rs
@@ -1,0 +1,59 @@
+//! Application-level close codes for iroh connections.
+//!
+//! A QUIC application close carries a numeric error code plus reason bytes.
+//! These codes let the remote peer distinguish an intentional close from a
+//! network failure, so it can release the connection quietly.
+
+/// Application close code carried in the QUIC CONNECTION_CLOSE frame.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub(crate) enum CloseCode {
+    /// Unknown close code treated as a connection failure.
+    Unspecified = 0,
+    /// The peer closed the connection intentionally. The close reason bytes
+    /// carry a human-readable reason. Not a failure.
+    Graceful = 1,
+    /// The connection lost simultaneous-open resolution and was replaced by
+    /// a preferred connection to the same peer. Not a failure.
+    Superseded = 2,
+}
+
+impl CloseCode {
+    /// Numeric wire representation of this close code.
+    pub fn as_u8(self) -> u8 {
+        self as u8
+    }
+
+    /// Maps a wire error code to a [`CloseCode`].
+    ///
+    /// Future unknown codes map to [`CloseCode::Unspecified`].
+    pub fn from_wire(code: u64) -> Self {
+        match code {
+            1 => CloseCode::Graceful,
+            2 => CloseCode::Superseded,
+            _ => CloseCode::Unspecified,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_known_codes() {
+        for code in [
+            CloseCode::Unspecified,
+            CloseCode::Graceful,
+            CloseCode::Superseded,
+        ] {
+            assert_eq!(CloseCode::from_wire(code.as_u8() as u64), code);
+        }
+    }
+
+    #[test]
+    fn unknown_wire_code_maps_to_unspecified() {
+        assert_eq!(CloseCode::from_wire(3), CloseCode::Unspecified);
+        assert_eq!(CloseCode::from_wire(u64::MAX), CloseCode::Unspecified);
+    }
+}

--- a/crates/transport_iroh/src/connection.rs
+++ b/crates/transport_iroh/src/connection.rs
@@ -1,5 +1,6 @@
 //! Abstractions for connection operations, enabling unit testing.
 
+use crate::close_code::CloseCode;
 use crate::stream::{
     DynIrohRecvStream, DynIrohSendStream, IrohRecvStream, IrohSendStream,
 };
@@ -23,22 +24,22 @@ pub(crate) trait Connection: 'static + Send + Sync {
     /// Get the remote node ID.
     fn remote_id(&self) -> EndpointId;
 
-    /// Close the connection with a code and reason.
-    fn close(&self, code: u8, reason: &[u8]);
+    /// Close the connection with a close code and reason.
+    fn close(&self, code: CloseCode, reason: &[u8]);
 
     /// Check if the connection has a direct (non-relay) path.
     fn is_direct(&self) -> bool;
 
     /// If the connection has been closed *by the remote* with an application
-    /// close, return the reason bytes the remote sent.
+    /// close, return the close code and reason bytes the remote sent.
     ///
     /// Returns `None` while the connection is still open, when it was closed
     /// locally, or when it was torn down by a transport-level error (timeout,
     /// reset, ...) rather than a graceful application close. This lets the
-    /// reader distinguish a deliberate, signalled teardown (such as a
-    /// connection superseded during simultaneous-open resolution) from a
-    /// genuine peer disconnect.
-    fn remote_close_reason(&self) -> Option<Bytes>;
+    /// reader distinguish a deliberate, signalled teardown (a graceful
+    /// disconnect or a connection superseded during simultaneous-open
+    /// resolution) from a genuine peer disconnect.
+    fn remote_close_reason(&self) -> Option<(CloseCode, Bytes)>;
 }
 
 /// Production implementation wrapping iroh's Connection.
@@ -79,8 +80,8 @@ impl Connection for IrohConnection {
         self.inner.remote_id()
     }
 
-    fn close(&self, code: u8, reason: &[u8]) {
-        self.inner.close(code.into(), reason);
+    fn close(&self, code: CloseCode, reason: &[u8]) {
+        self.inner.close(code.as_u8().into(), reason);
     }
 
     fn is_direct(&self) -> bool {
@@ -90,11 +91,14 @@ impl Connection for IrohConnection {
             .any(|p| p.is_ip() && p.is_selected())
     }
 
-    fn remote_close_reason(&self) -> Option<Bytes> {
+    fn remote_close_reason(&self) -> Option<(CloseCode, Bytes)> {
         match self.inner.close_reason() {
             Some(iroh::endpoint::ConnectionError::ApplicationClosed(
                 application_close,
-            )) => Some(application_close.reason),
+            )) => Some((
+                CloseCode::from_wire(u64::from(application_close.error_code)),
+                application_close.reason,
+            )),
             _ => None,
         }
     }

--- a/crates/transport_iroh/src/connection_context.rs
+++ b/crates/transport_iroh/src/connection_context.rs
@@ -1,5 +1,6 @@
 use crate::IrohTransport;
 use crate::SpaceRelays;
+use crate::close_code::CloseCode;
 use crate::connection::DynConnection;
 #[cfg(feature = "metrics")]
 use crate::metrics::connection_counter_metric;
@@ -22,17 +23,56 @@ use std::{
 use tokio::{sync::MutexGuard, task::AbortHandle};
 use tracing::{debug, error, info, trace, warn};
 
-/// Application close reason sent when a connection is intentionally torn down
-/// because a different, preferred connection to the same peer won
-/// simultaneous-open resolution.
-///
-/// The remote end recognises this reason (via
-/// [`Connection::remote_close_reason`](crate::connection::Connection::remote_close_reason))
-/// and treats the close as a deliberate supersession rather than a peer
-/// disconnect, so it does not mark the peer unresponsive or fire
-/// `peer_disconnect`.
+/// Reason sent when a preferred connection wins simultaneous-open resolution.
 pub(super) const SUPERSEDED_CLOSE_REASON: &[u8] =
     b"superseded by preferred connection";
+
+/// Outcome of the connection reader's accept loop.
+struct ReaderExit {
+    /// Human-readable description of why the loop ended.
+    err: String,
+    /// Whether the reader failure should mark the peer unresponsive.
+    mark_unresponsive: bool,
+}
+
+/// Cleanup action for a stopped connection reader.
+#[derive(Debug, PartialEq, Eq)]
+pub(super) enum ReaderCleanup {
+    /// Reports that the active peer connection failed.
+    PeerGone {
+        /// Whether to mark the peer unresponsive.
+        mark_unresponsive: bool,
+    },
+    /// Reports an intentional remote close to local handlers.
+    Graceful {
+        /// The remote's close reason.
+        reason: String,
+    },
+    /// Closes a superseded or inactive connection without notifying handlers.
+    Quiet,
+}
+
+/// Selects the cleanup action for a stopped reader.
+pub(super) fn classify_exit(
+    was_active: bool,
+    remote_close: Option<(CloseCode, Bytes)>,
+    mark_unresponsive: bool,
+) -> ReaderCleanup {
+    let superseded_by_remote =
+        matches!(remote_close, Some((CloseCode::Superseded, _)));
+
+    if !was_active || superseded_by_remote {
+        return ReaderCleanup::Quiet;
+    }
+
+    if let Some((CloseCode::Graceful, reason)) = remote_close {
+        return ReaderCleanup::Graceful {
+            reason: String::from_utf8_lossy(&reason).to_string(),
+        };
+    }
+
+    ReaderCleanup::PeerGone { mark_unresponsive }
+}
 
 pub(super) struct ConnectionContext {
     handler: Arc<TxImpHnd>,
@@ -240,12 +280,18 @@ impl ConnectionContext {
             // The displaced connection was previously counted as active.
             #[cfg(feature = "metrics")]
             connection_counter_metric().add(-1, &[]);
-            displaced.connection.close(0u8, SUPERSEDED_CLOSE_REASON);
+            displaced
+                .connection
+                .close(CloseCode::Superseded, SUPERSEDED_CLOSE_REASON);
         }
 
         true
     }
 
+    /// Abort the connection reader task, if it is still running.
+    ///
+    /// Used during transport shutdown, where the reader must stop
+    /// immediately without running its exit cleanup.
     pub fn abort_tasks(&self) {
         if let Some(abort_handle) = self
             .connection_reader_abort_handle
@@ -264,12 +310,20 @@ impl ConnectionContext {
     /// through the identity-aware cleanup path, which sees that this is not the
     /// active connection and so does not fire `peer_disconnect`.
     pub(super) fn close_quietly(&self) {
-        self.connection.close(0u8, SUPERSEDED_CLOSE_REASON);
+        self.connection
+            .close(CloseCode::Superseded, SUPERSEDED_CLOSE_REASON);
     }
 
-    pub fn disconnect(&self, reason: String) {
+    /// Close the connection and inform the local handlers.
+    ///
+    /// The close `code` and `reason` are sent to the remote in the QUIC
+    /// application close frame; use [`CloseCode::Graceful`] for an
+    /// intentional disconnect so the remote releases the connection
+    /// quietly instead of marking this peer unresponsive. Local handlers
+    /// are informed via `peer_disconnect` with the same reason.
+    pub fn disconnect(&self, code: CloseCode, reason: String) {
         info!(reason, remote_url = ?self.remote_url(), "Disconnecting from remote");
-        self.connection.close(0u8, reason.as_bytes());
+        self.connection.close(code, reason.as_bytes());
         if let Some(peer) = self.remote_url() {
             self.handler.peer_disconnect(peer, Some(reason));
             // Record connection counter metric.
@@ -278,14 +332,9 @@ impl ConnectionContext {
         }
     }
 
-    // Spawns an asynchronous task to continuously read and handle incoming uni-directional
-    // streams from an iroh connection. There is only one stream at a time incoming from a
-    // remote. It's read from until the connection is closed or an error occurs.
-    //
-    // Errors when receiving the preflight frame lead to a break of the loop accepting
-    // incoming streams. The preflight must succeed for data frames to be accepted. The
-    // connection cannot recover from a failed preflight, and a new connection must be
-    // established.
+    // Spawns an asynchronous task that reads incoming uni-directional
+    // streams from an iroh connection until it dies, and then runs the
+    // cleanup matching why it died.
     //
     // # Parameters
     // - `ctx`: The connection context containing handler and remote URL state.
@@ -298,124 +347,169 @@ impl ConnectionContext {
         local_url: Arc<RwLock<Option<Url>>>,
     ) -> AbortHandle {
         tokio::spawn(async move {
-            // Track whether to skip marking peer as unresponsive.
-            // This is set to true for temporary errors like NoLocalAgentsDuringPreflight,
-            // which indicate a timing issue rather than a network problem.
-            let mut skip_unresponsive = false;
+            let exit =
+                Self::run_reader_loop(&ctx, &connections, &local_url).await;
+            Self::cleanup_after_exit(ctx, &connections, exit).await;
+        })
+        .abort_handle()
+    }
 
-            let err = loop {
-                // Main loop to accept incoming unidirectional streams from the remote peer.
-                match ctx.connection.accept_uni().await {
-                    Ok(stream) => {
-                        info!(remote_id = ?ctx.connection.remote_id(), "Accepted incoming stream");
-                        let connections = connections.clone();
-                        let local_url = local_url.clone();
-                        // Read frames from the stream.
-                        //
-                        // `Ok(true)` keeps the connection open and awaits the next
-                        // incoming stream — returned both after a successful preflight
-                        // and after a data stream ends normally.
-                        //
-                        // `Ok(false)` means this connection lost simultaneous-open
-                        // resolution: a preferred connection to the same peer is already
-                        // active, so this reader stops quietly.
-                        //
-                        // `Err` means the preflight could not be received. The connection
-                        // must be closed, because a successful preflight is the
-                        // prerequisite for establishing a connection.
-                        match Self::handle_incoming_stream(
-                            ctx.clone(),
-                            stream,
-                            connections.clone(),
-                            local_url,
-                        )
-                            .await
-                        {
-                            Ok(true) => {}
-                            Ok(false) => {
-                                break "superseded by preferred connection".to_string();
-                            }
-                            Err(err) => {
-                                // Don't mark peer as unresponsive for NoLocalAgentsDuringPreflight
-                                // errors - this is a temporary state that will resolve once an
-                                // agent joins. It is not a real failure, so log it quietly and
-                                // reserve `error!` for genuine preflight failures.
-                                if matches!(err, K2Error::NoLocalAgentsDuringPreflight) {
-                                    skip_unresponsive = true;
-                                    debug!(?err, "Stream closed during preflight; no local agents yet");
-                                } else {
-                                    error!(?err, "Stream closed by remote");
-                                }
-                                break err.to_string();
-                            }
+    // Continuously read and handle incoming uni-directional streams from
+    // the iroh connection. There is only one stream at a time incoming from
+    // a remote. It's read from until the connection is closed or an error
+    // occurs.
+    //
+    // Errors when receiving the preflight frame lead to a break of the loop
+    // accepting incoming streams. The preflight must succeed for data frames
+    // to be accepted. The connection cannot recover from a failed preflight,
+    // and a new connection must be established.
+    async fn run_reader_loop(
+        ctx: &Arc<Self>,
+        connections: &Connections,
+        local_url: &Arc<RwLock<Option<Url>>>,
+    ) -> ReaderExit {
+        // Temporary preflight errors do not mark the peer unresponsive.
+        let mut mark_unresponsive = true;
+
+        let err = loop {
+            // Main loop to accept incoming unidirectional streams from the remote peer.
+            match ctx.connection.accept_uni().await {
+                Ok(stream) => {
+                    info!(remote_id = ?ctx.connection.remote_id(), "Accepted incoming stream");
+                    // Read frames from the stream.
+                    //
+                    // `Ok(true)` keeps the connection open and awaits the next
+                    // incoming stream — returned both after a successful preflight
+                    // and after a data stream ends normally.
+                    //
+                    // `Ok(false)` means this connection lost simultaneous-open
+                    // resolution: a preferred connection to the same peer is already
+                    // active, so this reader stops quietly.
+                    //
+                    // `Err` means the preflight could not be received. The connection
+                    // must be closed, because a successful preflight is the
+                    // prerequisite for establishing a connection.
+                    match Self::handle_incoming_stream(
+                        ctx.clone(),
+                        stream,
+                        connections.clone(),
+                        local_url.clone(),
+                    )
+                    .await
+                    {
+                        Ok(true) => {}
+                        Ok(false) => {
+                            break "superseded by preferred connection"
+                                .to_string();
                         }
-                    }
-                    Err(err) => {
-                        error!(?err, "Connection closed by remote");
-                        break err.to_string();
+                        Err(err) => {
+                            // Don't mark peer as unresponsive for NoLocalAgentsDuringPreflight
+                            // errors - this is a temporary state that will resolve once an
+                            // agent joins. It is not a real failure, so log it quietly and
+                            // reserve `error!` for genuine preflight failures.
+                            if matches!(
+                                err,
+                                K2Error::NoLocalAgentsDuringPreflight
+                            ) {
+                                mark_unresponsive = false;
+                                debug!(
+                                    ?err,
+                                    "Stream closed during preflight; no local agents yet"
+                                );
+                            } else {
+                                error!(?err, "Stream closed by remote");
+                            }
+                            break err.to_string();
+                        }
                     }
                 }
-            };
-
-            // The reader loop has ended. Only the connection that is *still the
-            // active connection* for this peer and that died for a genuine
-            // reason performs the "peer is gone" cleanup — marking the peer
-            // unresponsive and firing `peer_disconnect`.
-            //
-            // A connection that was superseded during simultaneous-open
-            // resolution, or already replaced by a newer connection, is torn
-            // down deliberately, not because the peer is gone. It closes
-            // quietly so that tearing it down does not mark the peer
-            // unresponsive or tear down the surviving connection. There are two
-            // such cases:
-            //
-            // - It is no longer the map entry for this peer (a preferred or
-            //   newer connection already replaced it locally).
-            // - The *remote* closed it with [`SUPERSEDED_CLOSE_REASON`] because
-            //   it preferred a different connection. This can arrive while this
-            //   connection is still our active map entry, because the winning
-            //   connection has not finished its preflight and registered yet.
-            //   Without honouring that reason we would wrongly mark the peer
-            //   unresponsive (which lasts until the agent info expires) and
-            //   stall gossip, even though a usable connection is moments away.
-            if let Some(remote_url) = ctx.remote_url() {
-                let superseded_by_remote = ctx
-                    .connection
-                    .remote_close_reason()
-                    .as_deref()
-                    == Some(SUPERSEDED_CLOSE_REASON);
-
-                let was_active = {
-                    let mut map = connections.write().expect("poisoned");
-                    match map.get(&remote_url) {
-                        Some(active) if Arc::ptr_eq(active, &ctx) => {
-                            map.remove(&remote_url);
-                            true
-                        }
-                        _ => false,
-                    }
-                };
-
-                if was_active && !superseded_by_remote {
-                    if !skip_unresponsive {
-                        info!(?remote_url, "Setting peer unresponsive");
-                        if let Err(err) = ctx.handler.set_unresponsive(remote_url.clone(), Timestamp::now()).await {
-                            warn!(?err, ?remote_url, "Failed to set peer unresponsive");
-                        }
-                    } else {
-                        info!(?remote_url, "Skipping set_unresponsive due to temporary error (no local agents)");
-                    }
-                    ctx.disconnect(err);
-                } else {
-                    debug!(?remote_url, reason = %err, superseded_by_remote, "Connection reader stopped without marking peer unresponsive (superseded or not the active connection)");
-                    ctx.connection.close(0u8, SUPERSEDED_CLOSE_REASON);
+                Err(err) => {
+                    error!(?err, "Connection closed by remote");
+                    break err.to_string();
                 }
-            } else {
-                // Preflight never completed, so no peer URL was learned and the
-                // peer was never surfaced to the handler.
-                ctx.connection.close(0u8, err.as_bytes());
             }
-        }).abort_handle()
+        };
+
+        ReaderExit {
+            err,
+            mark_unresponsive,
+        }
+    }
+
+    /// Remove `self` from the active-connections map if it is still the
+    /// entry for `remote_url`.
+    ///
+    /// Returns `true` if `self` was the active connection.
+    fn remove_if_active(
+        self: &Arc<Self>,
+        connections: &Connections,
+        remote_url: &Url,
+    ) -> bool {
+        let mut map = connections.write().expect("poisoned");
+        match map.get(remote_url) {
+            Some(active) if Arc::ptr_eq(active, self) => {
+                map.remove(remote_url);
+                true
+            }
+            _ => false,
+        }
+    }
+
+    // The reader loop has ended: run the cleanup matching why it ended.
+    // See [`ReaderCleanup`] for the possible verdicts and their rationale.
+    async fn cleanup_after_exit(
+        ctx: Arc<Self>,
+        connections: &Connections,
+        exit: ReaderExit,
+    ) {
+        let Some(remote_url) = ctx.remote_url() else {
+            // Preflight never completed, so no peer URL was learned and the
+            // peer was never surfaced to the handler.
+            ctx.connection
+                .close(CloseCode::Unspecified, exit.err.as_bytes());
+            return;
+        };
+
+        let was_active = ctx.remove_if_active(connections, &remote_url);
+        let verdict = classify_exit(
+            was_active,
+            ctx.connection.remote_close_reason(),
+            exit.mark_unresponsive,
+        );
+
+        match verdict {
+            ReaderCleanup::Graceful { reason } => {
+                info!(?remote_url, %reason, "Peer disconnected gracefully");
+                ctx.disconnect(CloseCode::Graceful, reason);
+            }
+            ReaderCleanup::PeerGone { mark_unresponsive } => {
+                if mark_unresponsive {
+                    info!(?remote_url, "Setting peer unresponsive");
+                    if let Err(err) = ctx
+                        .handler
+                        .set_unresponsive(remote_url.clone(), Timestamp::now())
+                        .await
+                    {
+                        warn!(
+                            ?err,
+                            ?remote_url,
+                            "Failed to set peer unresponsive"
+                        );
+                    }
+                } else {
+                    info!(
+                        ?remote_url,
+                        "Skipping set_unresponsive due to temporary error (no local agents)"
+                    );
+                }
+                ctx.disconnect(CloseCode::Unspecified, exit.err);
+            }
+            ReaderCleanup::Quiet => {
+                debug!(?remote_url, reason = %exit.err, "Connection reader stopped without marking peer unresponsive (superseded or not the active connection)");
+                ctx.connection
+                    .close(CloseCode::Superseded, SUPERSEDED_CLOSE_REASON);
+            }
+        }
     }
 
     // Handle frames from an incoming stream.

--- a/crates/transport_iroh/src/lib.rs
+++ b/crates/transport_iroh/src/lib.rs
@@ -219,6 +219,7 @@ use std::{
 use tokio::task::AbortHandle;
 use tracing::{debug, error, info, warn};
 
+mod close_code;
 mod frame;
 use frame::*;
 mod url;
@@ -1081,12 +1082,18 @@ impl TxImp for IrohTransport {
     fn disconnect(
         &self,
         peer: Url,
-        _payload: Option<(String, Bytes)>,
+        payload: Option<(String, Bytes)>,
     ) -> BoxFut<'_, ()> {
         if let Some(ctx) =
             self.connections.write().expect("poisoned").remove(&peer)
         {
-            ctx.disconnect("Disconnecting from remote".to_string());
+            // The reason string travels in the QUIC application close frame
+            // itself, so the encoded payload message is intentionally not
+            // sent as a data frame first.
+            let reason = payload
+                .map(|(reason, _)| reason)
+                .unwrap_or_else(|| "Disconnecting from remote".to_string());
+            ctx.disconnect(close_code::CloseCode::Graceful, reason);
         }
         Box::pin(async {})
     }

--- a/crates/transport_iroh/src/tests/close.rs
+++ b/crates/transport_iroh/src/tests/close.rs
@@ -1,0 +1,245 @@
+//! Unit tests for graceful connection close (issue #496).
+//!
+//! A graceful close is signalled with [`CloseCode::Graceful`] and a
+//! human-readable reason in the QUIC application close frame. The receiving
+//! side must release the connection quietly — informing handlers via
+//! `peer_disconnect(url, Some(reason))` — without marking the peer
+//! unresponsive.
+
+use super::support::{build_recording_handler, spawn_active_reader};
+use crate::close_code::CloseCode;
+use crate::connection_context::{ReaderCleanup, classify_exit};
+use bytes::Bytes;
+use kitsune2_test_utils::retry_fn_until_timeout;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+#[test]
+fn classify_not_active_is_quiet() {
+    assert_eq!(classify_exit(false, None, true), ReaderCleanup::Quiet);
+    assert_eq!(
+        classify_exit(
+            false,
+            Some((CloseCode::Graceful, Bytes::from_static(b"bye"))),
+            true
+        ),
+        ReaderCleanup::Quiet,
+        "a non-active connection is torn down quietly even on graceful close"
+    );
+}
+
+#[test]
+fn classify_superseded_code_is_quiet() {
+    assert_eq!(
+        classify_exit(
+            true,
+            Some((CloseCode::Superseded, Bytes::from_static(b"whatever"))),
+            true
+        ),
+        ReaderCleanup::Quiet
+    );
+}
+
+#[test]
+fn classify_graceful_close_carries_reason() {
+    assert_eq!(
+        classify_exit(
+            true,
+            Some((CloseCode::Graceful, Bytes::from_static(b"space closed"))),
+            true
+        ),
+        ReaderCleanup::Graceful {
+            reason: "space closed".to_string()
+        }
+    );
+}
+
+#[test]
+fn classify_genuine_death_marks_unresponsive() {
+    assert_eq!(
+        classify_exit(true, None, true),
+        ReaderCleanup::PeerGone {
+            mark_unresponsive: true
+        }
+    );
+}
+
+#[test]
+fn classify_temporary_error_skips_unresponsive() {
+    assert_eq!(
+        classify_exit(true, None, false),
+        ReaderCleanup::PeerGone {
+            mark_unresponsive: false
+        }
+    );
+}
+
+/// A remote graceful close must fire `peer_disconnect` with the remote's
+/// reason and must NOT mark the peer unresponsive.
+#[tokio::test(flavor = "multi_thread")]
+async fn graceful_remote_close_releases_quietly_with_reason() {
+    let recorder = build_recording_handler();
+
+    let reader = spawn_active_reader(
+        recorder.handler.clone(),
+        Some((CloseCode::Graceful, Bytes::from_static(b"space closed"))),
+    );
+    reader.accept_gate.notify_one();
+
+    retry_fn_until_timeout(
+        || async { !recorder.disconnects.lock().unwrap().is_empty() },
+        Some(5_000),
+        Some(10),
+    )
+    .await
+    .expect("condition not met within timeout");
+
+    assert_eq!(
+        recorder.unresponsive_calls.load(Ordering::SeqCst),
+        0,
+        "a graceful remote close must not mark the peer unresponsive"
+    );
+    let disconnects = recorder.disconnects.lock().unwrap();
+    assert!(
+        disconnects
+            .iter()
+            .all(|reason| reason.as_deref() == Some("space closed")),
+        "peer_disconnect must carry the remote's close reason, got {disconnects:?}"
+    );
+}
+
+/// A local `disconnect` must close the underlying connection with the
+/// `Graceful` code and the caller's reason bytes, and inform local handlers
+/// via `peer_disconnect` with the same reason.
+#[tokio::test(flavor = "multi_thread")]
+async fn local_disconnect_closes_with_graceful_code_and_reason() {
+    let recorder = build_recording_handler();
+
+    // Reader stays parked on the accept gate; only the explicit disconnect
+    // call below is exercised.
+    let reader = spawn_active_reader(recorder.handler.clone(), None);
+
+    reader
+        .ctx
+        .disconnect(CloseCode::Graceful, "bye".to_string());
+
+    assert_eq!(
+        reader.close_calls.lock().unwrap().as_slice(),
+        &[(CloseCode::Graceful, b"bye".to_vec())],
+        "the connection must be closed with the Graceful code and reason"
+    );
+    let disconnects = recorder.disconnects.lock().unwrap();
+    assert!(
+        !disconnects.is_empty()
+            && disconnects
+                .iter()
+                .all(|reason| reason.as_deref() == Some("bye")),
+        "local handlers must get peer_disconnect with the reason, got {disconnects:?}"
+    );
+    assert_eq!(recorder.unresponsive_calls.load(Ordering::SeqCst), 0);
+}
+
+/// End-to-end: a graceful `Transport::disconnect` on one peer must inform
+/// the other peer of the reason and must not get it marked unresponsive.
+#[cfg(feature = "test-utils")]
+#[tokio::test(flavor = "multi_thread")]
+async fn graceful_disconnect_informs_remote_end_to_end() {
+    use crate::test_utils::{IrohTransportTestHarness, MockTxHandler};
+    use kitsune2_api::DynTxHandler;
+    use kitsune2_test_utils::space::TEST_SPACE_ID;
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::{Arc, Mutex};
+
+    kitsune2_test_utils::enable_tracing();
+
+    let harness = IrohTransportTestHarness::new().await;
+
+    // Peer B records peer_disconnect reasons and set_unresponsive calls.
+    let b_disconnects: Arc<Mutex<Vec<Option<String>>>> =
+        Arc::new(Mutex::new(Vec::new()));
+    let b_unresponsive = Arc::new(AtomicUsize::new(0));
+    let b_got_notify = Arc::new(tokio::sync::Notify::new());
+    let mock_b = {
+        let disconnects = b_disconnects.clone();
+        let unresponsive = b_unresponsive.clone();
+        let got_notify = b_got_notify.clone();
+        Arc::new(MockTxHandler {
+            peer_disconnect: Arc::new(move |_peer, reason| {
+                disconnects.lock().unwrap().push(reason);
+            }),
+            set_unresponsive: Arc::new(move |_peer, _ts| {
+                unresponsive.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }),
+            recv_space_notify: Arc::new(move |_peer, _space, _data| {
+                got_notify.notify_one();
+                Ok(())
+            }),
+            ..MockTxHandler::default()
+        })
+    };
+    // `as` cannot unsize-coerce an Arc; a typed binding performs the
+    // Arc<MockTxHandler> -> Arc<dyn TxHandler> coercion.
+    let handler_b: DynTxHandler = mock_b.clone();
+    let transport_b = harness.build_transport(handler_b).await;
+    transport_b.register_space_handler(TEST_SPACE_ID, mock_b.clone());
+
+    let mock_a = Arc::new(MockTxHandler::default());
+    let handler_a: DynTxHandler = mock_a.clone();
+    let transport_a = harness.build_transport(handler_a).await;
+    transport_a.register_space_handler(TEST_SPACE_ID, mock_a.clone());
+
+    // Wait until B has a real listening address (new_listening_address
+    // updates MockTxHandler::current_url).
+    let initial_url = crate::test_utils::dummy_url();
+    retry_fn_until_timeout(
+        || async { *mock_b.current_url.lock().unwrap() != initial_url },
+        Some(30_000),
+        Some(10),
+    )
+    .await
+    .expect("condition not met within timeout");
+    let url_b = mock_b.current_url.lock().unwrap().clone();
+
+    // Establish a connection A -> B with a space notify and wait for B to
+    // receive it.
+    transport_a
+        .send_space_notify(
+            url_b.clone(),
+            TEST_SPACE_ID,
+            Bytes::from_static(b"hello"),
+        )
+        .await
+        .unwrap();
+    tokio::time::timeout(Duration::from_secs(30), b_got_notify.notified())
+        .await
+        .expect("B did not receive the space notify");
+
+    // A disconnects gracefully with a reason.
+    transport_a
+        .disconnect(url_b, Some("test disconnect".to_string()))
+        .await;
+
+    // B must observe the disconnect with A's reason...
+    retry_fn_until_timeout(
+        || async { !b_disconnects.lock().unwrap().is_empty() },
+        Some(30_000),
+        Some(10),
+    )
+    .await
+    .expect("condition not met within timeout");
+    let disconnects = b_disconnects.lock().unwrap();
+    assert!(
+        disconnects
+            .iter()
+            .all(|reason| reason.as_deref() == Some("test disconnect")),
+        "B must get the graceful close reason, got {disconnects:?}"
+    );
+
+    // ...and must NOT have marked A unresponsive.
+    assert_eq!(
+        b_unresponsive.load(Ordering::SeqCst),
+        0,
+        "a graceful disconnect must not mark the peer unresponsive"
+    );
+}

--- a/crates/transport_iroh/src/tests/mod.rs
+++ b/crates/transport_iroh/src/tests/mod.rs
@@ -2,10 +2,12 @@
 
 use super::*;
 
+mod close;
 mod connect_failure;
 mod frame;
 mod simultaneous_open;
 mod stream;
+mod support;
 mod url;
 
 #[test]

--- a/crates/transport_iroh/src/tests/simultaneous_open.rs
+++ b/crates/transport_iroh/src/tests/simultaneous_open.rs
@@ -11,258 +11,68 @@
 //! mistaken for a genuine peer disconnect. Doing so spuriously marks the peer
 //! unresponsive (which lasts until the agent info expires) and stalls gossip.
 
-use crate::connection::{Connection, DynConnection};
-use crate::connection_context::{
-    ConnectionContext, ConnectionContextParams, SUPERSEDED_CLOSE_REASON,
-};
-use crate::stream::{DynIrohRecvStream, DynIrohSendStream};
-use crate::test_utils::MockTxHandler;
-use crate::url::endpoint_from_url;
+use super::support::{build_recording_handler, spawn_active_reader};
+use crate::close_code::CloseCode;
+use crate::connection_context::SUPERSEDED_CLOSE_REASON;
 use bytes::Bytes;
-use iroh::EndpointId;
-use kitsune2_api::{
-    BoxFut, DefaultTransport, K2Error, K2Result, TransportStats, TxImp,
-    TxImpHnd, Url,
-};
-use kitsune2_test_utils::space::TEST_SPACE_ID;
-use std::collections::HashMap;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::{Arc, RwLock};
-use std::time::{Duration, Instant};
-
-/// A fake [`Connection`] whose first `accept_uni` blocks until released and
-/// then fails, simulating the connection being closed. `remote_close_reason`
-/// returns whatever the test configured, letting us drive both the
-/// "superseded by remote" and the "genuine death" cleanup paths.
-struct FakeConnection {
-    /// Released by the test once the context is registered as active, so the
-    /// reader's exit cleanup observes the populated `connections` map.
-    accept_gate: Arc<tokio::sync::Notify>,
-    remote_close_reason: Option<Bytes>,
-    remote_id: EndpointId,
-    close_calls: Arc<AtomicUsize>,
-}
-
-impl Connection for FakeConnection {
-    fn open_uni(&self) -> BoxFut<'_, K2Result<DynIrohSendStream>> {
-        Box::pin(async {
-            Err(K2Error::other("open_uni not used in this test"))
-        })
-    }
-
-    fn accept_uni(&self) -> BoxFut<'_, K2Result<DynIrohRecvStream>> {
-        let gate = self.accept_gate.clone();
-        Box::pin(async move {
-            gate.notified().await;
-            Err(K2Error::other("remote closed connection"))
-        })
-    }
-
-    fn remote_id(&self) -> EndpointId {
-        self.remote_id
-    }
-
-    fn close(&self, _code: u8, _reason: &[u8]) {
-        self.close_calls.fetch_add(1, Ordering::SeqCst);
-    }
-
-    fn is_direct(&self) -> bool {
-        false
-    }
-
-    fn remote_close_reason(&self) -> Option<Bytes> {
-        self.remote_close_reason.clone()
-    }
-}
-
-/// Minimal `TxImp` stub, used only so we can build a `DefaultTransport` and
-/// register a space handler against the shared `TxImpHnd` (which is what makes
-/// `set_unresponsive` reach our recording handler).
-#[derive(Debug)]
-struct StubTxImp;
-
-impl TxImp for StubTxImp {
-    fn url(&self) -> Option<Url> {
-        None
-    }
-
-    fn disconnect(
-        &self,
-        _peer: Url,
-        _payload: Option<(String, Bytes)>,
-    ) -> BoxFut<'_, ()> {
-        Box::pin(async {})
-    }
-
-    fn send(&self, _peer: Url, _data: Bytes) -> BoxFut<'_, K2Result<()>> {
-        Box::pin(async { unreachable!("StubTxImp::send should not be called") })
-    }
-
-    fn get_connected_peers(&self) -> BoxFut<'_, K2Result<Vec<Url>>> {
-        Box::pin(async { Ok(Vec::new()) })
-    }
-
-    fn dump_network_stats(&self) -> BoxFut<'_, K2Result<TransportStats>> {
-        Box::pin(async {
-            Ok(TransportStats {
-                backend: String::new(),
-                peer_urls: Vec::new(),
-                connections: Vec::new(),
-            })
-        })
-    }
-}
-
-struct Recorder {
-    handler: Arc<TxImpHnd>,
-    unresponsive_calls: Arc<AtomicUsize>,
-    disconnect_calls: Arc<AtomicUsize>,
-}
-
-/// Build a `TxImpHnd` whose `set_unresponsive` and `peer_disconnect` calls are
-/// counted, with a space handler registered so `set_unresponsive` propagates.
-fn build_recording_handler() -> Recorder {
-    let unresponsive_calls = Arc::new(AtomicUsize::new(0));
-    let disconnect_calls = Arc::new(AtomicUsize::new(0));
-    let mock = {
-        let unresponsive = unresponsive_calls.clone();
-        let disconnect = disconnect_calls.clone();
-        Arc::new(MockTxHandler {
-            set_unresponsive: Arc::new(move |_peer, _ts| {
-                unresponsive.fetch_add(1, Ordering::SeqCst);
-                Ok(())
-            }),
-            peer_disconnect: Arc::new(move |_peer, _reason| {
-                disconnect.fetch_add(1, Ordering::SeqCst);
-            }),
-            ..MockTxHandler::default()
-        })
-    };
-    let handler = TxImpHnd::new(mock.clone());
-    let transport = DefaultTransport::create(&handler, Arc::new(StubTxImp));
-    transport.register_space_handler(TEST_SPACE_ID, mock);
-    Recorder {
-        handler,
-        unresponsive_calls,
-        disconnect_calls,
-    }
-}
-
-fn remote_url() -> Url {
-    // 64 hex characters → valid iroh EndpointId encoding.
-    Url::from_str(
-        "https://relay.example.com:443/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-    )
-    .unwrap()
-}
-
-/// Build a connection context whose reader is parked in `accept_uni`, register
-/// it as the active connection for `remote_url`, then release the reader so its
-/// exit cleanup runs against a populated `connections` map.
-fn spawn_active_reader(
-    handler: Arc<TxImpHnd>,
-    remote_close_reason: Option<Bytes>,
-) -> (Arc<tokio::sync::Notify>, Arc<AtomicUsize>) {
-    let url = remote_url();
-    let accept_gate = Arc::new(tokio::sync::Notify::new());
-    let close_calls = Arc::new(AtomicUsize::new(0));
-    let connection: DynConnection = Arc::new(FakeConnection {
-        accept_gate: accept_gate.clone(),
-        remote_close_reason,
-        remote_id: endpoint_from_url(&url).unwrap().id,
-        close_calls: close_calls.clone(),
-    });
-
-    let connections = Arc::new(RwLock::new(HashMap::new()));
-
-    let ctx = ConnectionContext::new(ConnectionContextParams {
-        handler,
-        connection,
-        local_id: [0u8; 32],
-        dialed_by_us: true,
-        remote_url: Some(url.clone()),
-        preflight_sent: true,
-        opened_at_s: 0,
-        connections: connections.clone(),
-        local_url: Arc::new(RwLock::new(Some(url.clone()))),
-        space_relays: Arc::new(RwLock::new(HashMap::new())),
-        max_frame_bytes: 64 * 1024,
-    });
-
-    // Register as the active connection *before* releasing the reader, so the
-    // exit cleanup sees this context as the live map entry (`was_active`).
-    connections.write().unwrap().insert(url, ctx);
-
-    // Release the parked `accept_uni`, which fails and drives the reader into
-    // its exit cleanup.
-    accept_gate.notify_one();
-
-    (accept_gate, close_calls)
-}
-
-/// Poll `condition` every 10ms until it returns true or `timeout` elapses.
-async fn wait_for<F: FnMut() -> bool>(mut condition: F, timeout: Duration) {
-    let deadline = Instant::now() + timeout;
-    loop {
-        if condition() {
-            return;
-        }
-        assert!(
-            Instant::now() < deadline,
-            "condition not met within timeout"
-        );
-        tokio::time::sleep(Duration::from_millis(10)).await;
-    }
-}
+use kitsune2_test_utils::retry_fn_until_timeout;
+use std::sync::atomic::Ordering;
 
 /// When the active connection is closed by the remote with the superseded
-/// reason — i.e. the remote preferred a different connection during
+/// close code — i.e. the remote preferred a different connection during
 /// simultaneous-open resolution — the reader exit must NOT mark the peer
 /// unresponsive or fire `peer_disconnect`.
 #[tokio::test(flavor = "multi_thread")]
 async fn superseded_remote_close_does_not_mark_unresponsive() {
     let recorder = build_recording_handler();
 
-    let (_gate, close_calls) = spawn_active_reader(
+    let reader = spawn_active_reader(
         recorder.handler.clone(),
-        Some(Bytes::from_static(SUPERSEDED_CLOSE_REASON)),
+        Some((
+            CloseCode::Superseded,
+            Bytes::from_static(SUPERSEDED_CLOSE_REASON),
+        )),
     );
+    reader.accept_gate.notify_one();
 
     // The exit cleanup finishes by closing the connection.
-    wait_for(
-        || close_calls.load(Ordering::SeqCst) >= 1,
-        Duration::from_secs(5),
+    retry_fn_until_timeout(
+        || async { !reader.close_calls.lock().unwrap().is_empty() },
+        Some(5_000),
+        Some(10),
     )
-    .await;
+    .await
+    .expect("condition not met within timeout");
 
     assert_eq!(
         recorder.unresponsive_calls.load(Ordering::SeqCst),
         0,
         "a connection superseded by the remote must not mark the peer unresponsive"
     );
-    assert_eq!(
-        recorder.disconnect_calls.load(Ordering::SeqCst),
-        0,
+    assert!(
+        recorder.disconnects.lock().unwrap().is_empty(),
         "a connection superseded by the remote must not fire peer_disconnect"
     );
 }
 
-/// When the active connection dies without the superseded reason (a genuine
-/// peer disconnect), the reader exit must still mark the peer unresponsive and
-/// fire `peer_disconnect`. Guards against the fix over-suppressing real
-/// disconnects.
+/// When the active connection dies without a graceful or superseded close
+/// (a genuine peer disconnect), the reader exit must still mark the peer
+/// unresponsive and fire `peer_disconnect`. Guards against over-suppressing
+/// real disconnects.
 #[tokio::test(flavor = "multi_thread")]
 async fn genuine_remote_close_marks_unresponsive() {
     let recorder = build_recording_handler();
 
-    let (_gate, _close_calls) =
-        spawn_active_reader(recorder.handler.clone(), None);
+    let reader = spawn_active_reader(recorder.handler.clone(), None);
+    reader.accept_gate.notify_one();
 
-    wait_for(
-        || recorder.disconnect_calls.load(Ordering::SeqCst) >= 1,
-        Duration::from_secs(5),
+    retry_fn_until_timeout(
+        || async { !recorder.disconnects.lock().unwrap().is_empty() },
+        Some(5_000),
+        Some(10),
     )
-    .await;
+    .await
+    .expect("condition not met within timeout");
 
     assert_eq!(
         recorder.unresponsive_calls.load(Ordering::SeqCst),

--- a/crates/transport_iroh/src/tests/support.rs
+++ b/crates/transport_iroh/src/tests/support.rs
@@ -1,0 +1,213 @@
+//! Shared helpers for connection-reader exit-cleanup tests.
+//!
+//! Used by the `simultaneous_open` and `close` test modules to drive a
+//! [`ConnectionContext`] reader into its exit cleanup with a configurable
+//! remote close, and to record the resulting handler calls.
+
+use crate::close_code::CloseCode;
+use crate::connection::{Connection, DynConnection};
+use crate::connection_context::{ConnectionContext, ConnectionContextParams};
+use crate::stream::{DynIrohRecvStream, DynIrohSendStream};
+use crate::test_utils::MockTxHandler;
+use crate::url::endpoint_from_url;
+use bytes::Bytes;
+use iroh::EndpointId;
+use kitsune2_api::{
+    BoxFut, DefaultTransport, K2Error, K2Result, TransportStats, TxImp,
+    TxImpHnd, Url,
+};
+use kitsune2_test_utils::space::TEST_SPACE_ID;
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex, RwLock};
+
+/// Recorded [`Connection::close`] calls as `(code, reason)` pairs.
+pub(super) type CloseCalls = Arc<Mutex<Vec<(CloseCode, Vec<u8>)>>>;
+
+/// A fake [`Connection`] whose first `accept_uni` blocks until released and
+/// then fails, simulating the connection being closed. `remote_close_reason`
+/// returns whatever the test configured, letting tests drive each exit
+/// cleanup path.
+pub(super) struct FakeConnection {
+    /// Released by the test once the context is registered as active, so
+    /// the reader's exit cleanup observes the populated `connections` map.
+    pub accept_gate: Arc<tokio::sync::Notify>,
+    pub remote_close: Option<(CloseCode, Bytes)>,
+    pub remote_id: EndpointId,
+    /// Records every `close` call as `(code, reason)`.
+    pub close_calls: CloseCalls,
+}
+
+impl Connection for FakeConnection {
+    fn open_uni(&self) -> BoxFut<'_, K2Result<DynIrohSendStream>> {
+        Box::pin(async {
+            Err(K2Error::other("open_uni not used in this test"))
+        })
+    }
+
+    fn accept_uni(&self) -> BoxFut<'_, K2Result<DynIrohRecvStream>> {
+        let gate = self.accept_gate.clone();
+        Box::pin(async move {
+            gate.notified().await;
+            Err(K2Error::other("remote closed connection"))
+        })
+    }
+
+    fn remote_id(&self) -> EndpointId {
+        self.remote_id
+    }
+
+    fn close(&self, code: CloseCode, reason: &[u8]) {
+        self.close_calls
+            .lock()
+            .unwrap()
+            .push((code, reason.to_vec()));
+    }
+
+    fn is_direct(&self) -> bool {
+        false
+    }
+
+    fn remote_close_reason(&self) -> Option<(CloseCode, Bytes)> {
+        self.remote_close.clone()
+    }
+}
+
+/// Minimal `TxImp` stub, used only so we can build a `DefaultTransport` and
+/// register a space handler against the shared `TxImpHnd` (which is what
+/// makes `set_unresponsive` reach our recording handler).
+#[derive(Debug)]
+struct StubTxImp;
+
+impl TxImp for StubTxImp {
+    fn url(&self) -> Option<Url> {
+        None
+    }
+
+    fn disconnect(
+        &self,
+        _peer: Url,
+        _payload: Option<(String, Bytes)>,
+    ) -> BoxFut<'_, ()> {
+        Box::pin(async {})
+    }
+
+    fn send(&self, _peer: Url, _data: Bytes) -> BoxFut<'_, K2Result<()>> {
+        Box::pin(async { unreachable!("StubTxImp::send should not be called") })
+    }
+
+    fn get_connected_peers(&self) -> BoxFut<'_, K2Result<Vec<Url>>> {
+        Box::pin(async { Ok(Vec::new()) })
+    }
+
+    fn dump_network_stats(&self) -> BoxFut<'_, K2Result<TransportStats>> {
+        Box::pin(async {
+            Ok(TransportStats {
+                backend: String::new(),
+                peer_urls: Vec::new(),
+                connections: Vec::new(),
+            })
+        })
+    }
+}
+
+pub(super) struct Recorder {
+    pub handler: Arc<TxImpHnd>,
+    pub unresponsive_calls: Arc<AtomicUsize>,
+    /// Reason of every `peer_disconnect` call, in order. NOTE: the handler
+    /// fan-out delivers each disconnect to both the space handler and the
+    /// base handler, so a single disconnect records two identical entries.
+    pub disconnects: Arc<Mutex<Vec<Option<String>>>>,
+}
+
+/// Build a `TxImpHnd` whose `set_unresponsive` and `peer_disconnect` calls
+/// are recorded, with a space handler registered so `set_unresponsive`
+/// propagates.
+pub(super) fn build_recording_handler() -> Recorder {
+    let unresponsive_calls = Arc::new(AtomicUsize::new(0));
+    let disconnects: Arc<Mutex<Vec<Option<String>>>> =
+        Arc::new(Mutex::new(Vec::new()));
+    let mock = {
+        let unresponsive = unresponsive_calls.clone();
+        let disconnects = disconnects.clone();
+        Arc::new(MockTxHandler {
+            set_unresponsive: Arc::new(move |_peer, _ts| {
+                unresponsive.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }),
+            peer_disconnect: Arc::new(move |_peer, reason| {
+                disconnects.lock().unwrap().push(reason);
+            }),
+            ..MockTxHandler::default()
+        })
+    };
+    let handler = TxImpHnd::new(mock.clone());
+    let transport = DefaultTransport::create(&handler, Arc::new(StubTxImp));
+    transport.register_space_handler(TEST_SPACE_ID, mock);
+    Recorder {
+        handler,
+        unresponsive_calls,
+        disconnects,
+    }
+}
+
+pub(super) fn remote_url() -> Url {
+    // 64 hex characters → valid iroh EndpointId encoding.
+    Url::from_str(
+        "https://relay.example.com:443/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    )
+    .unwrap()
+}
+
+pub(super) struct ActiveReader {
+    pub ctx: Arc<ConnectionContext>,
+    /// Release this to let the parked `accept_uni` fail, driving the reader
+    /// into its exit cleanup.
+    pub accept_gate: Arc<tokio::sync::Notify>,
+    pub close_calls: CloseCalls,
+}
+
+/// Build a connection context whose reader is parked in `accept_uni` and
+/// register it as the active connection for [`remote_url`]. The caller
+/// releases the reader via `accept_gate.notify_one()` so its exit cleanup
+/// runs against a populated `connections` map.
+pub(super) fn spawn_active_reader(
+    handler: Arc<TxImpHnd>,
+    remote_close: Option<(CloseCode, Bytes)>,
+) -> ActiveReader {
+    let url = remote_url();
+    let accept_gate = Arc::new(tokio::sync::Notify::new());
+    let close_calls = Arc::new(Mutex::new(Vec::new()));
+    let connection: DynConnection = Arc::new(FakeConnection {
+        accept_gate: accept_gate.clone(),
+        remote_close,
+        remote_id: endpoint_from_url(&url).unwrap().id,
+        close_calls: close_calls.clone(),
+    });
+
+    let connections = Arc::new(RwLock::new(HashMap::new()));
+
+    let ctx = ConnectionContext::new(ConnectionContextParams {
+        handler,
+        connection,
+        local_id: [0u8; 32],
+        dialed_by_us: true,
+        remote_url: Some(url.clone()),
+        preflight_sent: true,
+        opened_at_s: 0,
+        connections: connections.clone(),
+        local_url: Arc::new(RwLock::new(Some(url.clone()))),
+        space_relays: Arc::new(RwLock::new(HashMap::new())),
+        max_frame_bytes: 64 * 1024,
+    });
+
+    // Register as the active connection *before* the reader is released, so
+    // the exit cleanup sees this context as the live map entry (`was_active`).
+    connections.write().unwrap().insert(url, ctx.clone());
+
+    ActiveReader {
+        ctx,
+        accept_gate,
+        close_calls,
+    }
+}


### PR DESCRIPTION
## What changed

A connection to another peer can now be closed on purpose, with a reason. The closing side sends a numeric close code and a short reason text as part of the close itself. The other side reads that code and, when the close was intentional, it lets the connection go quietly and passes the reason on to the application instead of treating the peer as unreachable.

Before this change, an intentional close looked exactly like a network failure to the other side. The other peer would mark the closer as unresponsive and avoid it until that state expired, which could stall communication for no good reason. One example: when a space is removed, the node closes its connections, and the peers on the other end wrongly penalised it.

There are three close codes: one for an intentional close, one for the case where two peers opened duplicate connections at the same time and one of them is discarded, and a fallback for anything else. Closes from peers running older versions are still understood through the previous mechanism, so mixed-version networks keep working.

## Why

Closes #496. The issue asks for the ability to close a connection, a defined set of close reasons, and for the other side to be told the close was intentional so it can release the connection without treating it as an error. Upcoming connection management work needs this.

## Notes

The issue suggested looking into the strum crate for mapping codes to reasons. It was evaluated and skipped: there is a single small enum, and a hand-written mapping is less code than the dependency.

The issue also mentioned a possible double disconnect through the reader task. That was already fixed on main by an earlier change (88949e9), so this PR does not need to address it.

Known limitation: a peer running an older version does not understand the new codes, so it will still treat a graceful close from a new peer as a failure. That resolves as peers upgrade.

The cleanup logic that decides how to react when a connection dies was also restructured into a small decision function with its own table of unit tests, plus an end to end test where one peer disconnects and the other observes the reason without penalising it.