### PR TITLE
ci: speed up the Test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,21 @@ on:
   pull_request: {}
 
 jobs:
-  static:
+  fmt:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-make@0.37.24,taplo@0.9.3
+
+      - name: Format
+        run: cargo make static-fmt
+
+  clippy:
+    needs: fmt
     runs-on: ubuntu-latest
 
     steps:
@@ -22,11 +36,33 @@ jobs:
         with:
           cmake-version: '3.31.x'
 
-      - name: Static
-        run: cargo make static
+      - name: Clippy
+        run: cargo make clippy
+
+  doc-check:
+    needs: fmt
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-make@0.37.24
+
+      - uses: Swatinem/rust-cache@v2
+
+      # we cannot use cmake 4 until openssl-src is updated
+      - name: cmake
+        uses: jwlawson/actions-setup-cmake@v2
+        with:
+          cmake-version: '3.31.x'
+
+      - name: Doc check
+        run: cargo make doc-check
 
   test:
-    needs: static
+    needs: fmt
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
@@ -72,7 +108,7 @@ jobs:
         run: cargo run --example schema --features schema
 
   test-windows:
-    needs: static
+    needs: fmt
     strategy:
       matrix:
         os: [windows-latest]
@@ -114,7 +150,7 @@ jobs:
           cargo make test
 
   nix-build:
-    needs: static
+    needs: fmt
     strategy:
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
@@ -135,7 +171,7 @@ jobs:
       - run: nix build --verbose -L .#bootstrap-srv
 
   docker-build-bootstrap:
-    needs: static
+    needs: fmt
     runs-on: ubuntu-latest
 
     steps:
@@ -145,7 +181,7 @@ jobs:
         run: docker buildx build -f docker/kitsune2_bootstrap_srv/Dockerfile .
 
   docker-build-bootstrap-auth-test:
-    needs: static
+    needs: fmt
     runs-on: ubuntu-latest
 
     steps:
@@ -162,7 +198,9 @@ jobs:
     if: ${{ always() }}
     runs-on: "ubuntu-latest"
     needs:
-      - static
+      - fmt
+      - clippy
+      - doc-check
       - test
       - test-windows
       - nix-build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,13 @@ name: Test
 
 on:
   pull_request: {}
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: test-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   fmt:
@@ -29,6 +36,8 @@ jobs:
           tool: cargo-make@0.37.24
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # we cannot use cmake 4 until openssl-src is updated
       - name: cmake
@@ -51,6 +60,8 @@ jobs:
           tool: cargo-make@0.37.24
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # we cannot use cmake 4 until openssl-src is updated
       - name: cmake
@@ -92,6 +103,8 @@ jobs:
           tool: cargo-make@0.37.24
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # we cannot use cmake 4 until openssl-src is updated
       - name: cmake
@@ -129,6 +142,8 @@ jobs:
           tool: cargo-make@0.37.24
 
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # we cannot use cmake 4 until openssl-src is updated
       - name: cmake
@@ -192,6 +207,7 @@ jobs:
 
   changelog-preview-comment:
       name: Add comment of changelog preview
+      if: github.event_name == 'pull_request'
       uses: holochain/actions/.github/workflows/changelog-preview-comment.yml@v1.16.0
 
   ci_pass:

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -71,7 +71,7 @@ args = ["format"]
 #
 
 [tasks.static-fmt]
-description = "Formatting checks only, with no compilation. Used as a fast CI gate"
+description = "Formatting checks only, with no compilation"
 workspace = false
 dependencies = ["format-toml-check", "format-check"]
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -70,6 +70,11 @@ args = ["format"]
 # Helper tasks
 #
 
+[tasks.static-fmt]
+description = "Formatting checks only, with no compilation. Used as a fast CI gate"
+workspace = false
+dependencies = ["format-toml-check", "format-check"]
+
 [tasks.static]
 description = "Run all static checks"
 dependencies = [


### PR DESCRIPTION
The `Test` workflow takes 56-95 minutes per pull request. Two measured causes:

**Everything waited on `static`.** It took 27-28 minutes and every other job declared `needs: static`, so the critical path was `static` (28m) then `test-windows` (28m).

**No pull request could restore a cache.** `test.yaml` ran on `pull_request` only, so every cache it wrote was scoped to `refs/pull/N/merge`. GitHub only lets a pull request restore from its own ref or its base branch, and `main` had no cache for these jobs — so every new branch built cold. Same branch, back to back: 58m34s cold, then 13m43s warm. Repository cache usage was also 11.49 GB against a 10 GB limit, so entries were evicting each other.

## Changes

- **Split `static`** into a `fmt` gate (formatting only, ~0.7s of work, no compilation) plus parallel `clippy` and `doc-check` jobs. Measured with `cargo --unit-graph`, the three configurations share *zero* compilation units — 1090 + 711 + 1087 = 2888, exactly the total distinct count — because each differs in toolchain, feature set, or profile. Splitting them duplicates no work.
- **Dropped `bench-build` from the pull-request path.** It was 1087 units, 910 of them at opt-level 3, forked into all 11 crates — but only `bootstrap_srv` has benchmarks. `bench.yaml` on `main` already builds and runs every bench target.
- **Seeded caches from `main`** via a `push: branches: [main]` trigger, with `save-if` making pull requests restore-only so one authoritative set fits the 10 GB budget.
- **Added a concurrency group.** `cancel-in-progress` is conditional on `pull_request` — cancelling a `main` run would abort the cache-seeding job this depends on.
- **Gated `changelog-preview-comment`** to `pull_request`, since it posts onto a pull request and the workflow now also runs on `main`.

Per-crate test invocation is deliberately kept: measured at 1090 distinct units against 947 for a unified workspace build, so the feature isolation costs 15%, not a multiple. It catches bugs where a crate only compiles because a sibling's dev-dependencies enable a feature.

## Expected

~30 min cold, ~18-25 min warm. Note the payoff starts one merge late — the merge commit's own `main` run restores nothing, because no `main`-scoped cache exists yet, and will take the full cold path.
