### PR TITLE
fix(transport_iroh): keep QAD enabled when a relay is re-inserted

### DIFF
--- a/crates/transport_iroh/src/lib.rs
+++ b/crates/transport_iroh/src/lib.rs
@@ -719,11 +719,16 @@ impl IrohTransport {
     /// iroh sends the token as an `Authorization: Bearer` header on every
     /// relay WebSocket upgrade, so it is automatically re-presented on
     /// every reconnect.
+    ///
+    /// QUIC address discovery stays enabled on the relay's default QAD
+    /// port, matching what `RelayMap::from_iter` configures at endpoint
+    /// creation. The endpoint relies on QAD to learn its public address;
+    /// without it NAT traversal only ever advertises local candidates.
     fn relay_config_with_token(
         relay_url: &RelayUrl,
         token: Option<&str>,
     ) -> Arc<RelayConfig> {
-        let mut config = RelayConfig::new(relay_url.clone(), None);
+        let mut config = RelayConfig::from(relay_url.clone());
         if let Some(token) = token {
             config = config.with_auth_token(token);
         }

--- a/crates/transport_iroh/src/lib.rs
+++ b/crates/transport_iroh/src/lib.rs
@@ -719,11 +719,6 @@ impl IrohTransport {
     /// iroh sends the token as an `Authorization: Bearer` header on every
     /// relay WebSocket upgrade, so it is automatically re-presented on
     /// every reconnect.
-    ///
-    /// QUIC address discovery stays enabled on the relay's default QAD
-    /// port, matching what `RelayMap::from_iter` configures at endpoint
-    /// creation. The endpoint relies on QAD to learn its public address;
-    /// without it NAT traversal only ever advertises local candidates.
     fn relay_config_with_token(
         relay_url: &RelayUrl,
         token: Option<&str>,

--- a/crates/transport_iroh/src/tests/mod.rs
+++ b/crates/transport_iroh/src/tests/mod.rs
@@ -5,6 +5,7 @@ use super::*;
 mod close;
 mod connect_failure;
 mod frame;
+mod relay_qad;
 mod simultaneous_open;
 mod stream;
 mod support;

--- a/crates/transport_iroh/src/tests/relay_qad.rs
+++ b/crates/transport_iroh/src/tests/relay_qad.rs
@@ -1,16 +1,27 @@
-//! Re-inserting a relay must not strip QUIC address discovery (QAD) from it.
-//!
-//! A relay configured at endpoint creation gets QAD enabled by
-//! `RelayMap::from_iter`. `configure_for_space` later inserts the same relay
-//! again through `do_insert_relay`, and iroh's `insert_relay` replaces the
-//! existing map entry rather than merging into it. If the replacement carries
-//! no QAD config, net_report can no longer learn the endpoint's public
-//! address, every NAT-traversal round advertises LAN candidates only, and
-//! peers behind different NATs never go direct. That symptom cannot show on
-//! loopback (the QAD-discovered address is the local address), so this test
-//! asserts the relay-map state that the symptom follows from.
+//! `relay_config_with_token` builds the relay config used when authentication
+//! is enabled on the default relay or a relay is customized per space. It must
+//! keep QUIC address discovery (QAD) enabled: without it the endpoint cannot
+//! learn its public address, so NAT traversal only advertises local candidates
+//! and peers behind different NATs never go direct. That cannot be reproduced
+//! on loopback, so these tests assert the relay config instead.
 
 use super::*;
+
+#[test]
+fn relay_config_keeps_qad_enabled_with_and_without_token() {
+    let url = RelayUrl::from_str("http://127.0.0.1:1/relay/").unwrap();
+    let default_quic = RelayConfig::from(url.clone()).quic;
+    assert!(default_quic.is_some(), "iroh enables QAD by default");
+
+    let unauthenticated = IrohTransport::relay_config_with_token(&url, None);
+    assert_eq!(unauthenticated.quic, default_quic);
+    assert_eq!(unauthenticated.auth_token, None);
+
+    let authenticated =
+        IrohTransport::relay_config_with_token(&url, Some("test-token"));
+    assert_eq!(authenticated.quic, default_quic);
+    assert_eq!(authenticated.auth_token.as_deref(), Some("test-token"));
+}
 
 #[tokio::test(flavor = "multi_thread")]
 async fn reinserting_relay_keeps_qad_enabled() {

--- a/crates/transport_iroh/src/tests/relay_qad.rs
+++ b/crates/transport_iroh/src/tests/relay_qad.rs
@@ -1,0 +1,49 @@
+//! Re-inserting a relay must not strip QUIC address discovery (QAD) from it.
+//!
+//! A relay configured at endpoint creation gets QAD enabled by
+//! `RelayMap::from_iter`. `configure_for_space` later inserts the same relay
+//! again through `do_insert_relay`, and iroh's `insert_relay` replaces the
+//! existing map entry rather than merging into it. If the replacement carries
+//! no QAD config, net_report can no longer learn the endpoint's public
+//! address, every NAT-traversal round advertises LAN candidates only, and
+//! peers behind different NATs never go direct. That symptom cannot show on
+//! loopback (the QAD-discovered address is the local address), so this test
+//! asserts the relay-map state that the symptom follows from.
+
+use super::*;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn reinserting_relay_keeps_qad_enabled() {
+    let url = RelayUrl::from_str("http://127.0.0.1:1/relay/").unwrap();
+    let raw = Endpoint::builder(Minimal)
+        .relay_mode(RelayMode::Custom(RelayMap::from_iter([url.clone()])))
+        .bind()
+        .await
+        .unwrap();
+    let endpoint: DynIrohEndpoint = Arc::new(IrohEndpoint::new(raw));
+    let startup_quic = endpoint
+        .remove_relay(&url)
+        .await
+        .expect("relay configured at startup")
+        .quic
+        .clone();
+    assert!(startup_quic.is_some(), "startup relay has QAD enabled");
+    endpoint
+        .insert_relay(url.clone(), RelayConfig::from(url.clone()).into())
+        .await;
+
+    IrohTransport::do_insert_relay(endpoint.clone(), url.to_string(), None)
+        .await
+        .unwrap();
+
+    let reinserted = endpoint
+        .remove_relay(&url)
+        .await
+        .expect("relay still present after re-insert");
+    assert_eq!(
+        reinserted.quic, startup_quic,
+        "re-inserting the relay must not disable QAD"
+    );
+
+    endpoint.close().await;
+}


### PR DESCRIPTION
After diagnosing that Moss doesn't establish direct iroh connections in an number of cases nodes in (London & Uruguay) with many different relays, (LRL & Holochain's combined relay & Iroh's) where Webrtc connections do get established easily.  I pointed claude at the problem, and it generated this simple the solution.

I tested that this then works on [Moss built with a kistusne fork with this addition in it}(https://github.com/lightningrodlabs/moss/releases/tag/v0.16.0-dev.5-test.16) immediately getting a direct connection to uruguay node that's been the worst offender with no direct connections.

I don't fully understand the iroh connection dynamics so I don't know if the fix is sufficient or if it causes other problems.   Perhaps best to treat this PR as an issue rather than an actual pull request.

Below is the suggested Claude PR:

-------


## Problem

`IrohTransport::relay_config_with_token` builds the `RelayConfig` for `insert_relay` with `quic: None`, which turns off QUIC address discovery (QAD) for that relay. `configure_for_space` is called for every space with the transport's global config, and the global `relay_url` is `Some`, so `do_insert_relay` re-inserts the *same* relay that was configured at endpoint creation — and replaces the QAD-enabled `RelayMap::from_iter` entry with a QAD-less one.

Observed on Holochain 0.7.0 / kitsune2 0.5.0 / iroh 1.0.3 with `RUST_LOG=iroh::net_report=debug,iroh::_events=debug`: the first full `net_report` finds `global_v4: Some(<public ip>)`; the report right after the first space is configured logs `QADv4 probe failed: … No port available for this protocol` (iroh's `MissingPort`, i.e. `RelayConfig.quic == None`), `global_v4: None`, and it never recovers. Every later `qnt::init` advertises `local_candidates` with LAN addresses only, so two peers behind different NATs never open a direct path.

## Fix

Build the re-inserted config with `RelayConfig::from(relay_url)`, which carries the default QAD port — the same config `RelayMap::from_iter` produces at startup. Auth-token handling is unchanged.

## Test

`crates/transport_iroh/src/tests/relay_qad.rs::reinserting_relay_keeps_qad_enabled`: an endpoint is bound with the relay in its `RelayMap` (QAD enabled, as at startup), then `do_insert_relay` is run for the same URL — the `configure_for_space` path — and the relay's config is read back. On `main` the re-insert replaces the entry with `quic: None`; with the fix the QAD config survives.

The user-visible symptom (public address vanishes from the candidate set, peers stay relayed) only appears behind NAT and cannot be reproduced on loopback, where the QAD-discovered address *is* the local address — which is also why the existing `is_direct` integration test passes on `main`. The test therefore asserts the relay-map state the symptom follows from.

Against `main` without the fix (RED):

```
test tests::relay_qad::reinserting_relay_keeps_qad_enabled ... FAILED
thread 'tests::relay_qad::reinserting_relay_keeps_qad_enabled' (1717924) panicked at crates/transport_iroh/src/tests/relay_qad.rs:43:5:
  left: None
 right: Some(RelayQuicConfig { port: 7842 })
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 61 filtered out; finished in 0.02s
```

With the fix (GREEN):

```
test tests::relay_qad::reinserting_relay_keeps_qad_enabled ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 61 filtered out; finished in 0.02s
```

Verified on Holochain 0.7.0 nodes running a conductor with this patch: `global_v4` stays `Some` across the per-space `do_insert_relay` calls and the public address appears in the `qnt::init` candidate sets on both sides (on `main` it is gone within a second of the first space being configured and never returns).


With the fix (GREEN):

```
test tests::relay_qad::relay_config_enables_qad_with_and_without_token ... ok
test tests::relay_qad::do_insert_relay_keeps_qad_on_existing_relay ... ok
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 61 filtered out; finished in 0.02s
```

Verified end to end on two Holochain 0.7.0 nodes with a patched conductor: `global_v4` stays `Some` across the per-space `do_insert_relay` calls and the public address appears in `qnt::init` candidate sets on both sides.
