### PR TITLE
fix: Space overrides must not inherit global relay or credentials

### DIFF
--- a/crates/api/src/transport.rs
+++ b/crates/api/src/transport.rs
@@ -502,9 +502,10 @@ pub trait TxImp: 'static + Send + Sync + std::fmt::Debug {
 
     /// Apply per-space configuration to this transport.
     ///
-    /// Called by the space factory when creating a new space. The transport
-    /// reads any per-space settings it understands from the provided config
-    /// (e.g., a per-space relay URL and auth material) and applies them
+    /// Called by the space factory when creating a space that was given a
+    /// config override, with that override merged over the global config. The
+    /// transport reads any per-space settings it understands from the provided
+    /// config (e.g., a per-space relay URL and auth material) and applies them
     /// internally.
     ///
     /// Default implementation is a no-op.
@@ -602,9 +603,10 @@ pub trait Transport: 'static + Send + Sync + std::fmt::Debug {
 
     /// Apply per-space configuration to this transport.
     ///
-    /// Called by the space factory when creating a new space. The transport
-    /// reads any per-space settings it understands from the provided config
-    /// (e.g., a per-space relay URL and auth material) and applies them
+    /// Called by the space factory when creating a space that was given a
+    /// config override, with that override merged over the global config. The
+    /// transport reads any per-space settings it understands from the provided
+    /// config (e.g., a per-space relay URL and auth material) and applies them
     /// internally.
     ///
     /// Default implementation is a no-op.

--- a/crates/core/src/factories/core_bootstrap/test.rs
+++ b/crates/core/src/factories/core_bootstrap/test.rs
@@ -69,6 +69,36 @@ struct Test {
 
 impl Test {
     pub async fn new(server: &str, auth_material: Option<Vec<u8>>) -> Self {
+        Self::from_builder(Arc::new(Self::builder(server, auth_material))).await
+    }
+
+    /// Build the bootstrap the way `CoreSpaceFactory` does for a space that
+    /// overrides the bootstrap server: the override is merged over the global
+    /// config, and everything the space uses is built from the result.
+    pub async fn new_with_space_override(
+        global_server: &str,
+        space_server: &str,
+    ) -> Self {
+        let space_override = Config::default();
+        space_override
+            .set_module_config(&super::CoreBootstrapModConfig {
+                core_bootstrap: super::CoreBootstrapConfig {
+                    server_url: Some(space_server.into()),
+                    backoff_min_ms: 10,
+                    backoff_max_ms: 10,
+                    ..Default::default()
+                },
+            })
+            .unwrap();
+
+        let builder = Self::builder(global_server, None)
+            .with_config_overrides(space_override)
+            .unwrap();
+
+        Self::from_builder(Arc::new(builder)).await
+    }
+
+    fn builder(server: &str, auth_material: Option<Vec<u8>>) -> Builder {
         let builder = Builder {
             auth_material_bootstrap: auth_material,
             verifier: Arc::new(TestCrypto),
@@ -88,7 +118,10 @@ impl Test {
                 },
             })
             .unwrap();
-        let builder = Arc::new(builder);
+        builder
+    }
+
+    async fn from_builder(builder: Arc<Builder>) -> Self {
         println!("{}", serde_json::to_string(&builder.config).unwrap());
 
         let blocks = builder
@@ -316,4 +349,37 @@ async fn test_should_override_bootstrap_url_per_space() {
     // Creating a space MUST succeed because there we provided bootstrap config for space.
     kitsune.space(kitsune2_test_utils::space::TEST_SPACE_ID, Some(space_config)).await
     .expect("Expected creating a space to succeed after setting bootstrap URL per space");
+}
+
+/// A space that overrides the bootstrap server must push and poll against that
+/// server, not the global one. The existing per-space override test only proves
+/// the override reaches config validation.
+#[tokio::test(flavor = "multi_thread")]
+async fn space_override_targets_the_overridden_bootstrap_server() {
+    let global_srv = TestBootstrapSrv::new(false).await;
+    let space_srv = TestBootstrapSrv::new(false).await;
+
+    let overridden =
+        Test::new_with_space_override(global_srv.addr(), space_srv.addr())
+            .await;
+    let on_space_srv = Test::new(space_srv.addr(), None).await;
+    let on_global_srv = Test::new(global_srv.addr(), None).await;
+
+    let agent = overridden.push_agent().await;
+
+    for _ in 0..5 {
+        if on_space_srv.check_agent(agent.clone()).await.is_ok() {
+            // The poller on the global server has had the same wall clock to
+            // see this agent, and must not have.
+            assert!(
+                on_global_srv.check_agent(agent).await.is_err(),
+                "agent info reached the global bootstrap server"
+            );
+            return;
+        }
+
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+    }
+
+    panic!("agent info never reached the overridden bootstrap server");
 }

--- a/crates/core/src/factories/core_space.rs
+++ b/crates/core/src/factories/core_space.rs
@@ -74,6 +74,33 @@ impl CoreSpaceFactory {
     }
 }
 
+fn bootstrap_server_url(config: &Config) -> Option<String> {
+    config
+        .get_module_config::<crate::factories::CoreBootstrapModConfig>()
+        .ok()
+        .and_then(|c| c.core_bootstrap.server_url)
+}
+
+/// Whether this space customized the bootstrap server, naming one other than
+/// the server the global auth material was configured to authenticate against.
+///
+/// A config merge hands a space every field its override did not set, so a space
+/// naming only its own server is still handed the global credential. Presenting
+/// it there would let that server replay it against ours.
+///
+/// Global auth material with no global server of our own was configured for
+/// whatever server the spaces name, so it stays.
+fn bootstrap_server_customized(global: &Config, space: &Config) -> bool {
+    let Some(global_url) = bootstrap_server_url(global) else {
+        return false;
+    };
+    let Some(space_url) = bootstrap_server_url(space) else {
+        return false;
+    };
+
+    space_url.trim_end_matches('/') != global_url.trim_end_matches('/')
+}
+
 impl SpaceFactory for CoreSpaceFactory {
     fn default_config(&self, config: &mut Config) -> K2Result<()> {
         config.set_module_config(&CoreSpaceModConfig::default())
@@ -99,8 +126,22 @@ impl SpaceFactory for CoreSpaceFactory {
             // nothing about a space that chose nothing of its own.
             let builder = match config_override {
                 Some(cfg_override) => {
-                    let builder =
-                        Arc::new(builder.with_config_overrides(cfg_override)?);
+                    let mut space_builder =
+                        builder.with_config_overrides(cfg_override)?;
+
+                    if bootstrap_server_customized(
+                        &builder.config,
+                        &space_builder.config,
+                    ) {
+                        // Cleared even when the override brought its own
+                        // material, which would take precedence anyway:
+                        // `Builder` is public and the bootstrap factory is
+                        // pluggable, so the global credential should not travel
+                        // on a space that named someone else's server at all.
+                        space_builder.auth_material_bootstrap = None;
+                    }
+
+                    let builder = Arc::new(space_builder);
                     tx.configure_for_space(space_id.clone(), &builder.config)
                         .await?;
                     builder

--- a/crates/core/src/factories/core_space.rs
+++ b/crates/core/src/factories/core_space.rs
@@ -93,19 +93,20 @@ impl SpaceFactory for CoreSpaceFactory {
         tx: DynTransport,
     ) -> BoxFut<'static, K2Result<DynSpace>> {
         Box::pin(async move {
+            // Let the transport handle any per-space configuration it
+            // understands (e.g., a per-space relay URL for iroh), but only for a
+            // space that overrides something, because the global config says
+            // nothing about a space that chose nothing of its own.
             let builder = match config_override {
                 Some(cfg_override) => {
-                    Arc::new(builder.with_config_overrides(cfg_override)?)
+                    let builder =
+                        Arc::new(builder.with_config_overrides(cfg_override)?);
+                    tx.configure_for_space(space_id.clone(), &builder.config)
+                        .await?;
+                    builder
                 }
                 None => builder,
             };
-
-            // Let the transport handle any per-space configuration it
-            // understands (e.g., a per-space relay URL for iroh).
-            // This is non-blocking; the transport delivers the URL
-            // asynchronously via the space handler's new_listening_address.
-            tx.configure_for_space(space_id.clone(), &builder.config)
-                .await?;
 
             let builder_config = &builder.config;
             let config: CoreSpaceModConfig =

--- a/crates/core/src/factories/core_space/test.rs
+++ b/crates/core/src/factories/core_space/test.rs
@@ -582,3 +582,192 @@ mod configure_for_space_only_when_overridden {
         assert_eq!(configured, vec![TEST_SPACE_ID]);
     }
 }
+
+/// Global bootstrap auth material authenticates the global bootstrap server. A
+/// config merge hands a space every field its override did not set, so a space
+/// naming its own server is still handed our credential - presenting it there
+/// would let that server replay it against ours.
+mod bootstrap_auth_material_is_not_carried_to_another_server {
+    use super::*;
+    use crate::factories::core_space::bootstrap_server_customized;
+    use crate::factories::{CoreBootstrapConfig, CoreBootstrapModConfig};
+
+    const GLOBAL_SERVER: &str = "http://global-bootstrap.example";
+    const SPACE_SERVER: &str = "http://space-bootstrap.example";
+
+    type Seen = Arc<Mutex<Vec<Option<Vec<u8>>>>>;
+
+    #[derive(Debug)]
+    struct NoopBootstrap;
+    impl Bootstrap for NoopBootstrap {
+        fn put(&self, _info: Arc<AgentInfoSigned>) {}
+    }
+
+    /// Records the auth material the space's builder carries by the time the
+    /// bootstrap module is built from it.
+    #[derive(Debug)]
+    struct RecordingBootstrapFactory {
+        seen: Seen,
+    }
+
+    impl BootstrapFactory for RecordingBootstrapFactory {
+        fn default_config(&self, config: &mut Config) -> K2Result<()> {
+            config.set_module_config(&CoreBootstrapModConfig {
+                core_bootstrap: CoreBootstrapConfig {
+                    server_url: Some(GLOBAL_SERVER.into()),
+                    ..Default::default()
+                },
+            })
+        }
+
+        fn validate_config(&self, _config: &Config) -> K2Result<()> {
+            Ok(())
+        }
+
+        fn create(
+            &self,
+            builder: Arc<Builder>,
+            _peer_store: DynPeerStore,
+            _space_id: SpaceId,
+        ) -> BoxFut<'static, K2Result<DynBootstrap>> {
+            self.seen
+                .lock()
+                .expect("poison")
+                .push(builder.auth_material_bootstrap.clone());
+            Box::pin(async { Ok(Arc::new(NoopBootstrap) as DynBootstrap) })
+        }
+    }
+
+    #[derive(Debug)]
+    struct S;
+    impl SpaceHandler for S {}
+
+    #[derive(Debug)]
+    struct K;
+    impl KitsuneHandler for K {
+        fn create_space(
+            &self,
+            _space_id: SpaceId,
+            _config_override: Option<&Config>,
+        ) -> BoxFut<'_, K2Result<DynSpaceHandler>> {
+            Box::pin(async move {
+                let s: DynSpaceHandler = Arc::new(S);
+                Ok(s)
+            })
+        }
+    }
+
+    /// Build a node holding global bootstrap auth material, create one space
+    /// with the given override, and report the material its bootstrap was
+    /// built with.
+    async fn material_seen_by_space(
+        space_server: Option<&str>,
+    ) -> Option<Vec<u8>> {
+        let seen: Seen = Arc::new(Mutex::new(Vec::new()));
+        let builder = Builder {
+            verifier: Arc::new(TestVerifier),
+            auth_material_bootstrap: Some(b"global-credential".to_vec()),
+            bootstrap: Arc::new(RecordingBootstrapFactory {
+                seen: seen.clone(),
+            }),
+            ..crate::default_test_builder()
+        }
+        .with_default_config()
+        .unwrap()
+        .build()
+        .await
+        .unwrap();
+        builder
+            .register_handler(Arc::new(K) as DynKitsuneHandler)
+            .await
+            .unwrap();
+
+        let config_override = Config::default();
+        config_override
+            .set_module_config(&CoreBootstrapModConfig {
+                core_bootstrap: CoreBootstrapConfig {
+                    server_url: Some(
+                        space_server.unwrap_or(GLOBAL_SERVER).into(),
+                    ),
+                    ..Default::default()
+                },
+            })
+            .unwrap();
+
+        builder
+            .space(TEST_SPACE_ID, Some(config_override))
+            .await
+            .unwrap();
+
+        let seen = seen.lock().expect("poison").clone();
+        assert_eq!(seen.len(), 1, "expected exactly one bootstrap to be built");
+        seen.into_iter().next().unwrap()
+    }
+
+    fn config_with_server(server_url: Option<&str>) -> Config {
+        let config = Config::default();
+        config
+            .set_module_config(&CoreBootstrapModConfig {
+                core_bootstrap: CoreBootstrapConfig {
+                    server_url: server_url.map(Into::into),
+                    ..Default::default()
+                },
+            })
+            .unwrap();
+        config
+    }
+
+    #[test]
+    fn a_different_server_is_a_customized_one() {
+        assert!(bootstrap_server_customized(
+            &config_with_server(Some(GLOBAL_SERVER)),
+            &config_with_server(Some(SPACE_SERVER)),
+        ));
+    }
+
+    #[test]
+    fn a_trailing_slash_is_not_a_different_server() {
+        assert!(!bootstrap_server_customized(
+            &config_with_server(Some("http://bootstrap.example")),
+            &config_with_server(Some("http://bootstrap.example/")),
+        ));
+    }
+
+    /// Auth material given with no global server of our own was configured for
+    /// whatever server the spaces name, so it stays.
+    #[test]
+    fn no_global_server_means_the_material_was_meant_for_the_space() {
+        assert!(!bootstrap_server_customized(
+            &config_with_server(None),
+            &config_with_server(Some(SPACE_SERVER)),
+        ));
+    }
+
+    /// A bootstrap module with a config shape we cannot read handles its own
+    /// material; we leave it alone rather than guessing.
+    #[test]
+    fn an_unreadable_bootstrap_config_leaves_the_material_alone() {
+        let unknown = Config::default();
+        unknown
+            .set_module_config(&serde_json::json!({ "somethingElse": {} }))
+            .unwrap();
+
+        assert!(!bootstrap_server_customized(
+            &unknown,
+            &config_with_server(Some(SPACE_SERVER)),
+        ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn cleared_when_the_space_names_its_own_server() {
+        assert_eq!(material_seen_by_space(Some(SPACE_SERVER)).await, None);
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn kept_when_the_space_names_the_global_server() {
+        assert_eq!(
+            material_seen_by_space(None).await,
+            Some(b"global-credential".to_vec()),
+        );
+    }
+}

--- a/crates/core/src/factories/core_space/test.rs
+++ b/crates/core/src/factories/core_space/test.rs
@@ -432,3 +432,153 @@ async fn broadcast_new_agent_info_on_resign() {
     let broadcast = p.0.lock().unwrap().last().cloned().unwrap();
     assert_eq!(bob.agent(), &broadcast.0.agent);
 }
+
+/// The per-space transport hook exists so a space can name a relay of its own.
+/// Calling it for a space that overrides nothing hands the transport the global
+/// config and presents the defaults as that space's own - which the transport
+/// cannot tell apart, and the iroh transport acts on by reconfiguring the relay
+/// it is already connected to.
+mod configure_for_space_only_when_overridden {
+    use super::*;
+
+    type Configured = Arc<Mutex<Vec<SpaceId>>>;
+
+    /// Records the per-space hook and does nothing else; this test only creates
+    /// spaces, it never moves data.
+    #[derive(Debug)]
+    struct RecordingTx {
+        configured: Configured,
+    }
+
+    impl TxImp for RecordingTx {
+        fn url(&self) -> Option<Url> {
+            None
+        }
+
+        fn disconnect(
+            &self,
+            _peer: Url,
+            _payload: Option<(String, bytes::Bytes)>,
+        ) -> BoxFut<'_, ()> {
+            Box::pin(async {})
+        }
+
+        fn send(
+            &self,
+            _peer: Url,
+            _data: bytes::Bytes,
+        ) -> BoxFut<'_, K2Result<()>> {
+            Box::pin(async { Ok(()) })
+        }
+
+        fn get_connected_peers(&self) -> BoxFut<'_, K2Result<Vec<Url>>> {
+            Box::pin(async { Ok(Vec::new()) })
+        }
+
+        fn dump_network_stats(&self) -> BoxFut<'_, K2Result<TransportStats>> {
+            Box::pin(async {
+                Ok(TransportStats {
+                    backend: "recording".to_string(),
+                    peer_urls: Vec::new(),
+                    connections: Vec::new(),
+                })
+            })
+        }
+
+        fn configure_for_space(
+            &self,
+            space_id: SpaceId,
+            _config: &Config,
+        ) -> BoxFut<'_, K2Result<()>> {
+            self.configured.lock().expect("poison").push(space_id);
+            Box::pin(async { Ok(()) })
+        }
+    }
+
+    #[derive(Debug)]
+    struct RecordingTxFactory {
+        configured: Configured,
+    }
+
+    impl TransportFactory for RecordingTxFactory {
+        fn default_config(&self, _config: &mut Config) -> K2Result<()> {
+            Ok(())
+        }
+
+        fn validate_config(&self, _config: &Config) -> K2Result<()> {
+            Ok(())
+        }
+
+        fn create(
+            &self,
+            _builder: Arc<Builder>,
+            handler: DynTxHandler,
+        ) -> BoxFut<'static, K2Result<DynTransport>> {
+            let configured = self.configured.clone();
+            Box::pin(async move {
+                let handler = TxImpHnd::new(handler);
+                let imp: DynTxImp = Arc::new(RecordingTx { configured });
+                Ok(DefaultTransport::create(&handler, imp))
+            })
+        }
+    }
+
+    #[derive(Debug)]
+    struct S;
+    impl SpaceHandler for S {}
+
+    #[derive(Debug)]
+    struct K;
+    impl KitsuneHandler for K {
+        fn create_space(
+            &self,
+            _space_id: SpaceId,
+            _config_override: Option<&Config>,
+        ) -> BoxFut<'_, K2Result<DynSpaceHandler>> {
+            Box::pin(async move {
+                let s: DynSpaceHandler = Arc::new(S);
+                Ok(s)
+            })
+        }
+    }
+
+    async fn configured_spaces_for(
+        config_override: Option<Config>,
+    ) -> Vec<SpaceId> {
+        let configured: Configured = Arc::new(Mutex::new(Vec::new()));
+        let builder = Builder {
+            verifier: Arc::new(TestVerifier),
+            transport: Arc::new(RecordingTxFactory {
+                configured: configured.clone(),
+            }),
+            ..crate::default_test_builder()
+        }
+        .with_default_config()
+        .unwrap()
+        .build()
+        .await
+        .unwrap();
+        builder
+            .register_handler(Arc::new(K) as DynKitsuneHandler)
+            .await
+            .unwrap();
+
+        builder.space(TEST_SPACE_ID, config_override).await.unwrap();
+
+        configured.lock().expect("poison").clone()
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn not_called_when_the_space_overrides_nothing() {
+        assert!(
+            configured_spaces_for(None).await.is_empty(),
+            "the transport was handed the global config as if it were this space's own"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn called_when_the_space_overrides_something() {
+        let configured = configured_spaces_for(Some(Config::default())).await;
+        assert_eq!(configured, vec![TEST_SPACE_ID]);
+    }
+}

--- a/crates/transport_iroh/src/lib.rs
+++ b/crates/transport_iroh/src/lib.rs
@@ -1257,7 +1257,10 @@ impl TxImp for IrohTransport {
 
         let per_space = per_space_config.map(|c| c.iroh_transport);
 
-        let relay_url = per_space.as_ref().and_then(|c| c.relay_url.clone());
+        let relay_url = per_space_relay_url(
+            per_space.as_ref().and_then(|c| c.relay_url.as_deref()),
+            self.config.relay_url.as_deref(),
+        );
 
         let auth_material = per_space
             .as_ref()

--- a/crates/transport_iroh/src/lib.rs
+++ b/crates/transport_iroh/src/lib.rs
@@ -400,7 +400,7 @@ impl TransportFactory for IrohTransportFactory {
                 });
 
             let auth_material = builder.auth_material_relay.clone();
-            let imp = IrohTransport::create(
+            let imp: DynTxImp = IrohTransport::create(
                 transport_config,
                 handler.clone(),
                 auth_material,
@@ -486,7 +486,7 @@ impl IrohTransport {
         config: IrohTransportConfig,
         handler: Arc<TxImpHnd>,
         auth_material: Option<Vec<u8>>,
-    ) -> K2Result<DynTxImp> {
+    ) -> K2Result<Arc<Self>> {
         // Determine whether we need to authenticate for relay access.
         // Authentication is required when both a relay URL and auth material
         // are provided.
@@ -647,7 +647,7 @@ impl IrohTransport {
             )
         });
 
-        let out: DynTxImp = Arc::new(Self {
+        let out = Arc::new(Self {
             endpoint,
             handler,
             local_url,
@@ -1257,20 +1257,35 @@ impl TxImp for IrohTransport {
 
         let per_space = per_space_config.map(|c| c.iroh_transport);
 
-        let relay_url = per_space_relay_url(
+        let space_relay = per_space_relay(
             per_space.as_ref().and_then(|c| c.relay_url.as_deref()),
+            per_space
+                .as_ref()
+                .and_then(|c| c.auth_material_relay_base64.as_deref()),
             self.config.relay_url.as_deref(),
+            self.config.auth_material_relay_base64.as_deref(),
         );
 
-        let auth_material = per_space
-            .as_ref()
-            .and_then(|c| c.auth_material_relay_base64.as_ref())
-            .and_then(|b64| {
+        if let Some(SpaceRelay {
+            url,
+            auth_material_base64,
+        }) = space_relay
+        {
+            let auth_material = auth_material_base64.and_then(|b64| {
                 use ::base64::Engine;
-                ::base64::engine::general_purpose::STANDARD.decode(b64).ok()
+                let decoded = ::base64::engine::general_purpose::STANDARD
+                    .decode(&b64)
+                    .ok();
+                if decoded.is_none() {
+                    tracing::warn!(
+                        ?space_id,
+                        "Ignoring per-space relay auth material that is not \
+                         valid base64; the relay will be used unauthenticated"
+                    );
+                }
+                decoded
             });
 
-        if let Some(url) = relay_url {
             let endpoint = self.endpoint.clone();
             let space_relays = self.space_relays.clone();
             let space_relay_keepalives = self.space_relay_keepalives.clone();
@@ -1350,7 +1365,28 @@ impl TxImp for IrohTransport {
                     .any(|(r, _)| r == &relay_url);
 
                 if !still_used {
-                    self.endpoint.remove_relay(&relay_url).await;
+                    // A space may have inserted the transport's own relay to
+                    // present auth material of its own. It does not own it, so
+                    // releasing the space must not take the relay with it.
+                    if is_transport_own_relay(
+                        relay_url.as_str(),
+                        self.config.relay_url.as_deref(),
+                    ) {
+                        tracing::debug!(
+                            ?space_id,
+                            %relay_url,
+                            "Keeping the transport's own relay after releasing the space"
+                        );
+                    } else {
+                        self.endpoint.remove_relay(&relay_url).await;
+                        tracing::info!(
+                            ?space_id,
+                            %relay_url,
+                            "Removed per-space relay from endpoint"
+                        );
+                    }
+
+                    // The space's keepalive goes with the space either way.
                     if let Some(handle) = self
                         .space_relay_keepalives
                         .lock()
@@ -1359,11 +1395,6 @@ impl TxImp for IrohTransport {
                     {
                         handle.abort();
                     }
-                    tracing::info!(
-                        ?space_id,
-                        %relay_url,
-                        "Removed per-space relay from endpoint"
-                    );
                 }
             }
 

--- a/crates/transport_iroh/src/tests/mod.rs
+++ b/crates/transport_iroh/src/tests/mod.rs
@@ -5,6 +5,7 @@ use super::*;
 mod close;
 mod connect_failure;
 mod frame;
+mod relay_lifecycle;
 mod relay_qad;
 mod simultaneous_open;
 mod stream;

--- a/crates/transport_iroh/src/tests/relay_lifecycle.rs
+++ b/crates/transport_iroh/src/tests/relay_lifecycle.rs
@@ -1,0 +1,172 @@
+//! A space may name the transport's own relay in order to present auth material
+//! of its own. Releasing that space must not take the relay with it:
+//! `remove_relay` drops the endpoint's active relay entry, which would cut the
+//! node off from the relay everything else is still using.
+//!
+//! Asserted on the endpoint's relay map rather than on connectivity, because on
+//! loopback a lost relay is masked by iroh connecting directly.
+
+use super::*;
+use crate::test_utils::MockTxHandler;
+use base64::Engine as _;
+use kitsune2_api::{Config, DynTxHandler, SpaceId, TxImp, TxImpHnd};
+use kitsune2_bootstrap_srv::{AuthConfig, BootstrapSrv};
+use kitsune2_test_utils::auth::AuthHookServer;
+use kitsune2_test_utils::space::TEST_SPACE_ID;
+use std::time::Duration;
+
+/// Start a local bootstrap server with relay authentication enabled.
+async fn start_authenticated_relay() -> (AuthHookServer, BootstrapSrv, String) {
+    let auth_hook = AuthHookServer::spawn(None);
+    let hook_url = auth_hook.url();
+
+    // BootstrapSrv::new() creates its own tokio runtime and cannot be called
+    // from within an existing runtime.
+    let srv = tokio::task::spawn_blocking(move || {
+        BootstrapSrv::new(kitsune2_bootstrap_srv::Config {
+            prune_interval: Duration::from_millis(5),
+            auth: AuthConfig {
+                authentication_hook_server: Some(hook_url),
+                ..Default::default()
+            },
+            ..kitsune2_bootstrap_srv::Config::testing()
+        })
+    })
+    .await
+    .expect("spawn_blocking panicked")
+    .expect("failed to start local bootstrap server");
+
+    let relay_url = format!("http://{}/relay", srv.listen_addrs()[0]);
+    (auth_hook, srv, relay_url)
+}
+
+fn space_config(relay_url: &str, auth_material: &[u8]) -> Config {
+    let config = Config::default();
+    config
+        .set_module_config(&IrohTransportModConfig {
+            iroh_transport: IrohTransportConfig {
+                relay_url: Some(relay_url.to_string()),
+                relay_allow_plain_text: true,
+                auth_material_relay_base64: Some(
+                    base64::engine::general_purpose::STANDARD
+                        .encode(auth_material),
+                ),
+                ..Default::default()
+            },
+        })
+        .unwrap();
+    config
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn releasing_a_space_keeps_the_transport_own_relay() {
+    kitsune2_test_utils::enable_tracing();
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let (_auth_hook, _srv, relay_url) = start_authenticated_relay().await;
+    let auth_material = b"local-test-auth-material".to_vec();
+
+    let handler: DynTxHandler = Arc::new(MockTxHandler::default());
+    let handler = TxImpHnd::new(handler);
+    let tx = IrohTransport::create(
+        IrohTransportConfig {
+            relay_url: Some(relay_url.clone()),
+            relay_allow_plain_text: true,
+            ..Default::default()
+        },
+        handler,
+        Some(auth_material.clone()),
+    )
+    .await
+    .unwrap();
+
+    // The space names the relay the transport is already on, with auth material
+    // of its own, so it is inserted under this space.
+    tx.configure_for_space(
+        TEST_SPACE_ID,
+        &space_config(&relay_url, &auth_material),
+    )
+    .await
+    .unwrap();
+
+    let inserted = tokio::time::timeout(Duration::from_secs(30), async {
+        loop {
+            if let Some((relay, _)) = tx
+                .space_relays
+                .read()
+                .expect("poisoned")
+                .get(&TEST_SPACE_ID)
+                .cloned()
+            {
+                return relay;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("relay was not inserted for the space within 30 s");
+
+    tx.unconfigure_for_space(TEST_SPACE_ID).await.unwrap();
+
+    // remove_relay returns the entry it removed, so a present relay yields Some.
+    assert!(
+        tx.endpoint.remove_relay(&inserted).await.is_some(),
+        "releasing the space took the transport's own relay with it"
+    );
+}
+
+/// A relay the space named itself is still removed when the space goes.
+#[tokio::test(flavor = "multi_thread")]
+async fn releasing_a_space_removes_a_relay_it_named() {
+    kitsune2_test_utils::enable_tracing();
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let (_auth_hook, _srv, relay_url) = start_authenticated_relay().await;
+    let auth_material = b"local-test-auth-material".to_vec();
+
+    let handler: DynTxHandler = Arc::new(MockTxHandler::default());
+    let handler = TxImpHnd::new(handler);
+    // No relay of our own, so the relay the space names is the space's.
+    let tx = IrohTransport::create(
+        IrohTransportConfig {
+            relay_allow_plain_text: true,
+            ..Default::default()
+        },
+        handler,
+        None,
+    )
+    .await
+    .unwrap();
+
+    let space_id: SpaceId = TEST_SPACE_ID;
+    tx.configure_for_space(
+        space_id.clone(),
+        &space_config(&relay_url, &auth_material),
+    )
+    .await
+    .unwrap();
+
+    let inserted = tokio::time::timeout(Duration::from_secs(30), async {
+        loop {
+            if let Some((relay, _)) = tx
+                .space_relays
+                .read()
+                .expect("poisoned")
+                .get(&space_id)
+                .cloned()
+            {
+                return relay;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .expect("relay was not inserted for the space within 30 s");
+
+    tx.unconfigure_for_space(space_id).await.unwrap();
+
+    assert!(
+        tx.endpoint.remove_relay(&inserted).await.is_none(),
+        "a relay the space named should go when the space does"
+    );
+}

--- a/crates/transport_iroh/src/tests/url.rs
+++ b/crates/transport_iroh/src/tests/url.rs
@@ -1,7 +1,8 @@
 use crate::IrohTransport;
 use crate::url::endpoint_from_url;
 use crate::url::{
-    canonicalize_relay_url, get_url_with_first_relay, per_space_relay_url,
+    SpaceRelay, canonicalize_relay_url, get_url_with_first_relay,
+    is_transport_own_relay, per_space_relay,
 };
 use iroh::{EndpointAddr, EndpointId, RelayUrl, TransportAddr};
 use kitsune2_api::{Id, SpaceId, Url};
@@ -368,64 +369,169 @@ fn own_url_for_preflight_space_relay_takes_precedence() {
     assert_eq!(result, Some(our_space_url));
 }
 
-/// The case that matters in practice: a space overriding nothing is handed the
-/// global config, so its `relay_url` is the relay already in use. Acting on it
-/// re-inserts that relay from a config with no auth material, which an
-/// authenticated relay then refuses for the life of the process.
+/// A space overriding nothing is handed the global config, so its `relay_url` is
+/// the relay already in use. Acting on it would insert that relay as a custom
+/// override. At best, that's pointless, at worst it loses the mapping to auth
+/// material and results in a broken configuration.
 #[test]
-fn per_space_relay_url_ignores_the_relay_already_in_use() {
+fn per_space_relay_ignores_the_relay_already_in_use() {
     assert_eq!(
-        per_space_relay_url(
+        per_space_relay(
             Some("https://relay.example/"),
-            Some("https://relay.example/")
+            None,
+            Some("https://relay.example/"),
+            None,
         ),
         None
     );
 }
 
 #[test]
-fn per_space_relay_url_ignores_a_trailing_slash_difference() {
+fn per_space_relay_ignores_trailing_slash_differences() {
     assert_eq!(
-        per_space_relay_url(
+        per_space_relay(
             Some("https://relay.example"),
-            Some("https://relay.example/")
+            None,
+            Some("https://relay.example/"),
+            None,
         ),
         None
     );
     assert_eq!(
-        per_space_relay_url(
-            Some("https://relay.example/"),
-            Some("https://relay.example")
+        per_space_relay(
+            Some("https://relay.example///"),
+            None,
+            Some("https://relay.example"),
+            None,
         ),
         None
     );
 }
 
 #[test]
-fn per_space_relay_url_keeps_a_genuine_override() {
+fn per_space_relay_keeps_a_genuine_override() {
     assert_eq!(
-        per_space_relay_url(
+        per_space_relay(
             Some("https://space-relay.example"),
-            Some("https://relay.example")
+            None,
+            Some("https://relay.example"),
+            None,
         ),
-        Some("https://space-relay.example".to_string())
+        Some(SpaceRelay {
+            url: "https://space-relay.example".to_string(),
+            auth_material_base64: None,
+        })
     );
 }
 
 /// With no relay of our own, whatever the space names is its own relay.
 #[test]
-fn per_space_relay_url_keeps_an_override_when_the_transport_has_no_relay() {
+fn per_space_relay_keeps_an_override_when_the_transport_has_no_relay() {
     assert_eq!(
-        per_space_relay_url(Some("https://space-relay.example"), None),
-        Some("https://space-relay.example".to_string())
+        per_space_relay(Some("https://space-relay.example"), None, None, None),
+        Some(SpaceRelay {
+            url: "https://space-relay.example".to_string(),
+            auth_material_base64: None,
+        })
+    );
+}
+
+/// A space that brings auth material of its own is naming its own relay even
+/// when the URL matches ours - skipping it would leave that space
+/// unauthenticated.
+#[test]
+fn per_space_relay_keeps_a_matching_relay_that_brings_its_own_auth_material() {
+    assert_eq!(
+        per_space_relay(
+            Some("https://relay.example"),
+            Some("c3BhY2U="),
+            Some("https://relay.example/"),
+            None,
+        ),
+        Some(SpaceRelay {
+            url: "https://relay.example".to_string(),
+            auth_material_base64: Some("c3BhY2U=".to_string()),
+        })
+    );
+}
+
+/// The leak this guards against: a config merge hands a space every field its
+/// override did not set, so a space naming only a relay is handed the global
+/// auth material. Carrying it would PUT our credential to a host the space
+/// chose, which can then replay it against the relay it was issued for.
+#[test]
+fn per_space_relay_never_carries_inherited_auth_material_to_another_relay() {
+    assert_eq!(
+        per_space_relay(
+            Some("https://space-relay.example"),
+            Some("Z2xvYmFs"),
+            Some("https://relay.example"),
+            Some("Z2xvYmFs"),
+        ),
+        Some(SpaceRelay {
+            url: "https://space-relay.example".to_string(),
+            auth_material_base64: None,
+        })
+    );
+}
+
+/// Inherited material naming the relay it was issued for is still nothing to do.
+#[test]
+fn per_space_relay_ignores_inherited_auth_material_for_the_same_relay() {
+    assert_eq!(
+        per_space_relay(
+            Some("https://relay.example"),
+            Some("Z2xvYmFs"),
+            Some("https://relay.example"),
+            Some("Z2xvYmFs"),
+        ),
+        None
+    );
+}
+
+/// A space may still authenticate a relay of its own, so long as the material
+/// came with it.
+#[test]
+fn per_space_relay_keeps_its_own_auth_material_for_its_own_relay() {
+    assert_eq!(
+        per_space_relay(
+            Some("https://space-relay.example"),
+            Some("c3BhY2U="),
+            Some("https://relay.example"),
+            Some("Z2xvYmFs"),
+        ),
+        Some(SpaceRelay {
+            url: "https://space-relay.example".to_string(),
+            auth_material_base64: Some("c3BhY2U=".to_string()),
+        })
     );
 }
 
 #[test]
-fn per_space_relay_url_is_none_when_the_space_names_no_relay() {
+fn per_space_relay_is_none_when_the_space_names_no_relay() {
     assert_eq!(
-        per_space_relay_url(None, Some("https://relay.example")),
+        per_space_relay(None, None, Some("https://relay.example"), None),
         None
     );
-    assert_eq!(per_space_relay_url(None, None), None);
+    assert_eq!(per_space_relay(None, None, None, None), None);
+    // Auth material without a relay to attach it to is still nothing to do.
+    assert_eq!(per_space_relay(None, Some("c3BhY2U="), None, None), None);
+}
+
+#[test]
+fn is_transport_own_relay_ignores_trailing_slashes() {
+    assert!(is_transport_own_relay(
+        "https://relay.example///",
+        Some("https://relay.example")
+    ));
+    assert!(!is_transport_own_relay(
+        "https://space-relay.example",
+        Some("https://relay.example")
+    ));
+}
+
+/// With no relay of our own, nothing is ours to keep.
+#[test]
+fn is_transport_own_relay_is_false_without_a_transport_relay() {
+    assert!(!is_transport_own_relay("https://relay.example", None));
 }

--- a/crates/transport_iroh/src/tests/url.rs
+++ b/crates/transport_iroh/src/tests/url.rs
@@ -1,6 +1,8 @@
 use crate::IrohTransport;
 use crate::url::endpoint_from_url;
-use crate::url::{canonicalize_relay_url, get_url_with_first_relay};
+use crate::url::{
+    canonicalize_relay_url, get_url_with_first_relay, per_space_relay_url,
+};
 use iroh::{EndpointAddr, EndpointId, RelayUrl, TransportAddr};
 use kitsune2_api::{Id, SpaceId, Url};
 use std::collections::HashMap;
@@ -364,4 +366,66 @@ fn own_url_for_preflight_space_relay_takes_precedence() {
         &global_url,
     );
     assert_eq!(result, Some(our_space_url));
+}
+
+/// The case that matters in practice: a space overriding nothing is handed the
+/// global config, so its `relay_url` is the relay already in use. Acting on it
+/// re-inserts that relay from a config with no auth material, which an
+/// authenticated relay then refuses for the life of the process.
+#[test]
+fn per_space_relay_url_ignores_the_relay_already_in_use() {
+    assert_eq!(
+        per_space_relay_url(
+            Some("https://relay.example/"),
+            Some("https://relay.example/")
+        ),
+        None
+    );
+}
+
+#[test]
+fn per_space_relay_url_ignores_a_trailing_slash_difference() {
+    assert_eq!(
+        per_space_relay_url(
+            Some("https://relay.example"),
+            Some("https://relay.example/")
+        ),
+        None
+    );
+    assert_eq!(
+        per_space_relay_url(
+            Some("https://relay.example/"),
+            Some("https://relay.example")
+        ),
+        None
+    );
+}
+
+#[test]
+fn per_space_relay_url_keeps_a_genuine_override() {
+    assert_eq!(
+        per_space_relay_url(
+            Some("https://space-relay.example"),
+            Some("https://relay.example")
+        ),
+        Some("https://space-relay.example".to_string())
+    );
+}
+
+/// With no relay of our own, whatever the space names is its own relay.
+#[test]
+fn per_space_relay_url_keeps_an_override_when_the_transport_has_no_relay() {
+    assert_eq!(
+        per_space_relay_url(Some("https://space-relay.example"), None),
+        Some("https://space-relay.example".to_string())
+    );
+}
+
+#[test]
+fn per_space_relay_url_is_none_when_the_space_names_no_relay() {
+    assert_eq!(
+        per_space_relay_url(None, Some("https://relay.example")),
+        None
+    );
+    assert_eq!(per_space_relay_url(None, None), None);
 }

--- a/crates/transport_iroh/src/url.rs
+++ b/crates/transport_iroh/src/url.rs
@@ -92,3 +92,36 @@ pub(super) fn endpoint_from_url(url: &Url) -> K2Result<EndpointAddr> {
         [TransportAddr::Relay(relay_url)],
     ))
 }
+
+/// The relay a space should be configured with, or `None` to leave the
+/// transport's relay alone.
+///
+/// A space that overrides no relay is still handed the global config, whose
+/// `relay_url` is the relay the transport already connected to. Acting on that
+/// would re-insert a relay that has not changed, and the global config carries no
+/// auth material, so an authenticated connection would be replaced by one the
+/// relay refuses - leaving the node with a live token, a live allowlist entry,
+/// and no relay. It would also mark the space per-space managed, so global
+/// address updates would stop reaching it.
+///
+/// Only a relay that actually differs from the transport's own is a per-space
+/// relay. A trailing slash is not a difference.
+pub(super) fn per_space_relay_url(
+    space_relay_url: Option<&str>,
+    transport_relay_url: Option<&str>,
+) -> Option<String> {
+    let space_relay_url = space_relay_url?;
+    let differs = match transport_relay_url {
+        Some(transport_relay_url) => {
+            trim_trailing_slash(space_relay_url)
+                != trim_trailing_slash(transport_relay_url)
+        }
+        // No relay of our own, so anything the space names is its own.
+        None => true,
+    };
+    differs.then(|| space_relay_url.to_string())
+}
+
+fn trim_trailing_slash(url: &str) -> &str {
+    url.strip_suffix('/').unwrap_or(url)
+}

--- a/crates/transport_iroh/src/url.rs
+++ b/crates/transport_iroh/src/url.rs
@@ -93,35 +93,59 @@ pub(super) fn endpoint_from_url(url: &Url) -> K2Result<EndpointAddr> {
     ))
 }
 
-/// The relay a space should be configured with, or `None` to leave the
-/// transport's relay alone.
-///
-/// A space that overrides no relay is still handed the global config, whose
-/// `relay_url` is the relay the transport already connected to. Acting on that
-/// would re-insert a relay that has not changed, and the global config carries no
-/// auth material, so an authenticated connection would be replaced by one the
-/// relay refuses - leaving the node with a live token, a live allowlist entry,
-/// and no relay. It would also mark the space per-space managed, so global
-/// address updates would stop reaching it.
-///
-/// Only a relay that actually differs from the transport's own is a per-space
-/// relay. A trailing slash is not a difference.
-pub(super) fn per_space_relay_url(
-    space_relay_url: Option<&str>,
-    transport_relay_url: Option<&str>,
-) -> Option<String> {
-    let space_relay_url = space_relay_url?;
-    let differs = match transport_relay_url {
-        Some(transport_relay_url) => {
-            trim_trailing_slash(space_relay_url)
-                != trim_trailing_slash(transport_relay_url)
-        }
-        // No relay of our own, so anything the space names is its own.
-        None => true,
-    };
-    differs.then(|| space_relay_url.to_string())
+/// What a space's config asks the transport to do about its relay.
+#[derive(Debug, PartialEq)]
+pub(super) struct SpaceRelay {
+    /// The relay to insert for this space.
+    pub url: String,
+    /// The auth material to present to it, if the space brought its own.
+    pub auth_material_base64: Option<String>,
 }
 
-fn trim_trailing_slash(url: &str) -> &str {
-    url.strip_suffix('/').unwrap_or(url)
+/// What to configure for a space, or `None` to leave the transport's relay
+/// alone.
+///
+/// A relay is the space's own when it differs from the transport's - trailing
+/// slashes are not a difference - or when the space brought auth material of its
+/// own.
+///
+/// Auth material only authenticates the relay it was issued for, and a config
+/// merge hands a space every field its override did not set. Material equal to
+/// the transport's was therefore inherited rather than chosen, and is never
+/// carried to a relay the space named itself.
+pub(super) fn per_space_relay(
+    space_relay_url: Option<&str>,
+    space_auth_material: Option<&str>,
+    transport_relay_url: Option<&str>,
+    transport_auth_material: Option<&str>,
+) -> Option<SpaceRelay> {
+    let url = space_relay_url?;
+
+    let own_auth_material =
+        space_auth_material.filter(|m| Some(*m) != transport_auth_material);
+
+    let ours = is_transport_own_relay(url, transport_relay_url);
+
+    if ours && own_auth_material.is_none() {
+        return None;
+    }
+
+    Some(SpaceRelay {
+        url: url.to_string(),
+        auth_material_base64: own_auth_material.map(str::to_string),
+    })
+}
+
+/// Whether this relay is the one the transport connected to itself.
+///
+/// A trailing slash is not a difference. With no relay of our own, nothing is
+/// ours, so anything a space names is its own.
+pub(super) fn is_transport_own_relay(
+    relay_url: &str,
+    transport_relay_url: Option<&str>,
+) -> bool {
+    transport_relay_url.is_some_and(|transport_relay_url| {
+        relay_url.trim_end_matches('/')
+            == transport_relay_url.trim_end_matches('/')
+    })
 }


### PR DESCRIPTION
Two bugs, one mechanism: `Config::merge_overrides` is a deep per-key merge, so a
space's override silently inherits every field it did not name — the global relay
it never asked for, and credentials issued for servers it is not talking to.

Changes span the iroh transport, `CoreSpaceFactory`, and the core bootstrap module.

## 1. Spaces reconfigure a relay that has not changed

A space overriding nothing is still handed the global config, so
`configure_for_space` re-inserts the relay the transport is already on — from a
config carrying no auth material, which an authenticated relay then refuses.

Nothing looks wrong while this happens: the node holds a valid token and keeps its
allowlist entry alive. It just reaches no peers. A node with a public address never
notices, so a fleet of public nodes stays healthy while every NAT'd client fails.

**Fix:** call the per-space hook only for a space that overrides something, and
treat only a relay that differs from the transport's own as a per-space relay.

## 2. Credentials reach servers they were not issued for

**Relay** — a space naming only its own relay inherits the global
`authMaterialRelayBase64`, and the auth server is derived from the space's relay
URL, so our credential is PUT to a host the space chose, which can replay it
against ours. Fixed by deciding the relay and its auth material as a pair: material
equal to the transport's own was inherited rather than chosen, so it is dropped.

**Bootstrap** — the same hole through the `builder.auth_material_bootstrap`
fallback, with no provenance to read because the global material lives on `Builder`
rather than in the config. `CoreSpaceFactory` clears it when the override names a
different bootstrap server. Material given with no global server of our own was
configured for whatever server the spaces name, so that case keeps it.

Also fixes `unconfigure_for_space` removing the transport's own relay when a space
had named it in order to present auth material of its own.

## Worth a reviewer's eye

- Spaces naming no relay of their own are no longer marked per-space managed, so
  they receive global relay address updates again.
- `TxImp::configure_for_space` no longer fires for spaces that override nothing.
  Signature and default impl unchanged; the trait docs now say so.

## Backport

For a 0.5.1, since 0.5.0 ships in Holochain 0.7.0. No API change, and every hunk
applies to `release-0.5` as-is. `c1d88b9f` (QAD lost on relay re-insert) shares
this root cause and is not on `release-0.5`, so that line likely wants both.

Verified against a production authenticated relay: a NAT'd client that previously
never reached a peer now joins and syncs.
