### PR TITLE
fix(transport_iroh): preserve sends during simultaneous open

### DIFF
--- a/crates/kitsune2/tests/integration.rs
+++ b/crates/kitsune2/tests/integration.rs
@@ -3,7 +3,7 @@ use kitsune2::default_builder;
 use kitsune2_api::{
     BoxFut, Builder, Config, DhtArc, DynKitsune, DynSpace, DynSpaceHandler, Id,
     IncomingOp, K2Result, KitsuneHandler, LocalAgent, OpId, SpaceHandler,
-    SpaceId, Timestamp,
+    SpaceId, Timestamp, Url,
 };
 use kitsune2_core::{
     Ed25519LocalAgent,
@@ -22,7 +22,8 @@ use kitsune2_transport_iroh::{
     IrohTransportFactory,
     config::{IrohTransportConfig, IrohTransportModConfig},
 };
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 fn create_op_list(num_ops: u16) -> (Vec<IncomingOp>, Vec<OpId>) {
     let mut ops = Vec::new();
@@ -36,29 +37,66 @@ fn create_op_list(num_ops: u16) -> (Vec<IncomingOp>, Vec<OpId>) {
     (ops, op_ids)
 }
 
-#[derive(Debug)]
-struct TestKitsuneHandler;
+/// A [KitsuneHandler] that records every notification received by any of
+/// its spaces, so tests can assert on what was actually delivered.
+#[derive(Debug, Default)]
+struct TestKitsuneHandler {
+    received: Arc<Mutex<Vec<Bytes>>>,
+}
 impl KitsuneHandler for TestKitsuneHandler {
     fn create_space(
         &self,
         _space_id: SpaceId,
         _config_override: Option<&Config>,
     ) -> BoxFut<'_, K2Result<DynSpaceHandler>> {
-        Box::pin(async {
-            let space_handler: DynSpaceHandler = Arc::new(TestSpaceHandler);
+        let received = self.received.clone();
+        Box::pin(async move {
+            let space_handler: DynSpaceHandler =
+                Arc::new(TestSpaceHandler { received });
             Ok(space_handler)
         })
     }
 }
+impl TestKitsuneHandler {
+    /// A snapshot of everything this node has been notified of so far.
+    fn received(&self) -> Vec<Bytes> {
+        self.received.lock().expect("poison").clone()
+    }
+}
 
 #[derive(Debug)]
-struct TestSpaceHandler;
-impl SpaceHandler for TestSpaceHandler {}
+struct TestSpaceHandler {
+    received: Arc<Mutex<Vec<Bytes>>>,
+}
+impl SpaceHandler for TestSpaceHandler {
+    fn recv_notify(
+        &self,
+        _from_peer: Url,
+        _space_id: SpaceId,
+        data: Bytes,
+    ) -> K2Result<()> {
+        self.received.lock().expect("poison").push(data);
+        Ok(())
+    }
+}
+
+/// The gossip settings used by every test node except where a test needs
+/// something different, such as suppressing gossip-initiated connections.
+fn default_test_gossip_config() -> K2GossipConfig {
+    K2GossipConfig {
+        initiate_interval_ms: 1000,
+        min_initiate_interval_ms: 100,
+        initiate_jitter_ms: 100,
+        round_timeout_ms: 10_000,
+        ..Default::default()
+    }
+}
 
 async fn make_kitsune_node(
     relay_server_url: &str,
     bootstrap_server_url: &str,
-) -> DynKitsune {
+    gossip_config: K2GossipConfig,
+) -> (DynKitsune, Arc<TestKitsuneHandler>) {
     let kitsune_builder = Builder {
         #[cfg(feature = "transport-iroh")]
         transport: IrohTransportFactory::create(),
@@ -93,24 +131,18 @@ async fn make_kitsune_node(
     kitsune_builder
         .config
         .set_module_config(&K2GossipModConfig {
-            k2_gossip: K2GossipConfig {
-                initiate_interval_ms: 1000,
-                min_initiate_interval_ms: 100,
-                initiate_jitter_ms: 100,
-                round_timeout_ms: 10_000,
-                ..Default::default()
-            },
+            k2_gossip: gossip_config,
         })
         .unwrap();
 
-    let kitsune_handler = Arc::new(TestKitsuneHandler);
+    let kitsune_handler = Arc::new(TestKitsuneHandler::default());
     let kitsune = kitsune_builder.build().await.unwrap();
     kitsune
         .register_handler(kitsune_handler.clone())
         .await
         .unwrap();
 
-    kitsune
+    (kitsune, kitsune_handler)
 }
 
 /// For iroh transport, the relay functionality is integrated into the bootstrap server.
@@ -158,6 +190,18 @@ async fn start_space(kitsune: &DynKitsune) -> DynSpace {
     space
 }
 
+/// The transport URL a node advertises, once the relay has assigned one.
+async fn peer_url_of(space: &DynSpace) -> Url {
+    let mut url = None;
+    iter_check!(10_000, 200, {
+        if let Some(current) = space.current_url() {
+            url = Some(current);
+            break;
+        }
+    });
+    url.expect("the space must learn its own URL")
+}
+
 #[tokio::test]
 async fn two_node_gossip() {
     enable_tracing();
@@ -169,10 +213,18 @@ async fn two_node_gossip() {
     let relay_server_url = iroh_relay_from_bootstrap(&bootstrap_server).await;
 
     // Create 2 Kitsune instances...
-    let kitsune_1 =
-        make_kitsune_node(&relay_server_url, &bootstrap_server_url).await;
-    let kitsune_2 =
-        make_kitsune_node(&relay_server_url, &bootstrap_server_url).await;
+    let (kitsune_1, _handler_1) = make_kitsune_node(
+        &relay_server_url,
+        &bootstrap_server_url,
+        default_test_gossip_config(),
+    )
+    .await;
+    let (kitsune_2, _handler_2) = make_kitsune_node(
+        &relay_server_url,
+        &bootstrap_server_url,
+        default_test_gossip_config(),
+    )
+    .await;
 
     // and 1 space with 1 joined agent each.
     let space_1 = start_space(&kitsune_1).await;
@@ -258,10 +310,18 @@ async fn shutdown_space() {
     let relay_server_url = iroh_relay_from_bootstrap(&bootstrap_server).await;
 
     // Create 2 Kitsune instances..
-    let kitsune_1 =
-        make_kitsune_node(&relay_server_url, &bootstrap_server_url).await;
-    let kitsune_2 =
-        make_kitsune_node(&relay_server_url, &bootstrap_server_url).await;
+    let (kitsune_1, _handler_1) = make_kitsune_node(
+        &relay_server_url,
+        &bootstrap_server_url,
+        default_test_gossip_config(),
+    )
+    .await;
+    let (kitsune_2, _handler_2) = make_kitsune_node(
+        &relay_server_url,
+        &bootstrap_server_url,
+        default_test_gossip_config(),
+    )
+    .await;
 
     // and 1 space with 1 joined agent each.
     let space_1 = start_space(&kitsune_1).await;
@@ -413,7 +473,7 @@ async fn test_space_should_not_start_without_bootstrap_url_configured() {
     let kitsune = kitsune_builder.build().await.expect("Build Kitsune2");
 
     // register handler
-    let kitsune_handler = Arc::new(TestKitsuneHandler);
+    let kitsune_handler = Arc::new(TestKitsuneHandler::default());
     kitsune
         .register_handler(kitsune_handler.clone())
         .await
@@ -456,7 +516,7 @@ async fn test_should_start_space_with_different_bootstrap_urls() {
 
     let kitsune = kitsune_builder.build().await.unwrap();
     kitsune
-        .register_handler(Arc::new(TestKitsuneHandler))
+        .register_handler(Arc::new(TestKitsuneHandler::default()))
         .await
         .unwrap();
 
@@ -577,7 +637,7 @@ async fn two_spaces_different_relays() {
 
     let kitsune = kitsune_builder.build().await.unwrap();
     kitsune
-        .register_handler(Arc::new(TestKitsuneHandler))
+        .register_handler(Arc::new(TestKitsuneHandler::default()))
         .await
         .unwrap();
 
@@ -737,4 +797,149 @@ async fn two_spaces_different_relays() {
         host_a, host_b,
         "Relay hosts should differ between the two spaces"
     );
+}
+
+/// A gossip config that never initiates on its own.
+///
+/// Gossip runs continuously between test nodes and would otherwise dial the
+/// peer on its own schedule, establishing a connection before a test gets a
+/// chance to exercise a genuinely first-contact simultaneous send.
+fn suppressed_gossip_config() -> K2GossipConfig {
+    K2GossipConfig {
+        initial_initiate_interval_ms: 3_600_000,
+        initiate_interval_ms: 3_600_000,
+        min_initiate_interval_ms: 3_600_000,
+        initiate_jitter_ms: 0,
+        round_timeout_ms: 10_000,
+        ..Default::default()
+    }
+}
+
+/// Two nodes that have never talked send to each other at the same instant.
+/// Both first messages must be delivered.
+///
+/// This is the kitsune2-level cover for the simultaneous-open message loss
+/// that wind-tunnel issue #690 surfaced as a flaky chatter scenario: when both
+/// peers dial at once, one of the two connections loses the deterministic
+/// tie-break, and whichever payload was written to the losing connection was
+/// silently dropped.
+///
+/// The race is only hit when both sides' first dial lands in the same narrow
+/// window, so a single pair of nodes is not a reliable reproduction: this
+/// runs several independent pairs, each a fresh "first contact", to make the
+/// race close to certain to be hit at least once if the bug is present.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn simultaneous_space_notify_is_delivered_both_ways() {
+    enable_tracing();
+
+    let bootstrap_server = TestBootstrapSrv::new(false).await;
+    let bootstrap_server_url = bootstrap_server.addr().to_string();
+
+    #[cfg(feature = "transport-iroh")]
+    let relay_server_url = iroh_relay_from_bootstrap(&bootstrap_server).await;
+
+    for round in 0..5u32 {
+        // Gossip is suppressed on both nodes so it cannot pre-establish a
+        // connection between them: the notify send below must be the first
+        // contact, and both dials race. Fresh nodes are created each round
+        // so that every round is a genuine first contact, rather than
+        // reusing a connection already established by a previous round.
+        let (kitsune_1, handler_1) = make_kitsune_node(
+            &relay_server_url,
+            &bootstrap_server_url,
+            suppressed_gossip_config(),
+        )
+        .await;
+        let (kitsune_2, handler_2) = make_kitsune_node(
+            &relay_server_url,
+            &bootstrap_server_url,
+            suppressed_gossip_config(),
+        )
+        .await;
+
+        let space_1 = start_space(&kitsune_1).await;
+        let space_2 = start_space(&kitsune_2).await;
+
+        // Each node must know the other's URL before the simultaneous send,
+        // so that the send itself is the first contact and both dials race.
+        let peer_url_1 = peer_url_of(&space_1).await;
+        let peer_url_2 = peer_url_of(&space_2).await;
+
+        // Each side must also already know the other as an agent, not just
+        // its URL, otherwise the notify is silently dropped by the
+        // access-control gate before the transport ever gets a chance to
+        // dial, which would fail the test for an unrelated reason. Agent
+        // info is exchanged by the bootstrap poll, independent of gossip, so
+        // this does not race with the suppressed gossip initiate above.
+        iter_check!(10_000, 200, {
+            let known_to_1 = space_1
+                .peer_store()
+                .get_all()
+                .await
+                .unwrap()
+                .iter()
+                .any(|agent| agent.url.as_ref() == Some(&peer_url_2));
+            let known_to_2 = space_2
+                .peer_store()
+                .get_all()
+                .await
+                .unwrap()
+                .iter()
+                .any(|agent| agent.url.as_ref() == Some(&peer_url_1));
+            if known_to_1 && known_to_2 {
+                break;
+            }
+        });
+
+        let payload_1 =
+            Bytes::from(format!("hello from node 1, round {round}"));
+        let payload_2 =
+            Bytes::from(format!("hello from node 2, round {round}"));
+
+        let barrier = Arc::new(tokio::sync::Barrier::new(3));
+
+        let send_1 = {
+            let space_1 = space_1.clone();
+            let barrier = barrier.clone();
+            let payload_1 = payload_1.clone();
+            let peer_url_2 = peer_url_2.clone();
+            tokio::spawn(async move {
+                barrier.wait().await;
+                space_1.send_notify(peer_url_2, payload_1).await
+            })
+        };
+        let send_2 = {
+            let space_2 = space_2.clone();
+            let barrier = barrier.clone();
+            let payload_2 = payload_2.clone();
+            let peer_url_1 = peer_url_1.clone();
+            tokio::spawn(async move {
+                barrier.wait().await;
+                space_2.send_notify(peer_url_1, payload_2).await
+            })
+        };
+
+        barrier.wait().await;
+        let (result_1, result_2) =
+            tokio::time::timeout(Duration::from_secs(20), async {
+                tokio::join!(send_1, send_2)
+            })
+            .await
+            .expect("both simultaneous sends must complete");
+        result_1
+            .expect("node 1 send task must not panic")
+            .expect("node 1 send must succeed");
+        result_2
+            .expect("node 2 send task must not panic")
+            .expect("node 2 send must succeed");
+
+        // Both payloads must reach the other node's handler.
+        iter_check!(10_000, 200, {
+            let seen_1 = handler_1.received();
+            let seen_2 = handler_2.received();
+            if seen_1.contains(&payload_2) && seen_2.contains(&payload_1) {
+                break;
+            }
+        });
+    }
 }

--- a/crates/transport_iroh/src/connection_context.rs
+++ b/crates/transport_iroh/src/connection_context.rs
@@ -2,8 +2,9 @@ use crate::IrohTransport;
 use crate::SpaceRelays;
 use crate::close_code::CloseCode;
 use crate::connection::DynConnection;
-#[cfg(feature = "metrics")]
-use crate::metrics::connection_counter_metric;
+use crate::connection_registry::{
+    ConnectionLifecycle, ConnectionResolution, RegistryEntry,
+};
 use crate::stream::{DynIrohRecvStream, DynIrohSendStream};
 use crate::{
     Connections, FRAME_HEADER_LEN, FrameType, decode_frame_header,
@@ -22,6 +23,9 @@ use std::{
 };
 use tokio::{sync::MutexGuard, task::AbortHandle};
 use tracing::{debug, error, info, trace, warn};
+
+/// Maximum time to open a stream and complete the preflight exchange.
+const PREFLIGHT_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Reason sent when a preferred connection wins simultaneous-open resolution.
 pub(super) const SUPERSEDED_CLOSE_REASON: &[u8] =
@@ -89,6 +93,9 @@ pub(super) struct ConnectionContext {
     remote_url: RwLock<Option<Url>>,
     preflight_sent: AtomicBool,
     preflight_received: AtomicBool,
+    /// One deadline for stream acceptance, validation, and the return preflight.
+    preflight_deadline: tokio::time::Instant,
+    lifecycle: ConnectionLifecycle,
     send_message_count: AtomicU64,
     send_bytes: AtomicU64,
     recv_message_count: AtomicU64,
@@ -130,6 +137,8 @@ impl ConnectionContext {
             remote_url: RwLock::new(params.remote_url),
             preflight_sent: AtomicBool::new(params.preflight_sent),
             preflight_received: AtomicBool::new(false),
+            preflight_deadline: tokio::time::Instant::now() + PREFLIGHT_TIMEOUT,
+            lifecycle: ConnectionLifecycle::new(),
             send_message_count: AtomicU64::new(0),
             send_bytes: AtomicU64::new(0),
             recv_message_count: AtomicU64::new(0),
@@ -168,12 +177,30 @@ impl ConnectionContext {
         info!(local_url = ?url, "Sending preflight frame");
         trace!(?frame, "Sending preflight frame");
         if let Err(err) = stream.write_all(&frame).await {
-            error!(?err, "Failed to send preflight frame");
+            self.log_write_failure(&err, "preflight");
             *stream_lock = None;
             return Err(err);
         }
 
         Ok(())
+    }
+
+    /// Report a failed frame write at the level the cause deserves.
+    ///
+    /// Losing simultaneous-open resolution closes this connection underneath
+    /// an in-flight write, and the caller retries on the connection that won.
+    /// That is a routine outcome of two peers dialing at once, so it must not
+    /// be reported as a failure. Every other write failure still is one.
+    fn log_write_failure(&self, err: &K2Error, frame: &str) {
+        if self.is_superseded() {
+            debug!(
+                ?err,
+                frame,
+                "Frame write ended because the connection was superseded"
+            );
+        } else {
+            error!(?err, frame, "Failed to send frame");
+        }
     }
 
     pub async fn send_data_frame(&self, data: Bytes) -> K2Result<()> {
@@ -185,7 +212,7 @@ impl ConnectionContext {
 
         trace!(?frame, "Sending data frame");
         if let Err(err) = stream.write_all(&frame).await {
-            error!(?err, "Failed to send data frame");
+            self.log_write_failure(&err, "data");
             *stream_lock = None;
             return Err(err);
         }
@@ -201,6 +228,13 @@ impl ConnectionContext {
 
     pub fn remote_url(&self) -> Option<Url> {
         self.remote_url.read().expect("poisoned").clone()
+    }
+
+    /// Waits for preflight completion and simultaneous-open resolution.
+    ///
+    /// Returns how preflight and simultaneous-open resolution completed.
+    pub(super) async fn wait_for_resolution(&self) -> ConnectionResolution {
+        self.lifecycle.wait_for_resolution().await
     }
 
     pub fn get_send_message_count(&self) -> u64 {
@@ -242,50 +276,26 @@ impl ConnectionContext {
         self.dialed_by_us == larger_endpoint_dialed
     }
 
-    /// Register `self` as the active connection for `remote_url`, resolving any
-    /// simultaneous-open race deterministically.
+    /// Whether this connection lost simultaneous-open resolution to a
+    /// preferred connection to the same peer, as opposed to ending for any
+    /// other reason.
     ///
-    /// - If the slot is free, `self` takes it.
-    /// - If `self` is already the active connection, this is a no-op.
-    /// - If a *different* connection to the same peer already exists, the
-    ///   [`is_preferred_connection`](Self::is_preferred_connection) tie-break
-    ///   decides which survives. When `self` wins, the displaced connection is
-    ///   closed (not aborted) so its reader observes the close and exits
-    ///   quietly through the identity-aware cleanup path. When `self` loses,
-    ///   the existing connection is left in place.
+    /// Two independent signals say so, and a send racing the teardown may only
+    /// see one of them:
     ///
-    /// Returns `true` if `self` is the active connection afterwards, `false` if
-    /// it lost the tie-break and should be torn down.
-    pub(super) fn register_as_active(
-        self: &Arc<Self>,
-        connections: &Connections,
-        remote_url: &Url,
-    ) -> bool {
-        let displaced = {
-            let mut map = connections.write().expect("poisoned");
-            match map.get(remote_url) {
-                Some(existing) if Arc::ptr_eq(existing, self) => return true,
-                Some(_) if !self.is_preferred_connection() => return false,
-                // Slot is free, or we win the tie-break against the existing
-                // connection: take the slot.
-                _ => map.insert(remote_url.clone(), self.clone()),
-            }
-        };
-
-        // We are now the active connection.
-        #[cfg(feature = "metrics")]
-        connection_counter_metric().add(1, &[]);
-
-        if let Some(displaced) = displaced {
-            // The displaced connection was previously counted as active.
-            #[cfg(feature = "metrics")]
-            connection_counter_metric().add(-1, &[]);
-            displaced
-                .connection
-                .close(CloseCode::Superseded, SUPERSEDED_CLOSE_REASON);
-        }
-
-        true
+    /// - When the *local* registry displaces this connection it marks the
+    ///   lifecycle before closing it, so the lifecycle is always the earlier
+    ///   signal there.
+    /// - When the *remote* supersedes it, the verdict arrives only as a close
+    ///   code. The lifecycle catches up when this connection's reader runs its
+    ///   exit cleanup, which races anything already writing to the connection.
+    ///   Reading the close code directly removes that race.
+    pub(super) fn is_superseded(&self) -> bool {
+        self.lifecycle.is_superseded()
+            || matches!(
+                self.connection.remote_close_reason(),
+                Some((CloseCode::Superseded, _))
+            )
     }
 
     /// Abort the connection reader task, if it is still running.
@@ -310,8 +320,21 @@ impl ConnectionContext {
     /// through the identity-aware cleanup path, which sees that this is not the
     /// active connection and so does not fire `peer_disconnect`.
     pub(super) fn close_quietly(&self) {
+        self.mark_superseded();
         self.connection
             .close(CloseCode::Superseded, SUPERSEDED_CLOSE_REASON);
+    }
+
+    /// Close the underlying connection without notifying the handler, using
+    /// the real failure reason rather than [`CloseCode::Superseded`].
+    ///
+    /// Used when this connection genuinely failed for a reason other than
+    /// simultaneous-open resolution, such as a preflight write that failed
+    /// for its own sake. The remote treats `Superseded` as a signal to
+    /// retry, so a genuine failure must not be reported that way.
+    pub(super) fn close_failed(&self, reason: &[u8]) {
+        self.mark_closed();
+        self.connection.close(CloseCode::Unspecified, reason);
     }
 
     /// Close the connection and inform the local handlers.
@@ -322,13 +345,11 @@ impl ConnectionContext {
     /// quietly instead of marking this peer unresponsive. Local handlers
     /// are informed via `peer_disconnect` with the same reason.
     pub fn disconnect(&self, code: CloseCode, reason: String) {
+        self.mark_closed();
         info!(reason, remote_url = ?self.remote_url(), "Disconnecting from remote");
         self.connection.close(code, reason.as_bytes());
         if let Some(peer) = self.remote_url() {
             self.handler.peer_disconnect(peer, Some(reason));
-            // Record connection counter metric.
-            #[cfg(feature = "metrics")]
-            connection_counter_metric().add(-1, &[]);
         }
     }
 
@@ -372,8 +393,23 @@ impl ConnectionContext {
         let mut mark_unresponsive = true;
 
         let err = loop {
+            let incoming = if ctx.preflight_received() {
+                ctx.connection.accept_uni().await
+            } else {
+                tokio::time::timeout_at(
+                    ctx.preflight_deadline,
+                    ctx.connection.accept_uni(),
+                )
+                .await
+                .unwrap_or_else(|err| {
+                    Err(K2Error::other_src(
+                        "timed out waiting for preflight",
+                        err,
+                    ))
+                })
+            };
             // Main loop to accept incoming unidirectional streams from the remote peer.
-            match ctx.connection.accept_uni().await {
+            match incoming {
                 Ok(stream) => {
                     info!(remote_id = ?ctx.connection.remote_id(), "Accepted incoming stream");
                     // Read frames from the stream.
@@ -436,25 +472,6 @@ impl ConnectionContext {
         }
     }
 
-    /// Remove `self` from the active-connections map if it is still the
-    /// entry for `remote_url`.
-    ///
-    /// Returns `true` if `self` was the active connection.
-    fn remove_if_active(
-        self: &Arc<Self>,
-        connections: &Connections,
-        remote_url: &Url,
-    ) -> bool {
-        let mut map = connections.write().expect("poisoned");
-        match map.get(remote_url) {
-            Some(active) if Arc::ptr_eq(active, self) => {
-                map.remove(remote_url);
-                true
-            }
-            _ => false,
-        }
-    }
-
     // The reader loop has ended: run the cleanup matching why it ended.
     // See [`ReaderCleanup`] for the possible verdicts and their rationale.
     async fn cleanup_after_exit(
@@ -463,6 +480,7 @@ impl ConnectionContext {
         exit: ReaderExit,
     ) {
         let Some(remote_url) = ctx.remote_url() else {
+            ctx.mark_closed();
             // Preflight never completed, so no peer URL was learned and the
             // peer was never surfaced to the handler.
             ctx.connection
@@ -470,7 +488,15 @@ impl ConnectionContext {
             return;
         };
 
-        let was_active = ctx.remove_if_active(connections, &remote_url);
+        let was_active = connections.remove_if_current(&remote_url, &ctx);
+        if matches!(
+            ctx.connection.remote_close_reason(),
+            Some((CloseCode::Superseded, _))
+        ) {
+            ctx.lifecycle.mark_superseded();
+        } else {
+            ctx.lifecycle.mark_closed();
+        }
         let verdict = classify_exit(
             was_active,
             ctx.connection.remote_close_reason(),
@@ -506,8 +532,19 @@ impl ConnectionContext {
             }
             ReaderCleanup::Quiet => {
                 debug!(?remote_url, reason = %exit.err, "Connection reader stopped without marking peer unresponsive (superseded or not the active connection)");
-                ctx.connection
-                    .close(CloseCode::Superseded, SUPERSEDED_CLOSE_REASON);
+                // Only claim `Superseded` toward the remote when this
+                // connection actually resolved that way (a genuine
+                // simultaneous-open loss). Other reasons a non-active reader
+                // stops quietly, such as a rejected preflight, must not be
+                // reported as superseded: the sender on the other end treats
+                // that code as a signal to retry.
+                if ctx.is_superseded() {
+                    ctx.connection
+                        .close(CloseCode::Superseded, SUPERSEDED_CLOSE_REASON);
+                } else {
+                    ctx.connection
+                        .close(CloseCode::Unspecified, exit.err.as_bytes());
+                }
             }
         }
     }
@@ -545,7 +582,7 @@ impl ConnectionContext {
         local_url: Arc<RwLock<Option<Url>>>,
     ) -> K2Result<bool> {
         if !ctx.preflight_received() {
-            let result = tokio::time::timeout(Duration::from_secs(10), async {
+            let result = tokio::time::timeout_at(ctx.preflight_deadline, async {
                 let (remote_url, preflight_bytes) = read_preflight_frame_from_stream(&recv_stream, ctx.max_frame_bytes).await?;
 
                 ctx.set_remote_url(remote_url.clone());
@@ -554,6 +591,17 @@ impl ConnectionContext {
                     .await?;
                 ctx.set_preflight_received();
                 info!(remote = ?remote_url.peer_id(),"Preflight received successfully");
+
+                // Select the surviving connection before acknowledging the
+                // preflight. The dialer treats that acknowledgement as proof
+                // that application data can be sent safely on this connection.
+                if !connections.register_candidate(&remote_url, &ctx) {
+                    debug!(
+                        remote = ?remote_url.peer_id(),
+                        "Connection superseded by preferred connection to same peer"
+                    );
+                    return Ok(None);
+                }
 
                 // If the preflight has not been sent yet, it must be the first message
                 // sent back to the remote.
@@ -581,26 +629,22 @@ impl ConnectionContext {
                     }
                 }
 
-                Ok(remote_url)
+                if !connections.activate(&remote_url, &ctx) {
+                    debug!(
+                        remote = ?remote_url.peer_id(),
+                        "Connection lost the peer's slot before it could be activated"
+                    );
+                    return Ok(None);
+                }
+                Ok(Some(remote_url))
             })
                 .await
                 .map_err(|err| {
                     K2Error::other_src("timed out waiting for preflight", err)
                 });
             match result {
-                Ok(Ok(remote_url)) => {
-                    // Register as the active connection, resolving any
-                    // simultaneous-open race with another connection to the
-                    // same peer. If this connection lost the tie-break, stop
-                    // reading it; the preferred connection is already active.
-                    if !ctx.register_as_active(&connections, &remote_url) {
-                        debug!(
-                            remote = ?remote_url.peer_id(),
-                            "Connection superseded by preferred connection to same peer"
-                        );
-                        return Ok(false);
-                    }
-                }
+                Ok(Ok(Some(_))) => {}
+                Ok(Ok(None)) => return Ok(false),
                 Ok(Err(err)) | Err(err) => {
                     error!(?err, "failed to receive preflight frame");
                     return Err(err);
@@ -678,6 +722,14 @@ impl ConnectionContext {
         self.preflight_received.store(true, Ordering::SeqCst);
     }
 
+    pub(super) fn mark_superseded(&self) {
+        self.lifecycle.mark_superseded();
+    }
+
+    pub(super) fn mark_closed(&self) {
+        self.lifecycle.mark_closed();
+    }
+
     fn increment_send_message_count(&self) {
         self.send_message_count.fetch_add(1, Ordering::SeqCst);
     }
@@ -692,6 +744,21 @@ impl ConnectionContext {
 
     fn increment_recv_bytes(&self, len: u64) {
         self.recv_bytes.fetch_add(len, Ordering::SeqCst);
+    }
+}
+
+impl RegistryEntry for ConnectionContext {
+    fn lifecycle(&self) -> &ConnectionLifecycle {
+        &self.lifecycle
+    }
+
+    fn is_preferred(&self) -> bool {
+        self.is_preferred_connection()
+    }
+
+    fn close_superseded(&self) {
+        self.connection
+            .close(CloseCode::Superseded, SUPERSEDED_CLOSE_REASON);
     }
 }
 

--- a/crates/transport_iroh/src/connection_registry.rs
+++ b/crates/transport_iroh/src/connection_registry.rs
@@ -1,0 +1,333 @@
+//! Connection lifecycle and the peer-URL → connection map.
+//!
+//! A connection is not usable the moment it is dialed or accepted: both peers
+//! may dial at the same time, and only one of the two resulting connections
+//! survives simultaneous-open resolution. This module owns the states a
+//! connection moves through and, in [`ConnectionRegistry`], every mutation of
+//! the map that decides which connection is the live one for a peer.
+
+#[cfg(feature = "metrics")]
+use crate::metrics::connection_counter_metric;
+use kitsune2_api::Url;
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+use tokio::sync::watch;
+
+/// Where a connection is in its life.
+///
+/// `Pending` is the only non-terminal state; `Superseded` and `Closed` are
+/// absorbing, so a connection never comes back from either.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ConnectionState {
+    /// Dialed or accepted, but preflight and simultaneous-open resolution
+    /// have not finished. Application data must not be written yet.
+    Pending,
+    /// Preflight completed and this connection holds the peer's map slot.
+    Active,
+    /// A competing connection to the same peer was selected instead.
+    Superseded,
+    /// The connection ended.
+    Closed,
+}
+
+/// How a wait for a connection's resolution ended.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ConnectionResolution {
+    /// The connection completed preflight and is selected for the peer.
+    Active,
+    /// A competing connection was selected for the peer.
+    Superseded,
+    /// The connection ended before preflight completed.
+    Closed,
+}
+
+/// The state machine of a single connection, observable by waiters.
+///
+/// Backed by a `watch` channel so a sender parked in
+/// [`wait_for_resolution`](Self::wait_for_resolution) is woken the moment the
+/// connection is activated or loses a race, with no polling.
+#[derive(Debug)]
+pub(crate) struct ConnectionLifecycle {
+    state: watch::Sender<ConnectionState>,
+}
+
+impl ConnectionLifecycle {
+    pub(crate) fn new() -> Self {
+        Self {
+            state: watch::Sender::new(ConnectionState::Pending),
+        }
+    }
+
+    /// Waits until this connection is either usable or definitively not.
+    pub(crate) async fn wait_for_resolution(&self) -> ConnectionResolution {
+        let mut state = self.state.subscribe();
+        loop {
+            match *state.borrow_and_update() {
+                ConnectionState::Active => {
+                    return ConnectionResolution::Active;
+                }
+                ConnectionState::Superseded => {
+                    return ConnectionResolution::Superseded;
+                }
+                ConnectionState::Closed => {
+                    return ConnectionResolution::Closed;
+                }
+                ConnectionState::Pending => {}
+            }
+
+            if state.changed().await.is_err() {
+                return ConnectionResolution::Closed;
+            }
+        }
+    }
+
+    pub(crate) fn is_active(&self) -> bool {
+        *self.state.borrow() == ConnectionState::Active
+    }
+
+    /// Whether this connection has resolved as superseded by a preferred
+    /// connection to the same peer, as opposed to closed for any other
+    /// reason.
+    pub(crate) fn is_superseded(&self) -> bool {
+        *self.state.borrow() == ConnectionState::Superseded
+    }
+
+    /// Whether this connection may still take or hold a peer's map slot.
+    pub(crate) fn is_live(&self) -> bool {
+        matches!(
+            *self.state.borrow(),
+            ConnectionState::Pending | ConnectionState::Active
+        )
+    }
+
+    /// Moves `Pending → Active`. Returns whether the transition happened.
+    pub(crate) fn activate(&self) -> bool {
+        let activated = self.state.send_if_modified(|state| {
+            if *state == ConnectionState::Pending {
+                *state = ConnectionState::Active;
+                true
+            } else {
+                false
+            }
+        });
+
+        #[cfg(feature = "metrics")]
+        if activated {
+            connection_counter_metric().add(1, &[]);
+        }
+
+        activated
+    }
+
+    pub(crate) fn mark_superseded(&self) {
+        self.transition_to_terminal(ConnectionState::Superseded);
+    }
+
+    pub(crate) fn mark_closed(&self) {
+        self.transition_to_terminal(ConnectionState::Closed);
+    }
+
+    /// Terminal states are absorbing: the first one to be set wins, and the
+    /// metrics counter is decremented exactly once, only if the connection had
+    /// been counted as active.
+    fn transition_to_terminal(&self, terminal: ConnectionState) {
+        #[cfg(feature = "metrics")]
+        let mut was_active = false;
+        self.state.send_if_modified(|state| match *state {
+            ConnectionState::Pending | ConnectionState::Active => {
+                #[cfg(feature = "metrics")]
+                {
+                    was_active = *state == ConnectionState::Active;
+                }
+                *state = terminal;
+                true
+            }
+            ConnectionState::Superseded | ConnectionState::Closed => false,
+        });
+
+        #[cfg(feature = "metrics")]
+        if was_active {
+            connection_counter_metric().add(-1, &[]);
+        }
+    }
+}
+
+/// What the registry needs to know about a connection to arbitrate the slot.
+///
+/// Kept deliberately small so the arbitration can be tested without an iroh
+/// endpoint, a reader task, or a handler.
+pub(crate) trait RegistryEntry {
+    /// This connection's state machine.
+    fn lifecycle(&self) -> &ConnectionLifecycle;
+
+    /// Whether this is the connection both peers converge on when a
+    /// simultaneous dial produced two connections for the same pair.
+    fn is_preferred(&self) -> bool;
+
+    /// Close this connection because a competing one was selected. The
+    /// connection's own reader observes the close and exits quietly.
+    fn close_superseded(&self);
+}
+
+/// The live connection for each peer URL, and the rules for which connection
+/// that is.
+#[derive(Debug)]
+pub(crate) struct ConnectionRegistry<E> {
+    entries: Arc<RwLock<HashMap<Url, Arc<E>>>>,
+}
+
+impl<E> Clone for ConnectionRegistry<E> {
+    fn clone(&self) -> Self {
+        Self {
+            entries: self.entries.clone(),
+        }
+    }
+}
+
+impl<E: RegistryEntry> Default for ConnectionRegistry<E> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<E: RegistryEntry> ConnectionRegistry<E> {
+    pub(crate) fn new() -> Self {
+        Self {
+            entries: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    pub(crate) fn get(&self, peer: &Url) -> Option<Arc<E>> {
+        self.entries.read().expect("poisoned").get(peer).cloned()
+    }
+
+    /// Claim `peer`'s slot for `candidate`, resolving any simultaneous-open
+    /// race deterministically.
+    ///
+    /// - A candidate in a terminal state can never take the slot.
+    /// - A free slot is taken.
+    /// - Re-registering the current entry is a no-op.
+    /// - An incumbent in a terminal state is evicted: it can never carry
+    ///   traffic again, and defending it would reject the connection that
+    ///   replaces it.
+    /// - Otherwise the incumbent is only defended when it is itself the
+    ///   preferred connection. Exactly one of the two connections in a genuine
+    ///   simultaneous open is preferred, so a non-preferred incumbent is a
+    ///   leftover in the same direction as the candidate and loses to it.
+    ///
+    /// Returns whether `candidate` holds the slot afterwards. A displaced
+    /// incumbent is marked superseded and closed; a rejected candidate is
+    /// marked superseded.
+    pub(crate) fn register_candidate(
+        &self,
+        peer: &Url,
+        candidate: &Arc<E>,
+    ) -> bool {
+        let displaced = {
+            let mut entries = self.entries.write().expect("poisoned");
+            if !candidate.lifecycle().is_live() {
+                return false;
+            }
+            let displaced = match entries.get(peer) {
+                Some(existing) if Arc::ptr_eq(existing, candidate) => {
+                    return true;
+                }
+                Some(existing) if !existing.lifecycle().is_live() => {
+                    entries.insert(peer.clone(), candidate.clone())
+                }
+                Some(existing)
+                    if existing.is_preferred() && !candidate.is_preferred() =>
+                {
+                    candidate.lifecycle().mark_superseded();
+                    return false;
+                }
+                _ => entries.insert(peer.clone(), candidate.clone()),
+            };
+            // Publish the verdict with the replacement. Otherwise the old
+            // reader can fail activation and mark itself closed before it
+            // learns that pending sends should retry on the winner.
+            if let Some(displaced) = &displaced {
+                displaced.lifecycle().mark_superseded();
+            }
+            displaced
+        };
+
+        if let Some(displaced) = displaced {
+            displaced.close_superseded();
+        }
+
+        true
+    }
+
+    /// Mark `entry` active if it is still `peer`'s slot holder.
+    ///
+    /// Returns whether the entry is active afterwards, so an already-active
+    /// entry reports success.
+    pub(crate) fn activate(&self, peer: &Url, entry: &Arc<E>) -> bool {
+        // A write lock is taken even though this method never writes to the
+        // map: it serializes against `register_candidate` so the entry
+        // cannot be displaced between the "is this still the current entry"
+        // check and the lifecycle transition below, and holding it across
+        // that transition keeps the critical section deliberately small.
+        let entries = self.entries.write().expect("poisoned");
+        let is_current = entries
+            .get(peer)
+            .is_some_and(|current| Arc::ptr_eq(current, entry));
+        if !is_current {
+            return false;
+        }
+
+        entry.lifecycle().activate() || entry.lifecycle().is_active()
+    }
+
+    /// Remove `entry` from the map if it is still `peer`'s slot holder.
+    /// Returns whether it was.
+    pub(crate) fn remove_if_current(&self, peer: &Url, entry: &Arc<E>) -> bool {
+        let mut entries = self.entries.write().expect("poisoned");
+        match entries.get(peer) {
+            Some(current) if Arc::ptr_eq(current, entry) => {
+                entries.remove(peer);
+                true
+            }
+            _ => false,
+        }
+    }
+
+    /// Remove and return whatever holds `peer`'s slot.
+    pub(crate) fn take(&self, peer: &Url) -> Option<Arc<E>> {
+        self.entries.write().expect("poisoned").remove(peer)
+    }
+
+    /// The peers with an active connection. A pending or superseded entry is
+    /// not a connected peer.
+    pub(crate) fn active_peers(&self) -> Vec<Url> {
+        self.entries
+            .read()
+            .expect("poisoned")
+            .iter()
+            .filter(|(_, entry)| entry.lifecycle().is_active())
+            .map(|(peer, _)| peer.clone())
+            .collect()
+    }
+
+    /// The active entries with their peer URLs, for stats reporting.
+    pub(crate) fn active_entries(&self) -> Vec<(Url, Arc<E>)> {
+        self.entries
+            .read()
+            .expect("poisoned")
+            .iter()
+            .filter(|(_, entry)| entry.lifecycle().is_active())
+            .map(|(peer, entry)| (peer.clone(), entry.clone()))
+            .collect()
+    }
+
+    /// Empty the map and return everything that was in it, for shutdown.
+    pub(crate) fn drain(&self) -> Vec<Arc<E>> {
+        self.entries
+            .write()
+            .expect("poisoned")
+            .drain()
+            .map(|(_, entry)| entry)
+            .collect()
+    }
+}

--- a/crates/transport_iroh/src/lib.rs
+++ b/crates/transport_iroh/src/lib.rs
@@ -226,9 +226,11 @@ mod url;
 use url::*;
 mod connection;
 mod connection_context;
+mod connection_registry;
 mod endpoint;
 mod stream;
 use connection_context::*;
+use connection_registry::{ConnectionRegistry, ConnectionResolution};
 #[cfg(feature = "metrics")]
 mod metrics;
 
@@ -239,6 +241,12 @@ pub mod test_utils;
 mod tests;
 
 const ALPN: &[u8] = b"kitsune2/0";
+/// How many times `send` will re-resolve a connection before giving up.
+///
+/// Each attempt is one full dial-and-preflight round; a peer that keeps losing
+/// simultaneous-open races is either genuinely flapping or being restarted, and
+/// the caller is better served by an error than by an unbounded loop.
+const MAX_SEND_CONNECT_ATTEMPTS: usize = 5;
 /// Error message returned when a connection attempt is skipped because the
 /// home relay is not connected.  Exported so integration tests can match it
 /// without depending on a free-form string literal.
@@ -411,7 +419,7 @@ impl TransportFactory for IrohTransportFactory {
     }
 }
 
-type Connections = Arc<RwLock<HashMap<Url, Arc<ConnectionContext>>>>;
+type Connections = ConnectionRegistry<ConnectionContext>;
 
 /// Per-space relay state: maps SpaceId to (relay URL, our local URL on that relay).
 type SpaceRelays = Arc<RwLock<HashMap<SpaceId, (RelayUrl, Option<Url>)>>>;
@@ -468,14 +476,10 @@ impl Drop for IrohTransport {
         // holds a reference to the context. Thus the context can
         // only be dropped once that reference is dropped, which
         // happens when the task is aborted.
-        self.connections
-            .write()
-            .expect("poisoned")
-            .drain()
-            .for_each(|(remote_url, ctx)| {
-                debug!(?remote_url, "Aborting connection context tasks");
-                ctx.abort_tasks();
-            });
+        self.connections.drain().into_iter().for_each(|ctx| {
+            debug!(remote_url = ?ctx.remote_url(), "Aborting connection context tasks");
+            ctx.abort_tasks();
+        });
         let endpoint = self.endpoint.clone();
         tokio::spawn(async move { endpoint.close().await });
     }
@@ -599,7 +603,7 @@ impl IrohTransport {
 
         let endpoint = Arc::new(IrohEndpoint::new(endpoint));
         let local_url = Arc::new(RwLock::new(None));
-        let connections = Arc::new(RwLock::new(HashMap::new()));
+        let connections = ConnectionRegistry::new();
         let connection_locks = Arc::new(Mutex::new(HashMap::new()));
 
         let watch_addr_task = Self::spawn_watch_addr_task(
@@ -971,6 +975,17 @@ impl IrohTransport {
                 max_frame_bytes: self.config.max_frame_bytes,
             });
 
+            // Publish the candidate before sending the preflight, so that a
+            // competing inbound connection from the same peer resolves against
+            // this dial instead of racing an unpublished one. Both directions
+            // reach the same verdict whichever order they register in, because
+            // the tie-break is deterministic and the registry applies it
+            // atomically.
+            if !self.connections.register_candidate(&remote_url, &ctx) {
+                ctx.close_quietly();
+                return Ok(ctx);
+            }
+
             if let Err(e) = ctx
                 .send_preflight_frame(
                     current_local_url.clone(),
@@ -978,11 +993,31 @@ impl IrohTransport {
                 )
                 .await
             {
+                // Being published from this point on means a competing
+                // connection can take the peer's slot and close this dial
+                // underneath the preflight write. Either end can decide that:
+                // the remote rejecting this dial in favour of its own is in
+                // fact the more common way this write fails. That is
+                // simultaneous-open resolution working as intended, not a peer
+                // that failed: marking it unresponsive would stall gossip with
+                // it until its agent info expires. Hand the context back
+                // instead, so the caller retries on the connection that won.
+                if ctx.is_superseded() {
+                    debug!(
+                        remote = ?remote_url.peer_id(),
+                        "Dial superseded while sending preflight"
+                    );
+                    return Ok(ctx);
+                }
+
                 // On send preflight error, mark the peer unresponsive
                 let _ = self
                     .handler
                     .set_unresponsive(remote_url.clone(), Timestamp::now())
                     .await;
+
+                ctx.close_failed(e.to_string().as_bytes());
+                self.connections.remove_if_current(&remote_url, &ctx);
 
                 return Err(e);
             }
@@ -1084,9 +1119,8 @@ impl TxImp for IrohTransport {
         peer: Url,
         payload: Option<(String, Bytes)>,
     ) -> BoxFut<'_, ()> {
-        if let Some(ctx) =
-            self.connections.write().expect("poisoned").remove(&peer)
-        {
+        let ctx = self.connections.take(&peer);
+        if let Some(ctx) = ctx {
             // The reason string travels in the QUIC application close frame
             // itself, so the encoded payload message is intentionally not
             // sent as a data frame first.
@@ -1130,100 +1164,108 @@ impl TxImp for IrohTransport {
                     .clone()
             };
 
-            // Acquire the write lock to serialize connection creation for this peer.
-            //
-            // Other send requests to the same peer will wait here to acquire the lock.
-            // The lock is released immediately if there is a connection, Otherwise
-            // a connection is established and the preflight and host URL are sent
-            // to the remote, before the lock is released.
-            //
-            // The alternative to this mechanism would be fold the function of this
-            // lock into the connections map. That would slightly reduce the
-            // complexity in this method, but would increase complexity in all places
-            // where the connection map is used. The connecions_locks map is only
-            // used in this method. Overall it is simpler as is.
-            let _lock_guard = peer_lock.lock().await;
+            let mut attempts = 0usize;
+            loop {
+                attempts += 1;
+                if attempts > MAX_SEND_CONNECT_ATTEMPTS {
+                    return Err(K2Error::other(format!(
+                        "no connection to {remote_url} survived simultaneous-open resolution after {MAX_SEND_CONNECT_ATTEMPTS} attempts"
+                    )));
+                }
 
-            // Atomically check and create connection and context if needed.
-            let connection_context = {
-                // Check if connection already exists, as another call might have
-                // created it while this one was waiting for the lock.
-                let existing = connections
-                    .read()
-                    .expect("poisoned")
-                    .get(&remote_url)
-                    .cloned();
-                if let Some(ctx) = existing {
-                    // Connection already exists, use it (preflight already done).
-                    drop(_lock_guard);
-                    ctx
-                } else {
-                    // Connection doesn't exist, create it.
-                    // This establishes the connection and sends the preflight to the remote.
-                    info!(remote = ?remote_url.peer_id(), "Establishing connection to remote");
-                    let ctx = self
-                        .create_connection_and_context(
-                            remote,
-                            remote_url.clone(),
-                        )
-                        .await?;
-
-                    // Now that the preflight has been sent successfully, register
-                    // the connection. This resolves any simultaneous-open race
-                    // with an inbound connection from the same peer: if our dial
-                    // lost the deterministic tie-break, close it and send over the
-                    // connection that won instead.
-                    if ctx.register_as_active(&connections, &remote_url) {
+                // Serialize local connection creation, but release the lock
+                // while preflight and simultaneous-open resolution complete.
+                let ctx = {
+                    let _lock_guard = peer_lock.lock().await;
+                    let existing = connections.get(&remote_url);
+                    if let Some(ctx) = existing {
                         ctx
                     } else {
-                        // Our dial lost the tie-break; discard it (its reader
-                        // then exits quietly) and use the connection that won.
-                        ctx.close_quietly();
-                        connections
-                            .read()
-                            .expect("poisoned")
-                            .get(&remote_url)
-                            .cloned()
-                            .unwrap_or(ctx)
+                        info!(remote = ?remote_url.peer_id(), "Establishing connection to remote");
+                        self.create_connection_and_context(
+                            remote.clone(),
+                            remote_url.clone(),
+                        )
+                        .await?
                     }
+                };
+
+                match ctx.wait_for_resolution().await {
+                    ConnectionResolution::Active => {
+                        let is_active = connections
+                            .get(&remote_url)
+                            .is_some_and(|active| Arc::ptr_eq(&active, &ctx));
+                        if !is_active {
+                            continue;
+                        }
+                    }
+                    ConnectionResolution::Superseded => {
+                        // Another connection to this peer won. Make sure the
+                        // loser cannot be picked up again on the next pass,
+                        // otherwise this loop spins on it.
+                        connections.remove_if_current(&remote_url, &ctx);
+                        debug!(
+                            remote = ?remote_url.peer_id(),
+                            attempts,
+                            "Connection superseded while sending; retrying"
+                        );
+                        continue;
+                    }
+                    // The remote rejected the preflight, or the connection
+                    // died before it was usable. Historically `send` returned
+                    // success here and the failure surfaced through
+                    // `peer_disconnect`/`set_unresponsive`; keep that
+                    // behavior so callers are not newly broken.
+                    ConnectionResolution::Closed => return Ok(()),
                 }
-            };
 
-            // Send actual message.
-            connection_context.send_data_frame(data).await?;
-
-            Ok(())
+                // The connection was the live one when it was picked, but a
+                // competing connection can still win the peer's slot while the
+                // frame is being written, which closes this one underneath the
+                // write. Either end can decide that, so `is_superseded` reads
+                // both the local verdict and the remote's close code; a write
+                // failure it does not recognize is reported as before.
+                //
+                // In principle the retry below can re-send a payload that
+                // actually reached the peer before a later flush/ack step
+                // failed. `send_space_notify` is at-most-once and every
+                // consumer already tolerates duplicates, so this is accepted.
+                match ctx.send_data_frame(data.clone()).await {
+                    Ok(()) => return Ok(()),
+                    Err(err) if ctx.is_superseded() => {
+                        connections.remove_if_current(&remote_url, &ctx);
+                        debug!(
+                            remote = ?remote_url.peer_id(),
+                            attempts,
+                            ?err,
+                            "Connection superseded mid-send; retrying"
+                        );
+                    }
+                    Err(err) => return Err(err),
+                }
+            }
         })
     }
 
     fn get_connected_peers(&self) -> BoxFut<'_, K2Result<Vec<Url>>> {
-        Box::pin(async {
-            Ok(self
-                .connections
-                .read()
-                .expect("poisoned")
-                .keys()
-                .cloned()
-                .collect())
-        })
+        Box::pin(async { Ok(self.connections.active_peers()) })
     }
 
     fn dump_network_stats(&self) -> BoxFut<'_, K2Result<TransportStats>> {
         Box::pin(async move {
-            let connections =
-                self.connections.read().expect("poisoned").clone();
             let mut peer_urls = Vec::new();
             if let Some(own_url) =
                 self.local_url.read().expect("poisoned").clone()
             {
                 peer_urls.push(own_url);
             }
-            let stat_connections = connections
-                .into_values()
-                .map(|context| {
+            let stat_connections = self
+                .connections
+                .active_entries()
+                .into_iter()
+                .map(|(_, context)| {
                     TransportConnectionStats {
-                        // When the context is added to the connections map, the handshake
-                        // with the URL exchange is already complete. URL must be `Some`.
+                        // Active contexts completed the URL exchange.
                         pub_key: context
                             .remote_url()
                             .unwrap()

--- a/crates/transport_iroh/src/tests/connect_failure.rs
+++ b/crates/transport_iroh/src/tests/connect_failure.rs
@@ -208,7 +208,7 @@ async fn marks_unresponsive_when_iroh_connect_returns_error() {
     let remote_url = fake_remote_url();
     let target = endpoint_from_url(&remote_url).unwrap();
 
-    let connections = Arc::new(RwLock::new(HashMap::new()));
+    let connections = crate::Connections::new();
     let local_url = Arc::new(RwLock::new(Some(remote_url.clone())));
 
     let transport = build_transport(
@@ -242,7 +242,7 @@ async fn marks_unresponsive_when_iroh_connect_returns_error() {
     assert_eq!(recorded[0].0, remote_url);
 
     // The connections map must not have been mutated for a failed connect.
-    assert!(connections.read().unwrap().is_empty());
+    assert!(connections.get(&remote_url).is_none());
 }
 
 /// When the *outer* `tokio::time::timeout` wrapper fires (i.e. iroh's connect
@@ -300,7 +300,7 @@ async fn marks_unresponsive_when_outer_connect_timeout_fires() {
     let remote_url = fake_remote_url();
     let target = endpoint_from_url(&remote_url).unwrap();
 
-    let connections = Arc::new(RwLock::new(HashMap::new()));
+    let connections = crate::Connections::new();
     let local_url = Arc::new(RwLock::new(Some(remote_url.clone())));
 
     let cfg = IrohTransportConfig {
@@ -342,4 +342,334 @@ async fn marks_unresponsive_when_outer_connect_timeout_fires() {
         "set_unresponsive should be called exactly once"
     );
     assert_eq!(recorded[0].0, remote_url);
+}
+
+/// An `Endpoint` whose `connect()` succeeds with a preconfigured connection.
+///
+/// `watch_addr`, `accept` and `close` are stubs that should not be exercised
+/// by the tests in this module.
+struct ConnectingEndpoint {
+    connection: DynConnection,
+}
+
+impl std::fmt::Debug for ConnectingEndpoint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ConnectingEndpoint").finish()
+    }
+}
+
+impl Endpoint for ConnectingEndpoint {
+    fn watch_addr(&self) -> Box<dyn EndpointAddrWatcher> {
+        Box::new(PendingWatcher)
+    }
+
+    fn accept(&self) -> BoxFut<'_, Option<K2Result<DynConnection>>> {
+        Box::pin(std::future::pending())
+    }
+
+    fn connect(
+        &self,
+        _endpoint_addr: EndpointAddr,
+        _alpn: &[u8],
+    ) -> BoxFut<'_, K2Result<DynConnection>> {
+        let connection = self.connection.clone();
+        Box::pin(async move { Ok(connection) })
+    }
+
+    fn close(&self) -> BoxFut<'_, ()> {
+        Box::pin(async {})
+    }
+
+    fn insert_relay(
+        &self,
+        _url: RelayUrl,
+        _config: Arc<RelayConfig>,
+    ) -> BoxFut<'_, ()> {
+        Box::pin(async {})
+    }
+
+    fn remove_relay(
+        &self,
+        _url: &RelayUrl,
+    ) -> BoxFut<'_, Option<Arc<RelayConfig>>> {
+        Box::pin(async { None })
+    }
+
+    fn id_bytes(&self) -> [u8; 32] {
+        [0u8; 32]
+    }
+
+    fn is_home_relay_known_down(&self) -> bool {
+        false
+    }
+}
+
+/// A genuine preflight-write failure (the connection's `open_uni` fails, not
+/// a simultaneous-open supersede) must close the connection with the real
+/// failure reason, not `CloseCode::Superseded`. A remote observing
+/// `Superseded` treats it as a signal to retry against the connection that
+/// "won", which is wrong here: this connection just failed on its own.
+#[tokio::test]
+async fn genuine_preflight_write_failure_closes_with_real_reason_not_superseded()
+ {
+    use super::support::FakeConnection;
+    use crate::close_code::CloseCode;
+
+    let calls = Arc::new(Mutex::new(Vec::new()));
+    let handler = build_handler_with_space(calls.clone());
+
+    let remote_url = fake_remote_url();
+    let target = endpoint_from_url(&remote_url).unwrap();
+
+    let close_calls = Arc::new(Mutex::new(Vec::new()));
+    let connection: DynConnection = Arc::new(FakeConnection {
+        accept_gate: Arc::new(tokio::sync::Notify::new()),
+        remote_close: None,
+        remote_id: target.id,
+        close_calls: close_calls.clone(),
+    });
+
+    let fake_endpoint: DynIrohEndpoint =
+        Arc::new(ConnectingEndpoint { connection });
+
+    let connections = crate::Connections::new();
+    let local_url = Arc::new(RwLock::new(Some(remote_url.clone())));
+
+    let transport = build_transport(
+        fake_endpoint,
+        handler,
+        connections.clone(),
+        local_url,
+        config(),
+    );
+
+    let result = transport
+        .create_connection_and_context(target, remote_url.clone())
+        .await;
+
+    assert!(
+        result.is_err(),
+        "a failed preflight write must surface as an error"
+    );
+
+    let recorded_closes = close_calls.lock().unwrap();
+    assert_eq!(
+        recorded_closes.len(),
+        1,
+        "the connection must be closed exactly once, got {recorded_closes:?}"
+    );
+    assert_eq!(
+        recorded_closes[0].0,
+        CloseCode::Unspecified,
+        "a genuine preflight failure must close with the real reason, not \
+         Superseded, or the remote will treat it as a signal to retry"
+    );
+}
+
+mod preflight_timeout {
+    use super::*;
+    use crate::close_code::CloseCode;
+    use crate::connection::MockConnection;
+    use crate::stream::mock::{MockRecvStream, MockSendStream};
+    use crate::stream::{DynIrohRecvStream, DynIrohSendStream, RecvStream};
+    use crate::tests::support::{
+        CloseCalls, Recorder, build_recording_handler,
+    };
+    use std::sync::atomic::Ordering;
+
+    /// Supplies a prefix and then stalls without closing the QUIC stream.
+    struct StalledStream(tokio::sync::Mutex<Bytes>);
+
+    impl RecvStream for StalledStream {
+        fn read_exact<'a>(
+            &'a self,
+            buf: &'a mut [u8],
+        ) -> BoxFut<'a, K2Result<()>> {
+            Box::pin(async move {
+                let mut bytes = self.0.lock().await;
+                if bytes.len() >= buf.len() {
+                    buf.copy_from_slice(&bytes.split_to(buf.len()));
+                    return Ok(());
+                }
+                drop(bytes);
+                std::future::pending().await
+            })
+        }
+    }
+
+    struct Test {
+        transport: IrohTransport,
+        writes: Arc<MockSendStream>,
+        recorder: Recorder,
+        closes: CloseCalls,
+    }
+
+    impl Test {
+        fn new(streams: Vec<(Duration, DynIrohRecvStream)>) -> Self {
+            let mut streams = streams.into_iter();
+            let url = fake_remote_url();
+            let remote_id = endpoint_from_url(&url).unwrap().id;
+            let recorder = build_recording_handler();
+            let writes = Arc::new(MockSendStream::new());
+            let closes: CloseCalls = Arc::new(Mutex::new(Vec::new()));
+            let mut connection = MockConnection::new();
+            let stream = writes.clone();
+            connection.expect_open_uni().returning(move || {
+                let stream = stream.clone();
+                Box::pin(async move { Ok(stream as DynIrohSendStream) })
+            });
+            connection.expect_accept_uni().returning(move || {
+                let next_stream = streams.next();
+                Box::pin(async move {
+                    if let Some((delay, stream)) = next_stream {
+                        tokio::time::sleep(delay).await;
+                        Ok(stream)
+                    } else {
+                        std::future::pending().await
+                    }
+                })
+            });
+            connection.expect_remote_id().return_const(remote_id);
+            connection.expect_is_direct().return_const(false);
+            connection.expect_remote_close_reason().returning(|| None);
+            let close_calls = closes.clone();
+            connection.expect_close().returning(move |code, reason| {
+                close_calls
+                    .lock()
+                    .expect("poison")
+                    .push((code, reason.to_vec()));
+            });
+
+            let transport = build_transport(
+                Arc::new(ConnectingEndpoint {
+                    connection: Arc::new(connection),
+                }),
+                recorder.handler.clone(),
+                crate::Connections::new(),
+                Arc::new(RwLock::new(Some(url))),
+                config(),
+            );
+            Self {
+                transport,
+                writes,
+                recorder,
+                closes,
+            }
+        }
+
+        async fn assert_expires(&self) {
+            let send = || {
+                self.transport
+                    .send(fake_remote_url(), Bytes::from_static(b"hello"))
+            };
+            tokio::time::timeout(Duration::from_secs(11), async {
+                let (first, second) = tokio::join!(send(), send());
+                // Preflight failures retain the transport's existing result
+                // contract; the handler reports the connection failure.
+                first.unwrap();
+                second.unwrap();
+            })
+            .await
+            .expect(
+                "pending sends must finish when the preflight deadline expires",
+            );
+
+            assert!(
+                self.transport.connections.get(&fake_remote_url()).is_none()
+            );
+            assert_eq!(
+                self.recorder.unresponsive_calls.load(Ordering::SeqCst),
+                1
+            );
+            let closes = self.closes.lock().expect("poison");
+            assert_eq!(closes.len(), 1);
+            assert_eq!(closes[0].0, CloseCode::Unspecified);
+            assert!(
+                String::from_utf8_lossy(&closes[0].1)
+                    .contains("timed out waiting for preflight")
+            );
+            assert_eq!(
+                self.writes.get_written_data().len(),
+                1,
+                "only preflight may be written before validation"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn a_peer_that_never_opens_a_stream_expires() {
+        Test::new(Vec::new()).assert_expires().await;
+    }
+
+    #[tokio::test]
+    async fn a_late_stream_does_not_restart_the_preflight_deadline() {
+        Test::new(vec![(
+            Duration::from_secs(8),
+            Arc::new(StalledStream(tokio::sync::Mutex::new(
+                Bytes::from_static(&[0]),
+            ))),
+        )])
+        .assert_expires()
+        .await;
+    }
+
+    #[tokio::test]
+    async fn an_active_connection_survives_the_preflight_deadline() {
+        use crate::frame::{Frame, encode_frame};
+        use kitsune2_api::{K2Proto, K2WireType};
+
+        let preflight = K2Proto {
+            ty: K2WireType::Preflight as i32,
+            ..Default::default()
+        }
+        .encode()
+        .unwrap();
+        let frame = encode_frame(
+            Frame::Preflight((fake_remote_url(), preflight)),
+            64 * 1024,
+        )
+        .unwrap();
+        let data = encode_frame(
+            Frame::Data(K2Proto::default().encode().unwrap()),
+            64 * 1024,
+        )
+        .unwrap();
+        // End the first stream after preflight, then open a data stream only
+        // after the original deadline. Established stream acceptance must not
+        // reuse the preflight timeout.
+        let test = Test::new(vec![
+            (
+                Duration::ZERO,
+                Arc::new(MockRecvStream::new(frame.to_vec())),
+            ),
+            (
+                Duration::from_secs(11),
+                Arc::new(MockRecvStream::new(data.to_vec())),
+            ),
+        ]);
+        test.transport
+            .send(fake_remote_url(), Bytes::from_static(b"first"))
+            .await
+            .unwrap();
+        let ctx = test.transport.connections.get(&fake_remote_url()).unwrap();
+        kitsune2_test_utils::retry_fn_until_timeout(
+            || async { ctx.get_recv_message_count() == 1 },
+            Some(12_000),
+            Some(10),
+        )
+        .await
+        .expect("an established connection must accept data after the preflight deadline");
+        test.transport
+            .send(fake_remote_url(), Bytes::from_static(b"second"))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            test.transport.get_connected_peers().await.unwrap(),
+            vec![fake_remote_url()]
+        );
+        assert!(test.closes.lock().expect("poison").is_empty());
+        assert_eq!(test.recorder.unresponsive_calls.load(Ordering::SeqCst), 0);
+        assert_eq!(test.writes.get_written_data().len(), 3);
+    }
 }

--- a/crates/transport_iroh/src/tests/connection_registry.rs
+++ b/crates/transport_iroh/src/tests/connection_registry.rs
@@ -1,0 +1,312 @@
+//! Unit tests for the peer-URL → connection map and the simultaneous-open
+//! tie-break, driven against fake entries so no iroh endpoint is involved.
+
+use crate::connection_registry::{
+    ConnectionLifecycle, ConnectionRegistry, ConnectionResolution,
+    RegistryEntry,
+};
+use kitsune2_api::Url;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+struct FakeEntry {
+    lifecycle: ConnectionLifecycle,
+    preferred: bool,
+    close_calls: AtomicUsize,
+    /// Whether the lifecycle already read as superseded when
+    /// `close_superseded` ran.
+    superseded_at_close: AtomicBool,
+}
+
+impl FakeEntry {
+    fn new(preferred: bool) -> Arc<Self> {
+        Arc::new(Self {
+            lifecycle: ConnectionLifecycle::new(),
+            preferred,
+            close_calls: AtomicUsize::new(0),
+            superseded_at_close: AtomicBool::new(false),
+        })
+    }
+
+    fn close_calls(&self) -> usize {
+        self.close_calls.load(Ordering::SeqCst)
+    }
+
+    fn superseded_at_close(&self) -> bool {
+        self.superseded_at_close.load(Ordering::SeqCst)
+    }
+}
+
+impl RegistryEntry for FakeEntry {
+    fn lifecycle(&self) -> &ConnectionLifecycle {
+        &self.lifecycle
+    }
+
+    fn is_preferred(&self) -> bool {
+        self.preferred
+    }
+
+    fn close_superseded(&self) {
+        self.superseded_at_close
+            .store(self.lifecycle.is_superseded(), Ordering::SeqCst);
+        self.close_calls.fetch_add(1, Ordering::SeqCst);
+    }
+}
+
+fn peer() -> Url {
+    Url::from_str(
+        "https://relay.example.com:443/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    )
+    .unwrap()
+}
+
+#[test]
+fn a_free_slot_is_taken() {
+    let registry = ConnectionRegistry::<FakeEntry>::new();
+    let entry = FakeEntry::new(false);
+    assert!(registry.register_candidate(&peer(), &entry));
+    assert!(Arc::ptr_eq(&registry.get(&peer()).unwrap(), &entry));
+}
+
+#[test]
+fn re_registering_the_same_entry_is_a_no_op() {
+    let registry = ConnectionRegistry::<FakeEntry>::new();
+    let entry = FakeEntry::new(true);
+    assert!(registry.register_candidate(&peer(), &entry));
+    assert!(registry.register_candidate(&peer(), &entry));
+    assert_eq!(entry.close_calls(), 0, "the entry must not close itself");
+}
+
+#[test]
+fn a_preferred_incumbent_defeats_a_non_preferred_candidate() {
+    let registry = ConnectionRegistry::<FakeEntry>::new();
+    let incumbent = FakeEntry::new(true);
+    let candidate = FakeEntry::new(false);
+    assert!(registry.register_candidate(&peer(), &incumbent));
+
+    assert!(!registry.register_candidate(&peer(), &candidate));
+    assert!(!candidate.lifecycle().is_live(), "the loser is superseded");
+    assert!(Arc::ptr_eq(&registry.get(&peer()).unwrap(), &incumbent));
+}
+
+#[test]
+fn a_preferred_candidate_displaces_a_non_preferred_incumbent() {
+    let registry = ConnectionRegistry::<FakeEntry>::new();
+    let incumbent = FakeEntry::new(false);
+    let candidate = FakeEntry::new(true);
+    assert!(registry.register_candidate(&peer(), &incumbent));
+
+    assert!(registry.register_candidate(&peer(), &candidate));
+    assert!(Arc::ptr_eq(&registry.get(&peer()).unwrap(), &candidate));
+    assert!(!incumbent.lifecycle().is_live());
+    assert_eq!(
+        incumbent.close_calls(),
+        1,
+        "the displaced connection must be closed exactly once"
+    );
+}
+
+/// A send that is already writing to the displaced connection only learns the
+/// write failed because of simultaneous-open resolution, rather than because
+/// the peer is gone, by asking the lifecycle. So the displaced entry must
+/// already read as superseded by the time its connection is closed, otherwise
+/// that send reports a spurious error for a message it could have retried.
+#[test]
+fn a_displaced_entry_is_superseded_before_it_is_closed() {
+    let registry = ConnectionRegistry::<FakeEntry>::new();
+    let incumbent = FakeEntry::new(false);
+    let candidate = FakeEntry::new(true);
+    assert!(registry.register_candidate(&peer(), &incumbent));
+
+    assert!(registry.register_candidate(&peer(), &candidate));
+    assert_eq!(incumbent.close_calls(), 1);
+    assert!(
+        incumbent.superseded_at_close(),
+        "the displaced connection must be marked superseded before it is closed"
+    );
+}
+
+#[test]
+fn a_same_direction_newcomer_replaces_the_incumbent() {
+    let registry = ConnectionRegistry::<FakeEntry>::new();
+    let incumbent = FakeEntry::new(false);
+    let newcomer = FakeEntry::new(false);
+    assert!(registry.register_candidate(&peer(), &incumbent));
+
+    assert!(
+        registry.register_candidate(&peer(), &newcomer),
+        "neither is preferred, so the newer connection wins"
+    );
+    assert!(Arc::ptr_eq(&registry.get(&peer()).unwrap(), &newcomer));
+}
+
+#[test]
+fn a_terminal_incumbent_is_evicted_even_when_preferred() {
+    let registry = ConnectionRegistry::<FakeEntry>::new();
+    let incumbent = FakeEntry::new(true);
+    assert!(registry.register_candidate(&peer(), &incumbent));
+    incumbent.lifecycle().mark_closed();
+
+    let newcomer = FakeEntry::new(false);
+    assert!(registry.register_candidate(&peer(), &newcomer));
+    assert!(Arc::ptr_eq(&registry.get(&peer()).unwrap(), &newcomer));
+}
+
+#[test]
+fn a_terminal_candidate_cannot_take_the_slot() {
+    let registry = ConnectionRegistry::<FakeEntry>::new();
+    let candidate = FakeEntry::new(true);
+    candidate.lifecycle().mark_superseded();
+    assert!(!registry.register_candidate(&peer(), &candidate));
+    assert!(registry.get(&peer()).is_none());
+}
+
+#[test]
+fn activate_only_succeeds_for_the_current_entry() {
+    let registry = ConnectionRegistry::<FakeEntry>::new();
+    let incumbent = FakeEntry::new(true);
+    let stranger = FakeEntry::new(true);
+    assert!(registry.register_candidate(&peer(), &incumbent));
+
+    assert!(registry.activate(&peer(), &incumbent));
+    assert!(incumbent.lifecycle().is_active());
+    assert!(!registry.activate(&peer(), &stranger));
+    assert!(!stranger.lifecycle().is_active());
+}
+
+#[test]
+fn activate_is_idempotent() {
+    let registry = ConnectionRegistry::<FakeEntry>::new();
+    let entry = FakeEntry::new(true);
+    assert!(registry.register_candidate(&peer(), &entry));
+    assert!(registry.activate(&peer(), &entry));
+    assert!(
+        registry.activate(&peer(), &entry),
+        "activating an already-active entry must still report success"
+    );
+}
+
+#[test]
+fn activate_does_not_revive_a_superseded_entry() {
+    let registry = ConnectionRegistry::<FakeEntry>::new();
+    let entry = FakeEntry::new(true);
+    assert!(registry.register_candidate(&peer(), &entry));
+    entry.lifecycle().mark_superseded();
+    assert!(!registry.activate(&peer(), &entry));
+    assert!(!entry.lifecycle().is_active());
+}
+
+#[test]
+fn remove_if_current_only_removes_the_current_entry() {
+    let registry = ConnectionRegistry::<FakeEntry>::new();
+    let incumbent = FakeEntry::new(true);
+    let stranger = FakeEntry::new(true);
+    assert!(registry.register_candidate(&peer(), &incumbent));
+
+    assert!(!registry.remove_if_current(&peer(), &stranger));
+    assert!(registry.get(&peer()).is_some());
+    assert!(registry.remove_if_current(&peer(), &incumbent));
+    assert!(registry.get(&peer()).is_none());
+}
+
+#[test]
+fn only_active_entries_are_reported_as_peers() {
+    let registry = ConnectionRegistry::<FakeEntry>::new();
+    let entry = FakeEntry::new(true);
+    assert!(registry.register_candidate(&peer(), &entry));
+    assert!(
+        registry.active_peers().is_empty(),
+        "a pending entry is not a connected peer"
+    );
+
+    assert!(registry.activate(&peer(), &entry));
+    assert_eq!(registry.active_peers(), vec![peer()]);
+}
+
+/// Let a reader finish preflight while its replacement is about to mark it
+/// superseded. Reader cleanup must never win by marking the loser closed.
+#[test]
+fn displacement_preserves_superseded_resolution_during_reader_cleanup() {
+    use std::sync::{Barrier, mpsc};
+    use std::time::Duration;
+
+    struct PausedEntry {
+        lifecycle: ConnectionLifecycle,
+        accesses: AtomicUsize,
+        preferred: bool,
+        reached: mpsc::Sender<()>,
+        resume: Arc<Barrier>,
+    }
+
+    impl RegistryEntry for PausedEntry {
+        fn lifecycle(&self) -> &ConnectionLifecycle {
+            // The incumbent is inspected when inserted, when challenged, and
+            // then when marked superseded. Pause at that last boundary.
+            if !self.preferred
+                && self.accesses.fetch_add(1, Ordering::SeqCst) == 2
+            {
+                self.reached.send(()).expect("reader must be waiting");
+                self.resume.wait();
+            }
+            &self.lifecycle
+        }
+
+        fn is_preferred(&self) -> bool {
+            self.preferred
+        }
+
+        fn close_superseded(&self) {}
+    }
+
+    let (reached, receive) = mpsc::channel();
+    let resume = Arc::new(Barrier::new(2));
+    let incumbent = Arc::new(PausedEntry {
+        lifecycle: ConnectionLifecycle::new(),
+        accesses: AtomicUsize::new(0),
+        preferred: false,
+        reached: reached.clone(),
+        resume: resume.clone(),
+    });
+    let candidate = Arc::new(PausedEntry {
+        lifecycle: ConnectionLifecycle::new(),
+        accesses: AtomicUsize::new(0),
+        preferred: true,
+        reached,
+        resume: resume.clone(),
+    });
+    let registry = ConnectionRegistry::new();
+    assert!(registry.register_candidate(&peer(), &incumbent));
+    let writer = {
+        let registry = registry.clone();
+        std::thread::spawn(move || {
+            assert!(registry.register_candidate(&peer(), &candidate));
+        })
+    };
+    receive.recv_timeout(Duration::from_secs(5)).unwrap();
+
+    let (finished, cleanup_finished) = mpsc::channel();
+    let reader = {
+        let incumbent = incumbent.clone();
+        std::thread::spawn(move || {
+            assert!(!registry.activate(&peer(), &incumbent));
+            assert!(!registry.remove_if_current(&peer(), &incumbent));
+            incumbent.lifecycle.mark_closed();
+            finished.send(()).unwrap();
+        })
+    };
+    // Give cleanup the opportunity to run. Correct arbitration holds the map
+    // lock until the verdict is set, so cleanup must wait for the writer.
+    let _ = cleanup_finished.recv_timeout(Duration::from_secs(1));
+    resume.wait();
+    writer.join().unwrap();
+    reader.join().unwrap();
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .build()
+        .unwrap();
+    assert_eq!(
+        runtime.block_on(incumbent.lifecycle.wait_for_resolution()),
+        ConnectionResolution::Superseded,
+        "a waiting send must retry the replacement instead of dropping its payload"
+    );
+}

--- a/crates/transport_iroh/src/tests/mod.rs
+++ b/crates/transport_iroh/src/tests/mod.rs
@@ -4,6 +4,7 @@ use super::*;
 
 mod close;
 mod connect_failure;
+mod connection_registry;
 mod frame;
 mod relay_lifecycle;
 mod relay_qad;

--- a/crates/transport_iroh/src/tests/simultaneous_open.rs
+++ b/crates/transport_iroh/src/tests/simultaneous_open.rs
@@ -11,11 +11,17 @@
 //! mistaken for a genuine peer disconnect. Doing so spuriously marks the peer
 //! unresponsive (which lasts until the agent info expires) and stalls gossip.
 
-use super::support::{build_recording_handler, spawn_active_reader};
+use super::support::{
+    build_parked_context, build_parked_context_with_remote_close,
+    build_recording_handler, remote_url, spawn_active_reader,
+};
+use crate::Connections;
 use crate::close_code::CloseCode;
 use crate::connection_context::SUPERSEDED_CLOSE_REASON;
+use crate::connection_registry::RegistryEntry;
 use bytes::Bytes;
 use kitsune2_test_utils::retry_fn_until_timeout;
+use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
 /// When the active connection is closed by the remote with the superseded
@@ -79,4 +85,163 @@ async fn genuine_remote_close_marks_unresponsive() {
         1,
         "a genuine peer disconnect must mark the peer unresponsive"
     );
+}
+
+/// A remote that supersedes a connection says so only in its close code. The
+/// local lifecycle catches up when this connection's reader runs its exit
+/// cleanup, which races a send already writing to the connection: when the
+/// reader loses that race, a send asking the lifecycle alone would report a
+/// spurious error for a message the winning connection can still carry. So the
+/// close code must be enough on its own.
+#[tokio::test(flavor = "multi_thread")]
+async fn a_remote_supersede_is_visible_before_the_reader_reacts() {
+    let recorder = build_recording_handler();
+
+    let ctx = build_parked_context_with_remote_close(
+        recorder.handler.clone(),
+        Connections::new(),
+        true,
+        [0xff; 32],
+        Some((
+            CloseCode::Superseded,
+            Bytes::from_static(SUPERSEDED_CLOSE_REASON),
+        )),
+    );
+
+    assert!(
+        ctx.lifecycle().is_live(),
+        "the reader is parked, so the lifecycle has not reacted to the close"
+    );
+    assert!(
+        ctx.is_superseded(),
+        "a remote supersede must be visible to a send that is already writing"
+    );
+}
+
+/// The close code must not be read so broadly that an ordinary remote close
+/// looks like a supersede, which would retry a send that should have failed.
+#[tokio::test(flavor = "multi_thread")]
+async fn an_ordinary_remote_close_is_not_a_supersede() {
+    let recorder = build_recording_handler();
+
+    let ctx = build_parked_context_with_remote_close(
+        recorder.handler.clone(),
+        Connections::new(),
+        true,
+        [0xff; 32],
+        Some((CloseCode::Graceful, Bytes::from_static(b"goodbye"))),
+    );
+
+    assert!(!ctx.is_superseded());
+}
+
+/// A reconnect arrives while the previous connection to the same peer is still
+/// the map entry, because its reader has not run its exit cleanup yet. Both
+/// connections were *accepted*, so neither is the preferred one. The tie-break
+/// must not defend the older connection: the newcomer takes the slot.
+///
+/// Regression: rejecting the newcomer here made a send immediately after a
+/// disconnect close the fresh connection with `CloseCode::Superseded`, and the
+/// message was lost.
+#[tokio::test(flavor = "multi_thread")]
+async fn newcomer_replaces_a_same_direction_incumbent() {
+    let recorder = build_recording_handler();
+    let connections: Connections = Connections::new();
+    let url = remote_url();
+
+    // `[0xff; 32]` > the `0xaa` remote id, so the preferred connection is the
+    // one *we* dialed. Both of these were accepted, so neither is preferred.
+    let incumbent = build_parked_context(
+        recorder.handler.clone(),
+        connections.clone(),
+        false,
+        [0xff; 32],
+    );
+    assert!(connections.register_candidate(&url, &incumbent));
+
+    let newcomer = build_parked_context(
+        recorder.handler.clone(),
+        connections.clone(),
+        false,
+        [0xff; 32],
+    );
+    assert!(
+        connections.register_candidate(&url, &newcomer),
+        "a same-direction newcomer must replace the stale incumbent"
+    );
+
+    assert!(
+        Arc::ptr_eq(&connections.get(&url).unwrap(), &newcomer),
+        "the newcomer must hold the slot"
+    );
+}
+
+/// A genuine simultaneous open: the incumbent is the connection we dialed and
+/// is the preferred one, the newcomer is the inbound duplicate. The newcomer
+/// must lose and be marked superseded, leaving the incumbent in the slot.
+#[tokio::test(flavor = "multi_thread")]
+async fn preferred_incumbent_defeats_an_inbound_duplicate() {
+    let recorder = build_recording_handler();
+    let connections: Connections = Connections::new();
+    let url = remote_url();
+
+    let incumbent = build_parked_context(
+        recorder.handler.clone(),
+        connections.clone(),
+        true,
+        [0xff; 32],
+    );
+    assert!(connections.register_candidate(&url, &incumbent));
+
+    let newcomer = build_parked_context(
+        recorder.handler.clone(),
+        connections.clone(),
+        false,
+        [0xff; 32],
+    );
+    assert!(
+        !connections.register_candidate(&url, &newcomer),
+        "the inbound duplicate must lose to the preferred incumbent"
+    );
+    assert!(
+        !newcomer.lifecycle().is_live(),
+        "the losing newcomer must be marked superseded"
+    );
+
+    assert!(
+        Arc::ptr_eq(&connections.get(&url).unwrap(), &incumbent),
+        "the preferred incumbent must keep the slot"
+    );
+}
+
+/// An incumbent that has already reached a terminal state is a corpse waiting
+/// for its reader to be reaped. Even when it is the preferred direction, it
+/// must not block a live newcomer.
+#[tokio::test(flavor = "multi_thread")]
+async fn terminal_incumbent_does_not_block_a_newcomer() {
+    let recorder = build_recording_handler();
+    let connections: Connections = Connections::new();
+    let url = remote_url();
+
+    let incumbent = build_parked_context(
+        recorder.handler.clone(),
+        connections.clone(),
+        true,
+        [0xff; 32],
+    );
+    assert!(connections.register_candidate(&url, &incumbent));
+    incumbent.mark_closed();
+
+    let newcomer = build_parked_context(
+        recorder.handler.clone(),
+        connections.clone(),
+        false,
+        [0xff; 32],
+    );
+    assert!(
+        connections.register_candidate(&url, &newcomer),
+        "a terminal incumbent must be evicted, not defended"
+    );
+
+    assert!(Arc::ptr_eq(&connections.get(&url).unwrap(), &newcomer));
 }

--- a/crates/transport_iroh/src/tests/support.rs
+++ b/crates/transport_iroh/src/tests/support.rs
@@ -4,6 +4,7 @@
 //! [`ConnectionContext`] reader into its exit cleanup with a configurable
 //! remote close, and to record the resulting handler calls.
 
+use crate::Connections;
 use crate::close_code::CloseCode;
 use crate::connection::{Connection, DynConnection};
 use crate::connection_context::{ConnectionContext, ConnectionContextParams};
@@ -185,7 +186,7 @@ pub(super) fn spawn_active_reader(
         close_calls: close_calls.clone(),
     });
 
-    let connections = Arc::new(RwLock::new(HashMap::new()));
+    let connections = Connections::new();
 
     let ctx = ConnectionContext::new(ConnectionContextParams {
         handler,
@@ -203,11 +204,67 @@ pub(super) fn spawn_active_reader(
 
     // Register as the active connection *before* the reader is released, so
     // the exit cleanup sees this context as the live map entry (`was_active`).
-    connections.write().unwrap().insert(url, ctx.clone());
+    connections.register_candidate(&url, &ctx);
 
     ActiveReader {
         ctx,
         accept_gate,
         close_calls,
     }
+}
+
+/// Build a connection context whose reader is parked in `accept_uni`, sharing
+/// `connections` with other contexts built by this helper. Unlike
+/// [`spawn_active_reader`] the context is *not* inserted into the map: tests
+/// drive `connections.register_candidate` to decide who takes the slot.
+///
+/// `local_id` controls the simultaneous-open tie-break: [`remote_url`] encodes
+/// a remote id of `0xaa` bytes, so `[0xff; 32]` makes this endpoint the larger
+/// one and `[0x00; 32]` makes it the smaller one.
+pub(super) fn build_parked_context(
+    handler: Arc<TxImpHnd>,
+    connections: Connections,
+    dialed_by_us: bool,
+    local_id: [u8; 32],
+) -> Arc<ConnectionContext> {
+    build_parked_context_with_remote_close(
+        handler,
+        connections,
+        dialed_by_us,
+        local_id,
+        None,
+    )
+}
+
+/// As [`build_parked_context`], but the connection reports `remote_close` as
+/// the reason the remote ended it. The reader stays parked, so the context's
+/// lifecycle has not yet reacted to that close.
+pub(super) fn build_parked_context_with_remote_close(
+    handler: Arc<TxImpHnd>,
+    connections: Connections,
+    dialed_by_us: bool,
+    local_id: [u8; 32],
+    remote_close: Option<(CloseCode, Bytes)>,
+) -> Arc<ConnectionContext> {
+    let url = remote_url();
+    let connection: DynConnection = Arc::new(FakeConnection {
+        accept_gate: Arc::new(tokio::sync::Notify::new()),
+        remote_close,
+        remote_id: endpoint_from_url(&url).unwrap().id,
+        close_calls: Arc::new(Mutex::new(Vec::new())),
+    });
+
+    ConnectionContext::new(ConnectionContextParams {
+        handler,
+        connection,
+        local_id,
+        dialed_by_us,
+        remote_url: Some(url.clone()),
+        preflight_sent: true,
+        opened_at_s: 0,
+        connections,
+        local_url: Arc::new(RwLock::new(Some(url))),
+        space_relays: Arc::new(RwLock::new(HashMap::new())),
+        max_frame_bytes: 64 * 1024,
+    })
 }

--- a/crates/transport_iroh/tests/integration.rs
+++ b/crates/transport_iroh/tests/integration.rs
@@ -961,6 +961,157 @@ async fn preflight_sent_and_received_by_both_endpoints() {
     .expect("preflight should have been sent by peer 2 and received by peer 1");
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn simultaneous_first_sends_are_delivered() {
+    enable_tracing();
+    let harness = IrohTransportTestHarness::new().await;
+    let dummy_url = dummy_url();
+    let preflight_gate =
+        Arc::new((std::sync::Mutex::new(0_u8), std::sync::Condvar::new()));
+
+    let (ep_1_sender, mut ep_1_receiver) =
+        tokio::sync::mpsc::unbounded_channel();
+    let handler_1 = Arc::new(MockTxHandler {
+        preflight_validate_incoming: Arc::new({
+            let first_preflight = Arc::new(AtomicBool::new(true));
+            let preflight_gate = preflight_gate.clone();
+            move |_, _| {
+                if first_preflight.swap(false, Ordering::SeqCst) {
+                    let (arrivals, ready) = &*preflight_gate;
+                    let mut arrivals = arrivals.lock().unwrap();
+                    *arrivals += 1;
+                    ready.notify_all();
+                    let (_arrivals, timeout) = ready
+                        .wait_timeout_while(
+                            arrivals,
+                            Duration::from_secs(5),
+                            |arrivals| *arrivals < 2,
+                        )
+                        .unwrap();
+                    assert!(
+                        !timeout.timed_out(),
+                        "both preflights must arrive"
+                    );
+                }
+                Ok(())
+            }
+        }),
+        recv_space_notify: Arc::new(move |_peer, _space_id, data| {
+            ep_1_sender.send(data).expect("receiver must remain open");
+            Ok(())
+        }),
+        ..Default::default()
+    });
+    let ep_1 = harness.build_transport(handler_1.clone()).await;
+    ep_1.register_space_handler(TEST_SPACE_ID, handler_1.clone());
+
+    let (ep_2_sender, mut ep_2_receiver) =
+        tokio::sync::mpsc::unbounded_channel();
+    let handler_2 = Arc::new(MockTxHandler {
+        preflight_validate_incoming: Arc::new({
+            let first_preflight = Arc::new(AtomicBool::new(true));
+            let preflight_gate = preflight_gate.clone();
+            move |_, _| {
+                if first_preflight.swap(false, Ordering::SeqCst) {
+                    let (arrivals, ready) = &*preflight_gate;
+                    let mut arrivals = arrivals.lock().unwrap();
+                    *arrivals += 1;
+                    ready.notify_all();
+                    let (_arrivals, timeout) = ready
+                        .wait_timeout_while(
+                            arrivals,
+                            Duration::from_secs(5),
+                            |arrivals| *arrivals < 2,
+                        )
+                        .unwrap();
+                    assert!(
+                        !timeout.timed_out(),
+                        "both preflights must arrive"
+                    );
+                }
+                Ok(())
+            }
+        }),
+        recv_space_notify: Arc::new(move |_peer, _space_id, data| {
+            ep_2_sender.send(data).expect("receiver must remain open");
+            Ok(())
+        }),
+        ..Default::default()
+    });
+    let ep_2 = harness.build_transport(handler_2.clone()).await;
+    ep_2.register_space_handler(TEST_SPACE_ID, handler_2.clone());
+
+    retry_fn_until_timeout(
+        || async {
+            handler_1.current_url.lock().unwrap().clone() != dummy_url
+                && handler_2.current_url.lock().unwrap().clone() != dummy_url
+        },
+        Some(6_000),
+        Some(100),
+    )
+    .await
+    .expect("both transports must receive listening addresses");
+
+    let ep_1_url = handler_1.current_url.lock().unwrap().clone();
+    let ep_2_url = handler_2.current_url.lock().unwrap().clone();
+    let send_barrier = Arc::new(tokio::sync::Barrier::new(3));
+
+    let send_from_ep_1 = {
+        let ep_1 = ep_1.clone();
+        let send_barrier = send_barrier.clone();
+        tokio::spawn(async move {
+            send_barrier.wait().await;
+            ep_1.send_space_notify(
+                ep_2_url,
+                TEST_SPACE_ID,
+                Bytes::from_static(b"from endpoint 1"),
+            )
+            .await
+        })
+    };
+    let send_from_ep_2 = {
+        let ep_2 = ep_2.clone();
+        let send_barrier = send_barrier.clone();
+        tokio::spawn(async move {
+            send_barrier.wait().await;
+            ep_2.send_space_notify(
+                ep_1_url,
+                TEST_SPACE_ID,
+                Bytes::from_static(b"from endpoint 2"),
+            )
+            .await
+        })
+    };
+
+    send_barrier.wait().await;
+    let (send_from_ep_1, send_from_ep_2) =
+        tokio::time::timeout(Duration::from_secs(10), async {
+            tokio::join!(send_from_ep_1, send_from_ep_2)
+        })
+        .await
+        .expect("both simultaneous sends must complete");
+    send_from_ep_1
+        .expect("endpoint 1 send task must complete")
+        .expect("endpoint 1 send must succeed");
+    send_from_ep_2
+        .expect("endpoint 2 send task must complete")
+        .expect("endpoint 2 send must succeed");
+
+    let received_by_ep_1 =
+        tokio::time::timeout(Duration::from_secs(2), ep_1_receiver.recv())
+            .await
+            .expect("endpoint 1 must receive the simultaneous first message")
+            .expect("endpoint 1 receive channel must remain open");
+    let received_by_ep_2 =
+        tokio::time::timeout(Duration::from_secs(2), ep_2_receiver.recv())
+            .await
+            .expect("endpoint 2 must receive the simultaneous first message")
+            .expect("endpoint 2 receive channel must remain open");
+
+    assert_eq!(received_by_ep_1, Bytes::from_static(b"from endpoint 2"));
+    assert_eq!(received_by_ep_2, Bytes::from_static(b"from endpoint 1"));
+}
+
 #[tokio::test]
 async fn network_stats() {
     let harness = IrohTransportTestHarness::new().await;
@@ -1313,4 +1464,211 @@ async fn no_unresponsive_when_relay_drops() {
         set_unresponsive_receiver.try_recv().is_err(),
         "set_unresponsive must not be called when the relay is disconnected"
     );
+}
+
+/// A `send` immediately after `disconnect` must re-dial and deliver. The
+/// remote may still hold the previous connection as its map entry, so the
+/// fresh connection can be closed as superseded; `send` must retry rather than
+/// return `Ok(())` for a message it never wrote.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn send_after_disconnect_reconnects_and_delivers() {
+    enable_tracing();
+    let harness = IrohTransportTestHarness::new().await;
+    let dummy_url = dummy_url();
+
+    let (space_notify_sender, mut space_notify_receiver) =
+        tokio::sync::mpsc::unbounded_channel();
+    let handler_1 = Arc::new(MockTxHandler {
+        recv_space_notify: Arc::new(move |_peer, _space_id, data| {
+            space_notify_sender
+                .send(data)
+                .expect("receiver must be open");
+            Ok(())
+        }),
+        ..Default::default()
+    });
+    let ep_1 = harness.build_transport(handler_1.clone()).await;
+    ep_1.register_space_handler(TEST_SPACE_ID, handler_1.clone());
+
+    let handler_2 = Arc::new(MockTxHandler::default());
+    let ep_2 = harness.build_transport(handler_2.clone()).await;
+    ep_2.register_space_handler(TEST_SPACE_ID, handler_2.clone());
+
+    retry_fn_until_timeout(
+        || async {
+            handler_1.current_url.lock().unwrap().clone() != dummy_url
+                && handler_2.current_url.lock().unwrap().clone() != dummy_url
+        },
+        Some(6_000),
+        Some(100),
+    )
+    .await
+    .expect("both transports must receive listening addresses");
+
+    let ep_1_url = handler_1.current_url.lock().unwrap().clone();
+
+    // Reconnect several times in a row. A single round trips the race only
+    // intermittently; five rounds make a regression reliably visible.
+    for round in 0..5u8 {
+        let payload = Bytes::from(format!("round {round}"));
+        ep_2.send_space_notify(
+            ep_1_url.clone(),
+            TEST_SPACE_ID,
+            payload.clone(),
+        )
+        .await
+        .unwrap_or_else(|err| {
+            panic!("round {round} send must succeed: {err:?}")
+        });
+
+        let received = tokio::time::timeout(
+            Duration::from_secs(5),
+            space_notify_receiver.recv(),
+        )
+        .await
+        .unwrap_or_else(|_| panic!("round {round} payload must arrive"))
+        .expect("receive channel must remain open");
+        assert_eq!(received, payload, "round {round} payload mismatch");
+
+        ep_2.disconnect(ep_1_url.clone(), None).await;
+        retry_fn_until_timeout(
+            || async { ep_2.get_connected_peers().await.unwrap().is_empty() },
+            Some(5_000),
+            Some(10),
+        )
+        .await
+        .unwrap_or_else(|_| panic!("round {round} connection must be dropped"));
+    }
+}
+
+/// Both peers disconnect and immediately redial at the same instant, over and
+/// over. No send may fail because of the resulting simultaneous open.
+///
+/// Unlike [`send_after_disconnect_reconnects_and_delivers`], both sides tear
+/// the connection down, so every redial races a redial from the other end. A
+/// dial is published as the peer's connection before its preflight is written,
+/// and a send picks a connection before it writes the data frame, so in both
+/// windows the competing inbound dial can take the slot and close the
+/// connection mid-write. That is resolution working, and the send must retry
+/// on the connection that won rather than report the peer as unresponsive and
+/// fail with a locally closed connection.
+///
+/// Only the send results are asserted. A frame written to a connection that is
+/// still the live one locally can still be dropped by a peer that superseded
+/// it before draining the stream, which the writer cannot observe: the write
+/// succeeded. That is a separate, pre-existing gap that needs an
+/// acknowledgement the wire protocol does not have, so per-round delivery is
+/// awaited to pace the rounds but not asserted. Delivery after a reconnect is
+/// asserted by [`send_after_disconnect_reconnects_and_delivers`], which
+/// disconnects from one side only and so does not race.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn simultaneous_disconnect_and_resend_never_fails_a_send() {
+    enable_tracing();
+    let harness = IrohTransportTestHarness::new().await;
+    let dummy_url = dummy_url();
+
+    let (ep_1_sender, mut ep_1_receiver) =
+        tokio::sync::mpsc::unbounded_channel();
+    let handler_1 = Arc::new(MockTxHandler {
+        recv_space_notify: Arc::new(move |_peer, _space_id, data| {
+            ep_1_sender.send(data).expect("receiver must be open");
+            Ok(())
+        }),
+        ..Default::default()
+    });
+    let ep_1 = harness.build_transport(handler_1.clone()).await;
+    ep_1.register_space_handler(TEST_SPACE_ID, handler_1.clone());
+
+    let (ep_2_sender, mut ep_2_receiver) =
+        tokio::sync::mpsc::unbounded_channel();
+    let handler_2 = Arc::new(MockTxHandler {
+        recv_space_notify: Arc::new(move |_peer, _space_id, data| {
+            ep_2_sender.send(data).expect("receiver must be open");
+            Ok(())
+        }),
+        ..Default::default()
+    });
+    let ep_2 = harness.build_transport(handler_2.clone()).await;
+    ep_2.register_space_handler(TEST_SPACE_ID, handler_2.clone());
+
+    retry_fn_until_timeout(
+        || async {
+            handler_1.current_url.lock().unwrap().clone() != dummy_url
+                && handler_2.current_url.lock().unwrap().clone() != dummy_url
+        },
+        Some(6_000),
+        Some(100),
+    )
+    .await
+    .expect("both transports must receive listening addresses");
+
+    let ep_1_url = handler_1.current_url.lock().unwrap().clone();
+    let ep_2_url = handler_2.current_url.lock().unwrap().clone();
+
+    // A single round hits the mid-write supersession only occasionally, so
+    // many rounds are needed to make a regression reliably visible.
+    for round in 0..40u8 {
+        let payload_1 = Bytes::from(format!("from endpoint 1, round {round}"));
+        let payload_2 = Bytes::from(format!("from endpoint 2, round {round}"));
+
+        let barrier = Arc::new(tokio::sync::Barrier::new(3));
+        let send_from_ep_1 = {
+            let ep_1 = ep_1.clone();
+            let barrier = barrier.clone();
+            let ep_2_url = ep_2_url.clone();
+            let payload_1 = payload_1.clone();
+            tokio::spawn(async move {
+                barrier.wait().await;
+                ep_1.send_space_notify(ep_2_url, TEST_SPACE_ID, payload_1)
+                    .await
+            })
+        };
+        let send_from_ep_2 = {
+            let ep_2 = ep_2.clone();
+            let barrier = barrier.clone();
+            let ep_1_url = ep_1_url.clone();
+            let payload_2 = payload_2.clone();
+            tokio::spawn(async move {
+                barrier.wait().await;
+                ep_2.send_space_notify(ep_1_url, TEST_SPACE_ID, payload_2)
+                    .await
+            })
+        };
+
+        barrier.wait().await;
+        let (result_1, result_2) =
+            tokio::time::timeout(Duration::from_secs(20), async {
+                tokio::join!(send_from_ep_1, send_from_ep_2)
+            })
+            .await
+            .unwrap_or_else(|_| panic!("round {round} sends must complete"));
+        result_1
+            .unwrap_or_else(|err| panic!("round {round} task 1: {err:?}"))
+            .unwrap_or_else(|err| {
+                panic!("round {round} endpoint 1 send must succeed: {err:?}")
+            });
+        result_2
+            .unwrap_or_else(|err| panic!("round {round} task 2: {err:?}"))
+            .unwrap_or_else(|err| {
+                panic!("round {round} endpoint 2 send must succeed: {err:?}")
+            });
+
+        // Give each payload a chance to land before tearing the connection
+        // down again, so a round starts from a settled connection. A payload
+        // the peer dropped when it superseded the connection is not a failure
+        // of the send, so the outcome is not asserted.
+        let _ =
+            tokio::time::timeout(Duration::from_secs(5), ep_1_receiver.recv())
+                .await;
+        let _ =
+            tokio::time::timeout(Duration::from_secs(5), ep_2_receiver.recv())
+                .await;
+
+        // Both ends tear the connection down at once, so the next round's
+        // sends both have to redial into each other.
+        tokio::join!(
+            ep_1.disconnect(ep_2_url.clone(), None),
+            ep_2.disconnect(ep_1_url.clone(), None),
+        );
+    }
 }


### PR DESCRIPTION
## What changed

Two Kitsune2 nodes can end up dialing each other at almost the same moment. When that happens, one of the two connections has to be closed and the other kept, and the node has to be sure which one won before it starts sending real data on it. This branch fixes several ways that decision could still go wrong and cause a message to be silently dropped instead of being sent (or retried) on the connection that actually survived.

## Why

The main fix already on this branch made sending wait for that decision to be resolved before writing data, instead of writing onto a connection that might be about to be torn down. This branch closes gaps that fix itself introduced, and fixes a few more found by going through the whole change looking for anything similar it might have missed:

- The rule for which connection wins sometimes kept the wrong one alive, specifically after a node disconnects and immediately reconnects to the same peer.
- When a connection lost the race, the sender was sometimes told the send had succeeded when it had not, instead of being told to retry on the winning connection.
- A send could still fail with an error instead of retrying, in a couple of narrower timing windows found only by close inspection: while a preflight message was still being written, and while the outgoing data itself was still being written.
- The reverse mistake was also happening in one place: a connection that failed for a real reason (not because it lost the race) was being reported to the other side as if it had merely lost the race, which made a genuine failure look like a harmless retry case.

A new automated test was added at the level where two full nodes talk to each other over the real network stack, so this class of bug gets caught by our own test suite instead of only showing up as flakiness in the separate wind-tunnel test suite ([wind-tunnel#690](https://github.com/holochain/wind-tunnel/issues/690)).

The internal bookkeeping for which connection is currently active per peer was also pulled out into its own, separately tested module, so the tricky part of this logic can be tested on its own without needing a real network connection.

## Notes

One narrow case is still possible and was deliberately left as is: a peer can still drop a message that was already fully sent, if that peer decides at the last moment to keep a different connection instead. The sender has no way to find out, since the send itself succeeded. Fixing this properly would need a change to the network protocol itself (an acknowledgement from the receiving side), which is out of scope for this branch. It is now far less likely to happen than before this fix: in testing, this branch lost about one message per 250 simultaneous-connection attempts, compared to losing a message on the very first attempt every single time before this fix. If the wind-tunnel flakiness mentioned above does not fully go away after this lands, this is the remaining known cause and would need its own follow-up.

## Test plan

- `cargo make static` passes (formatting, lint, docs)
- The full workspace test suite passes
- The three tests that previously failed or covered this bug each pass 10 out of 10 runs in a row
- The new test that reproduces two nodes sending to each other at the same time was confirmed to fail against the old code and pass against the fixed code
